### PR TITLE
ci: isolated Neon branch per run + pin claude-action model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,32 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      # Isolated, throwaway Neon database for this run only. Branched off the
+      # long-lived, pre-migrated `ci` parent so it inherits the schema instantly
+      # (copy-on-write). The DB-backed suites (gameStore.multiplayer.test.ts,
+      # mp-ai.test.ts) need a real Postgres; the rest run offline. Tests also
+      # self-provision the schema idempotently via ensureTestSchema, so a fresh
+      # PR migration is picked up even before the `ci` parent is re-migrated.
+      - name: Compute Neon branch expiry (orphan backstop TTL)
+        id: expiry
+        run: echo "at=$(date -u -d '+2 hours' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Create isolated Neon branch
+        id: create-branch
+        uses: neondatabase/create-branch-action@v6.4.0
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          parent_branch: ci
+          branch_name: ci-run-${{ github.run_id }}-${{ github.run_attempt }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          # Belt-and-braces cleanup: the always()-run delete step below removes
+          # the branch on every path, and this TTL reaps it even if the runner
+          # dies before that step gets to run.
+          expires_at: ${{ steps.expiry.outputs.at }}
+
       - name: Run tests
+        env:
+          DATABASE_URL: ${{ steps.create-branch.outputs.db_url }}
         run: pnpm test
 
       - name: Run linting
@@ -48,3 +73,11 @@ jobs:
 
       - name: Run type checking
         run: pnpm typecheck
+
+      - name: Delete isolated Neon branch
+        if: always()
+        uses: neondatabase/delete-branch-action@v3.2.1
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: ci-run-${{ github.run_id }}-${{ github.run_attempt }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # The action's built-in default (claude-sonnet-4-20250514) 404s — that
+          # model id is no longer served. Pin a current model explicitly.
+          model: "claude-sonnet-5"
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -39,9 +39,10 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+
+          # The action's built-in default (claude-sonnet-4-20250514) 404s — that
+          # model id is no longer served. Pin a current model explicitly.
+          model: "claude-sonnet-5"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,6 +306,27 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   refuses with a clear error. Rationales + cost are PUBLIC in
   `GameView.ai`; the AI's hand stays as hidden as any other seat's.
 
+## CI (GitHub Actions, Neon-per-run added 2026-07-15)
+
+- `.github/workflows/ci.yml` (`test` job) runs `pnpm test` + lint + typecheck.
+  The DB-backed suites (`gameStore.multiplayer.test.ts`, `mp-ai.test.ts`) need a
+  real Postgres, so CI provisions an ISOLATED Neon branch per run via
+  `neondatabase/create-branch-action@v6` off the long-lived, pre-migrated `ci`
+  parent branch (project `muddy-night-85782525`), exports its `db_url` output as
+  `DATABASE_URL`, then removes it with `delete-branch-action@v3` in an
+  `if: always()` step (plus a 2h `expires_at` TTL as orphan backstop). Schema
+  comes free via copy-on-write from `ci`; `ensureTestSchema()` re-applies
+  `drizzle/*.sql` idempotently so a new PR migration works before `ci` is
+  re-migrated. Re-migrate the `ci` parent after schema changes:
+  `neonctl connection-string ci --project-id muddy-night-85782525` → `pnpm db:migrate`.
+- REQUIRED repo secrets: `NEON_API_KEY` (Neon Console → Account → API keys) and
+  `NEON_PROJECT_ID` (= `muddy-night-85782525`). Without them the create-branch
+  step fails.
+- `claude.yml` / `claude-code-review.yml` (anthropics/claude-code-action@beta,
+  auth via `CLAUDE_CODE_OAUTH_TOKEN` secret) pin `model: claude-sonnet-5` — the
+  action's built-in default `claude-sonnet-4-20250514` 404s (id no longer
+  served). Bump this when the model id changes.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/biome.json
+++ b/biome.json
@@ -127,6 +127,17 @@
           }
         }
       }
+    },
+    {
+      "include": ["**/*.test.ts", "**/*.test.tsx"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off",
+            "noEmptyBlockStatements": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/src/app/api/mp/stream/route.ts
+++ b/src/app/api/mp/stream/route.ts
@@ -25,7 +25,9 @@ export async function GET(req: NextRequest) {
   kickAiTurns(token)
 
   const encoder = new TextEncoder()
-  let unsub = () => {}
+  let unsub = () => {
+    /* replaced once the SSE subscription is established */
+  }
   let ping: ReturnType<typeof setInterval> | undefined
 
   const stream = new ReadableStream({

--- a/src/components/mp/turnNotify.ts
+++ b/src/components/mp/turnNotify.ts
@@ -48,7 +48,11 @@ export function playTurnChime(): void {
     }
     note(660, 0)
     note(880, 0.12)
-    setTimeout(() => void ctx.close().catch(() => {}), 1200)
+    setTimeout(() => {
+      void ctx.close().catch(() => {
+        /* audio context already closed — nothing to do */
+      })
+    }, 1200)
   } catch {
     // sound is a nicety, never an error
   }

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -60,7 +60,6 @@ export function PlayerLedger({
   }, [onClose])
 
   return (
-    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop click-to-close is a convenience; Escape/close button are the accessible paths
     <div
       className="bb2-curtain fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 sm:p-8"
       style={{ background: 'rgba(10, 8, 6, 0.82)' }}

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -92,7 +92,9 @@ async function withGameLock<T>(
   const next = prev.then(fn, fn)
   locks.set(
     token,
-    next.catch(() => {}),
+    next.catch(() => {
+      /* per-token lock: swallow rejection so the chain never wedges */
+    }),
   )
   return next
 }


### PR DESCRIPTION
## Why

On PR #6 two checks failed: `test` and `claude-review`. Diagnosed both from the failing run logs (not assumed). **The `test` check is now green on this PR.**

## `test` — needed a real Postgres

`gameStore.multiplayer.test.ts` and `mp-ai.test.ts` import the DB layer (`neon(env.DATABASE_URL)`) at module load; with no `DATABASE_URL` both suites threw *"No database connection string"*.

**Fix (captain's preferred pattern): an isolated, throwaway Neon branch per CI run.**
- Branches off a new long-lived, pre-migrated **`ci`** parent (Neon project `muddy-night-85782525`) — each run inherits the schema instantly via copy-on-write.
- `create-branch-action@v6` `db_url` → `DATABASE_URL` for the test step.
- `delete-branch-action@v3` in an `if: always()` step tears it down every path; a 2h `expires_at` TTL backstops orphans.
- `ensureTestSchema()` still re-applies `drizzle/*.sql` idempotently, so a PR migration works before `ci` is re-migrated.

### Second blocker, unmasked: `pnpm lint`
The `test` job runs tests → lint → typecheck. Tests always failed first, so `biome lint` had *never actually run in CI*. With tests fixed it surfaced 406 pre-existing errors — 402 `as any` in test files (idiomatic XState event casting), 4 trivial source violations. Per captain decision: a scoped Biome override turns off `noExplicitAny`/`noEmptyBlockStatements` **for test files only** (source stays strict), and the 4 real source violations are fixed properly.

**Verified in real CI:** the `test` check passes end-to-end — Neon branch created → 37 test files / 298 tests pass → lint clean → typecheck clean → branch deleted.

## `claude-review`
1. **PR #6 root cause:** the OAuth token authenticated fine; it 404'd on the action's stale default model `claude-sonnet-4-20250514`. Fixed by pinning `model: claude-sonnet-5` in `claude-code-review.yml` + `claude.yml`.
2. **Expected-red on *this* PR:** because the PR modifies the review workflow, the action's GitHub-App token exchange refuses (*"workflow file must match the default branch"*) — a security guard that clears automatically once merged to `main`. Not a code problem; no removal proposed.

## Notes
- Merged `main` in (PR #8 had landed and touched the same mp source files) — one conflict in `stream/route.ts`, resolved; `@vercel/functions` dep installed; full suite still green.
- Required repo secrets `NEON_PROJECT_ID` + `NEON_API_KEY` are in place (captain-provided).
- Merging this PR also fixes CI on `main` (currently red for the same two reasons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)