### PR TITLE
feat(mp): DB-as-bus realtime sync (bounded SSE poll + act-response view)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,12 +367,29 @@ When updating this file, preserve this bar for all agents and keep entries conci
   `messages`/`ai`, atomic upsert, 7-day TTL sweep (a DELETE) — so game state
   and chat SURVIVE a redeploy (`.bb-games/` files, or any ephemeral-disk file,
   did not). `saveGame` is version-guarded (upsert applies only when the stored
-  `version` is lower; a stale writer throws 'Concurrent write') because the
-  game lock + SSE bus + AI runner are PER-PROCESS singletons — the app is
-  single-instance: a second instance's writes would be rejected but its SSE
-  clients would hear nothing. `store.ts` is the single seam (load/save/sweep
-  by token); the DB engine is a config swap in `drizzle.config.ts` +
-  `src/server/db/index.ts`.
+  `version` is lower; a stale writer throws 'Concurrent write').
+- REALTIME SYNC IS DB-AS-BUS (2026-07-15, decision doc
+  `brass-realtime-arch-d6`): the `games.version` column IS the event bus —
+  the app is NOT assumed single-instance. The stream (`stream/route.ts`,
+  `maxDuration=300`, needs Fluid compute) is a server-side poll loop: it
+  `loadVersion(token)` every ~1.2s and re-derives the full per-seat view on
+  change, deduped by version; it opens with a `retry: 1500` hint and closes
+  cleanly at ~290s so EventSource reconnects on our terms. The in-process
+  `subscribe`/`broadcast` bus in `game.ts` is now ONLY a same-instance FAST
+  PATH (zero-latency when writer + stream share a Fluid-reused instance), not
+  the delivery guarantee. `act`/`chat` routes return `{ok, view, version}`
+  (the actor's own `viewFor` — server-authoritative, NOT optimistic) so the
+  actor applies its result in POST time (~1s); opponents converge ≤~2s via
+  the poll. The client applies act/chat responses and SSE frames through ONE
+  version-guarded path (`applyView` in `mp-game.tsx`). `kickAiTurns` returns
+  its runner promise; the act/chat routes `waitUntil()` it (`@vercel/functions`)
+  so a serverless instance isn't frozen out from under a multi-step AI turn,
+  and the stream poll re-kicks a stalled AI each tick. Do NOT add
+  WebSockets/LISTEN-NOTIFY/an external pub-sub (decision doc §5). Wire tests:
+  `gameStore.multiplayer.test.ts` (act/chat view shape + hidden-info) +
+  `e2e/multiplayer.spec.ts` (raw SSE `retry:` line).
+- `store.ts` is the single seam (load/save/sweep/loadVersion by token); the
+  DB engine is a config swap in `drizzle.config.ts` + `src/server/db/index.ts`.
   DATABASE_URL is now REQUIRED (a libsql `file:` URL will NOT connect through
   neon-http). Migrations in `./drizzle`; apply with `pnpm db:migrate`/`db:push`.
   Store-touching tests need a live DB (a Neon dev branch) — they self-provision

--- a/e2e/multiplayer.spec.ts
+++ b/e2e/multiplayer.spec.ts
@@ -113,9 +113,9 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
       )
       const reader = res.body!.getReader()
       let text = ''
-      // the initial view arrives as the first data: frame; read until the
-      // frame terminator
-      for (let i = 0; i < 10 && !text.includes('\n\n'); i++) {
+      // The stream opens with a `retry:` reconnect hint, then the initial view
+      // as a `data:` frame; read until a complete data frame has arrived.
+      for (let i = 0; i < 20 && !/data: .+\n\n/.test(text); i++) {
         const { value, done } = await reader.read()
         if (done) break
         text += new TextDecoder().decode(value)
@@ -125,9 +125,15 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
     },
     { token },
   )
+  // The stream sends a reconnect hint so EventSource reconnects in ~1.5s (not
+  // Chrome's ~4s default) when the bounded stream rotates.
+  expect(rawEvent).toContain('retry: 1500')
   expect(rawEvent).toContain('data: ')
+  // Slice the data frame relative to `data: ` — the FIRST `\n\n` now
+  // terminates the leading `retry:` line, not the payload.
+  const dataStart = rawEvent.indexOf('data: ') + 6
   const payload = JSON.parse(
-    rawEvent.slice(rawEvent.indexOf('data: ') + 6, rawEvent.indexOf('\n\n')),
+    rawEvent.slice(dataStart, rawEvent.indexOf('\n\n', dataStart)),
   ) as {
     you: number
     snapshot: {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@libsql/client": "^0.9.0",
     "@neondatabase/serverless": "^1.0.1",
     "@t3-oss/env-nextjs": "^0.10.1",
+    "@vercel/functions": "^3.7.5",
     "@xstate/react": "^5.0.2",
     "drizzle-orm": "^0.44.4",
     "next": "^15.5.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: ^0.10.1
         version: 0.10.1(typescript@5.7.3)(zod@3.24.2)
+      '@vercel/functions':
+        specifier: ^3.7.5
+        version: 3.7.5(ws@8.18.1)
       '@xstate/react':
         specifier: ^5.0.2
         version: 5.0.2(@types/react@18.3.18)(react@18.3.1)(xstate@5.19.2)
@@ -1273,6 +1276,29 @@ packages:
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@1.0.0':
+    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+
+  '@vercel/functions@3.7.5':
+    resolution: {integrity: sha512-ESf8BbeDebqRUyMi09JwRbQqpLn4g6fjcVVHPsHB56j2dSqRrSHO4h3X4aaxJf6iQQjzhAtDGI2xCWQ27JE8PA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+      ws: '>=8'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+      ws:
+        optional: true
+
+  '@vercel/oidc@3.8.0':
+    resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
+    engines: {node: '>= 20'}
+
   '@vitest/expect@3.0.6':
     resolution: {integrity: sha512-zBduHf/ja7/QRX4HdP1DSq5XrPgdN+jzLOwaTq/0qZjYfgETNFCKf9nOAp2j3hmom3oTbczuUzrzg9Hafh7hNg==}
 
@@ -1958,6 +1984,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   execa@7.2.0:
     resolution: {integrity: sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==}
     engines: {node: ^14.18.0 || ^16.14.0 || >=18.0.0}
@@ -2151,6 +2181,10 @@ packages:
     resolution: {integrity: sha512-ONsE3+yfZF2caH5+bJlcddtWqNI3Gvs5A38+ngvljxaBiRXRswym2c7yf8UAeFpRFKjFNHIFEHqR/OLAWJzyiA==}
     engines: {node: '>= 14'}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   human-signals@4.3.1:
     resolution: {integrity: sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==}
     engines: {node: '>=14.18.0'}
@@ -2278,6 +2312,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2326,6 +2364,9 @@ packages:
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-base64@3.7.7:
     resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
@@ -2540,6 +2581,10 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2598,6 +2643,10 @@ packages:
   ora@6.3.1:
     resolution: {integrity: sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
@@ -3088,6 +3137,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
@@ -3402,6 +3455,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xstate@5.19.2:
     resolution: {integrity: sha512-B8fL2aP0ogn5aviAXFzI5oZseAMqN00fg/TeDa3ZtatyDcViYLIfuQl4y8qmHCiKZgGEzmnTyNtNQL9oeJE2gw==}
 
@@ -3423,6 +3484,9 @@ packages:
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
 snapshots:
 
@@ -4342,6 +4406,27 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.0':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/functions@3.7.5(ws@8.18.1)':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+    optionalDependencies:
+      ws: 8.18.1
+
+  '@vercel/oidc@3.8.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
+
   '@vitest/expect@3.0.6':
     dependencies:
       '@vitest/spy': 3.0.6
@@ -5172,6 +5257,18 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   execa@7.2.0:
     dependencies:
       cross-spawn: 7.0.6
@@ -5388,6 +5485,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@2.1.0: {}
+
   human-signals@4.3.1: {}
 
   ieee754@1.2.1: {}
@@ -5512,6 +5611,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.3
 
+  is-stream@2.0.1: {}
+
   is-stream@3.0.0: {}
 
   is-string@1.1.1:
@@ -5562,6 +5663,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
+
+  jose@5.10.0: {}
 
   js-base64@3.7.7: {}
 
@@ -5756,6 +5859,10 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -5835,6 +5942,8 @@ snapshots:
       stdin-discarder: 0.1.0
       strip-ansi: 7.1.0
       wcwidth: 1.0.1
+
+  os-paths@4.4.0: {}
 
   own-keys@1.0.1:
     dependencies:
@@ -6368,6 +6477,8 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@2.0.0: {}
+
   strip-final-newline@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -6706,6 +6817,15 @@ snapshots:
 
   ws@8.18.1: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xstate@5.19.2: {}
 
   xtend@4.0.2: {}
@@ -6717,3 +6837,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.24.2: {}
+
+  zod@4.1.11: {}

--- a/src/app/api/mp/act/route.ts
+++ b/src/app/api/mp/act/route.ts
@@ -1,7 +1,12 @@
+import { waitUntil } from '@vercel/functions'
 import { NextResponse } from 'next/server'
-import { actInGame } from '~/server/mp/game'
+import { actInGame, kickAiTurns } from '~/server/mp/game'
 
 export const runtime = 'nodejs'
+// A move may kick a multi-step AI turn (model calls); keep the instance alive
+// long enough for the waitUntil'd runner. Requires Fluid compute on the
+// project (300s default on all plans incl. Hobby once Fluid is enabled).
+export const maxDuration = 300
 
 export async function POST(req: Request) {
   try {
@@ -17,12 +22,19 @@ export async function POST(req: Request) {
         { status: 400 },
       )
     }
+    const token = String(body.token ?? '')
     const result = await actInGame(
-      String(body.token ?? ''),
+      token,
       Number(body.seatId ?? -1),
       String(body.seatSecret ?? ''),
       body.event,
     )
+    // The AI turn-runner is fire-and-forget inside actInGame; on serverless the
+    // instance freezes once the response returns, killing the detached runner.
+    // waitUntil ties its lifetime to this invocation so an AI turn can finish.
+    if (result.ok) waitUntil(kickAiTurns(token))
+    // Response carries the actor's own fresh per-seat view + version so the
+    // client applies its authoritative result immediately (see actInGame).
     return NextResponse.json(result, { status: result.ok ? 200 : 400 })
   } catch (e) {
     return NextResponse.json(

--- a/src/app/api/mp/chat/route.ts
+++ b/src/app/api/mp/chat/route.ts
@@ -1,7 +1,12 @@
+import { waitUntil } from '@vercel/functions'
 import { NextResponse } from 'next/server'
-import { sendChat } from '~/server/mp/game'
+import { kickAiTurns, sendChat } from '~/server/mp/game'
 
 export const runtime = 'nodejs'
+// Symmetric with the act route: a chat never advances the turn, but keeping
+// the same maxDuration + waitUntil shape means a message sent during an AI
+// turn re-attaches (never restarts) the in-flight runner to this invocation.
+export const maxDuration = 300
 
 export async function POST(req: Request) {
   try {
@@ -17,12 +22,16 @@ export async function POST(req: Request) {
         { status: 400 },
       )
     }
+    const token = String(body.token ?? '')
     const result = await sendChat(
-      String(body.token ?? ''),
+      token,
       Number(body.seatId ?? -1),
       String(body.seatSecret ?? ''),
       body.text,
     )
+    if (result.ok) waitUntil(kickAiTurns(token))
+    // Response carries the sender's fresh per-seat view + version (incl. the
+    // new message) so it applies immediately, same path as an SSE frame.
     return NextResponse.json(result, { status: result.ok ? 200 : 400 })
   } catch (e) {
     return NextResponse.json(

--- a/src/app/api/mp/stream/route.ts
+++ b/src/app/api/mp/stream/route.ts
@@ -1,14 +1,37 @@
 // SSE stream: the client's live window onto its per-seat filtered view.
-// Sends the current view on connect and on every game change; EventSource
-// reconnects automatically after dev-server restarts (the store is in the
-// DB, so the fresh process reloads the game). NOTE the change bus below is
-// per-process: this only fans out writes made by THIS instance.
+//
+// DB-AS-BUS MODEL. On serverless there is no single long-lived process, so
+// this stream is NOT a passive push subscriber — it is a server-side polling
+// loop with an open pipe to the client. The delivery GUARANTEE is a cheap
+// `loadVersion` DB poll every ~1.2s: the `games.version` column IS the event
+// bus, and any instance can read it. The in-process `subscribe()` bus is kept
+// only as a same-instance FAST PATH (zero-latency when the writer and this
+// stream share a Fluid-reused instance); every push is deduped by version so
+// the bus and the poll never double-send.
+//
+// The stream is bounded by design: it closes cleanly just before `maxDuration`
+// and the client's EventSource reconnects (a `retry` hint shortens the gap).
+// The first frame on every (re)connect is the full current view, and the
+// client's version guard makes overlap/reorder harmless.
 import { type NextRequest } from 'next/server'
 import { getGameView, kickAiTurns, subscribe } from '~/server/mp/game'
-import { loadGame } from '~/server/mp/store'
+import { loadGame, loadVersion } from '~/server/mp/store'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
+// Requires Fluid compute on the project (300s default on all plans, incl.
+// Hobby, once Fluid is enabled). Without it the platform default (~10s) kills
+// the stream and every viewer reconnect-storms.
+export const maxDuration = 300
+
+/** DB version-poll cadence — the delivery guarantee. */
+const POLL_INTERVAL_MS = 1_200
+/** Close before the 300s function cap so EventSource reconnects on our terms. */
+const MAX_STREAM_MS = 290_000
+/** Reconnect hint: bridge the close→reopen gap in ~1.5s (Chrome default ~4s). */
+const RETRY_HINT_MS = 1_500
+/** Comment ping to keep an idle connection alive through intermediaries. */
+const PING_INTERVAL_MS = 15_000
 
 export async function GET(req: NextRequest) {
   const params = req.nextUrl.searchParams
@@ -22,15 +45,19 @@ export async function GET(req: NextRequest) {
 
   // Recovery: if the server restarted mid-AI-turn, the first client to
   // reconnect restarts the turn-runner (no-op when it's a human's turn).
-  kickAiTurns(token)
+  void kickAiTurns(token)
 
   const encoder = new TextEncoder()
-  let unsub = () => {}
-  let ping: ReturnType<typeof setInterval> | undefined
+  let unsub = () => {
+    // replaced by the real unsubscribe once the stream starts
+  }
 
   const stream = new ReadableStream({
     start(controller) {
       let open = true
+      let lastSent = -1
+      let pollTimer: ReturnType<typeof setTimeout> | undefined
+
       const write = (chunk: string) => {
         if (!open) return
         try {
@@ -39,29 +66,70 @@ export async function GET(req: NextRequest) {
           open = false
         }
       }
-      const push = async () => {
-        const view = await getGameView(token, seatId, secret)
-        if (view) write(`data: ${JSON.stringify(view)}\n\n`)
-      }
-      unsub = subscribe(token, () => {
-        void push()
-      })
-      ping = setInterval(() => write(': ping\n\n'), 15_000)
-      void push()
-      req.signal.addEventListener('abort', () => {
+
+      const cleanup = () => {
         open = false
         unsub()
+        if (pollTimer) clearTimeout(pollTimer)
+        if (closeTimer) clearTimeout(closeTimer)
         if (ping) clearInterval(ping)
         try {
           controller.close()
         } catch {
           // already closed
         }
+      }
+
+      // Serialize pushes so the bus fast-path and the poll loop can't race on
+      // `lastSent` and double-send the same version.
+      let pushing: Promise<void> = Promise.resolve()
+      const pushIfNewer = () => {
+        pushing = pushing
+          .then(async () => {
+            if (!open) return
+            const view = await getGameView(token, seatId, secret)
+            if (view && view.version > lastSent) {
+              lastSent = view.version
+              write(`data: ${JSON.stringify(view)}\n\n`)
+            }
+          })
+          .catch(() => {
+            // a transient load/filter error must not break the pipe
+          })
+        return pushing
+      }
+
+      // Reconnect hint first, then the full current view.
+      write(`retry: ${RETRY_HINT_MS}\n\n`)
+      unsub = subscribe(token, () => {
+        void pushIfNewer()
       })
+      void pushIfNewer()
+
+      // The guarantee: poll the version column; re-derive & push on change,
+      // and re-kick a stalled AI turn (idempotent — no-op if running/human).
+      const poll = async () => {
+        if (!open) return
+        try {
+          void kickAiTurns(token)
+          const v = await loadVersion(token)
+          if (v !== null && v > lastSent) await pushIfNewer()
+        } catch {
+          // a transient DB blip must not kill the stream; next tick retries
+        }
+        if (open) pollTimer = setTimeout(() => void poll(), POLL_INTERVAL_MS)
+      }
+      pollTimer = setTimeout(() => void poll(), POLL_INTERVAL_MS)
+
+      const ping = setInterval(() => write(': ping\n\n'), PING_INTERVAL_MS)
+
+      // Bounded lifetime: close cleanly and let EventSource reconnect.
+      const closeTimer = setTimeout(cleanup, MAX_STREAM_MS)
+
+      req.signal.addEventListener('abort', cleanup)
     },
     cancel() {
       unsub()
-      if (ping) clearInterval(ping)
     },
   })
 

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -7,7 +7,7 @@
 // via POST /api/mp/act. A read-only local actor is rebuilt from each
 // broadcast purely so the existing dock/board components can keep using
 // `snapshot.matches` / `snapshot.can`; it never executes actions.
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { createActor } from 'xstate'
 import { Toaster } from '~/components/ui/sonner'
@@ -140,6 +140,14 @@ export function MpGame({ token }: { token: string }) {
     setCredsLoaded(true)
   }, [token])
 
+  // Single apply path for every authoritative view — SSE frames AND the fresh
+  // view returned by an act/chat POST. Guarded by `version`: only a strictly
+  // newer view replaces the current one, so a late/duplicate frame arriving
+  // after the act response (or vice-versa) can never regress the state.
+  const applyView = useCallback((incoming: GameViewWire) => {
+    setView((cur) => (!cur || incoming.version > cur.version ? incoming : cur))
+  }, [])
+
   // Live view over SSE; EventSource reconnects on its own after drops and
   // dev-server restarts (the game itself is durable on disk). The stream is
   // (re)opened whenever the credentials change; only THIS stream may decide
@@ -166,7 +174,7 @@ export function MpGame({ token }: { token: string }) {
         setCreds(null)
         return
       }
-      setView(parsed)
+      applyView(parsed)
     }
     es.onerror = () => {
       if (!closed) setStreamFailing(true)
@@ -175,7 +183,7 @@ export function MpGame({ token }: { token: string }) {
       closed = true
       es.close()
     }
-  }, [token, creds, credsLoaded])
+  }, [token, creds, credsLoaded, applyView])
 
   if (!credsLoaded || (!view && !streamFailing)) {
     return (
@@ -227,7 +235,9 @@ export function MpGame({ token }: { token: string }) {
     return <LobbyScreen view={view} />
   }
 
-  return <MpTable token={token} view={view} creds={creds!} />
+  return (
+    <MpTable token={token} view={view} creds={creds!} applyView={applyView} />
+  )
 }
 
 function Centered({ children }: { children: React.ReactNode }) {
@@ -625,10 +635,12 @@ function MpTable({
   token,
   view,
   creds,
+  applyView,
 }: {
   token: string
   view: GameViewWire
   creds: Creds
+  applyView: (view: GameViewWire) => void
 }) {
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
@@ -666,7 +678,12 @@ function MpTable({
               event,
             }),
           })
-          const body = (await res.json()) as { ok: boolean; error?: string }
+          const body = (await res.json()) as {
+            ok: boolean
+            error?: string
+            view?: GameViewWire
+            version?: number
+          }
           if (!body.ok) {
             // The server rejected the intent — no frame is coming, so settle
             // now; the existing error toast still surfaces the reason.
@@ -674,17 +691,23 @@ function MpTable({
             if (body.error && event.type !== 'CLEAR_ERROR') {
               toast.error(body.error)
             }
+          } else if (body.view) {
+            // Server-authoritative fast path: apply the engine's OWN fresh view
+            // from the POST response (same version-guarded apply path as an SSE
+            // frame — NOT an optimistic update). The version bump this causes
+            // settles the in-flight intent immediately (~1s), so the actor no
+            // longer waits for the next poll tick.
+            applyView(body.view)
           }
-          // On success we deliberately leave the intent pending: the engine
-          // advanced, and the resulting SSE frame settles it via the version
-          // bump (never a fixed timeout).
+          // If success carried no view (older server), we leave the intent
+          // pending: the resulting SSE frame settles it via the version bump.
         } catch {
           settle()
           toast.error('Could not reach the game server')
         }
       })()
     },
-    [token, creds, begin],
+    [token, creds, begin, applyView],
   )
 
   const ctx = state?.context
@@ -1133,16 +1156,29 @@ function MpTable({
             you={you}
             seats={view.seats}
             onSend={(text) => {
-              void fetch('/api/mp/chat', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                  token,
-                  seatId: creds.seatId,
-                  seatSecret: creds.seatSecret,
-                  text,
-                }),
-              }).catch(() => toast.error('Could not send the message'))
+              void (async () => {
+                try {
+                  const res = await fetch('/api/mp/chat', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                      token,
+                      seatId: creds.seatId,
+                      seatSecret: creds.seatSecret,
+                      text,
+                    }),
+                  })
+                  const body = (await res.json()) as {
+                    ok: boolean
+                    view?: GameViewWire
+                  }
+                  // Apply the sender's fresh view (with the new message) at once,
+                  // same version-guarded path as an SSE frame.
+                  if (body.ok && body.view) applyView(body.view)
+                } catch {
+                  toast.error('Could not send the message')
+                }
+              })()
             }}
           />
           <JournalPanel logs={ctx.logs} players={ctx.players} />

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -55,14 +55,24 @@ const g = globalThis as unknown as {
   __bbMpLocks?: Map<string, Promise<unknown>>
   __bbAiRunning?: Set<string>
   __bbAiThinking?: Map<string, number>
+  __bbAiPromise?: Map<string, Promise<void>>
 }
 const bus = (g.__bbMpBus ??= new Map())
 const locks = (g.__bbMpLocks ??= new Map())
 /** tokens with an AI turn-runner in flight (single runner per game) */
 const aiRunning = (g.__bbAiRunning ??= new Set())
+/** token → the in-flight runner promise, so a route can `waitUntil` it */
+const aiPromise = (g.__bbAiPromise ??= new Map())
 /** token → seatId currently waiting on a model decision */
 const aiThinking = (g.__bbAiThinking ??= new Map())
 
+// The change bus is per-process and therefore only a FAST PATH: it fans out
+// writes made by THIS instance to SSE streams living on the same instance
+// (common under Fluid compute). It is NOT the delivery guarantee — on
+// serverless the POST that bumps the version and the SSE stream watching for
+// it routinely land on different instances. The guarantee is the stream's
+// ~1.2s `loadVersion` DB poll (see stream/route.ts); the bus just delivers the
+// same-instance case with zero latency.
 export function subscribe(token: string, fn: Listener): () => void {
   const set = bus.get(token) ?? new Set()
   set.add(fn)
@@ -360,7 +370,7 @@ export async function createGame(
     startEngine(game)
   }
   await saveGame(game)
-  kickAiTurns(token)
+  void kickAiTurns(token)
   return { token, seatId: 0, seatSecret: secret }
 }
 
@@ -405,7 +415,7 @@ export async function joinGame(
     game.updatedAt = new Date().toISOString()
     await saveGame(game)
     broadcast(token)
-    kickAiTurns(token)
+    void kickAiTurns(token)
     return { seatId: seat.seatId, seatSecret: secret }
   })
 }
@@ -442,7 +452,9 @@ export async function actInGame(
   seatId: number,
   seatSecret: string,
   event: { type: string } & Record<string, unknown>,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<
+  { ok: true; view: GameView; version: number } | { ok: false; error: string }
+> {
   return withGameLock(token, async () => {
     const game = await loadGame(token)
     if (!game) return { ok: false, error: 'Game not found' }
@@ -485,8 +497,16 @@ export async function actInGame(
     game.updatedAt = new Date().toISOString()
     await saveGame(game)
     broadcast(token)
-    kickAiTurns(token)
-    return { ok: true }
+    void kickAiTurns(token)
+    // Return the actor's OWN fresh per-seat view so the client applies its
+    // authoritative result in POST time (~1s) instead of waiting for the next
+    // SSE poll tick. This is the engine's real result (viewFor filters hidden
+    // info exactly as an SSE frame does), NOT an optimistic prediction.
+    return {
+      ok: true,
+      view: viewFor(game, seatId, seatSecret),
+      version: game.version,
+    }
   })
 }
 
@@ -498,7 +518,9 @@ export async function sendChat(
   seatId: number,
   seatSecret: string,
   text: string,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<
+  { ok: true; view: GameView; version: number } | { ok: false; error: string }
+> {
   return withGameLock(token, async () => {
     const game = await loadGame(token)
     if (!game) return { ok: false, error: 'Game not found' }
@@ -523,28 +545,42 @@ export async function sendChat(
     game.updatedAt = new Date().toISOString()
     await saveGame(game)
     broadcast(token)
-    return { ok: true }
+    // Same shape as actInGame: the sender applies its own fresh view (which
+    // includes the new message) immediately, rather than waiting for a poll.
+    return {
+      ok: true,
+      view: viewFor(game, seatId, seatSecret),
+      version: game.version,
+    }
   })
 }
 
 /* ---------------- the AI turn runner ---------------- */
 
 /**
- * Start the AI turn-runner for this game unless one is already in flight.
- * Safe to call from anywhere (create/join/act/stream-connect) — it no-ops
- * instantly when the current player is human or the game is over.
+ * Start the AI turn-runner for this game unless one is already in flight, and
+ * return the promise that settles when the current run finishes. Safe to call
+ * from anywhere (create/join/act/stream-connect) — it no-ops instantly when
+ * the current player is human or the game is over. Callers on a serverless
+ * request path should `waitUntil(kickAiTurns(token))` so the instance isn't
+ * frozen out from under the (detached) runner after the response returns.
  */
-export function kickAiTurns(token: string): void {
-  if (aiRunning.has(token)) return
+export function kickAiTurns(token: string): Promise<void> {
+  const existing = aiPromise.get(token)
+  if (existing) return existing
+  if (aiRunning.has(token)) return Promise.resolve()
   aiRunning.add(token)
-  void runAiTurns(token)
+  const p = runAiTurns(token)
     .catch(() => {
       // the runner never propagates — a failed decision is logged in-game
     })
     .finally(() => {
       aiRunning.delete(token)
+      aiPromise.delete(token)
       if (aiThinking.delete(token)) broadcast(token)
     })
+  aiPromise.set(token, p)
+  return p
 }
 
 /** Model calls per AI turn before the driver goes safety-first (cost cap). */

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -105,6 +105,24 @@ export async function loadGame(token: string): Promise<GameRecord | null> {
   return row ? rowToRecord(row) : null
 }
 
+/**
+ * Read ONLY the monotonic `version` for a game — the cheap DB poll that lets
+ * the SSE stream act as a "server-side polling loop with an open pipe". This
+ * is the delivery guarantee for cross-instance updates on serverless (the
+ * in-process bus in `game.ts` is only a same-instance fast path): the stream
+ * selects this every ~1.2s and re-derives the full per-seat view on change.
+ * Returns null for an unknown/malformed token.
+ */
+export async function loadVersion(token: string): Promise<number | null> {
+  if (!TOKEN_RE.test(token)) return null
+  const rows = await db
+    .select({ version: games.version })
+    .from(games)
+    .where(eq(games.token, token))
+    .limit(1)
+  return rows[0]?.version ?? null
+}
+
 export async function saveGame(game: GameRecord): Promise<void> {
   if (!TOKEN_RE.test(game.token)) throw new Error('Malformed game token')
   const row = recordToRow(game)

--- a/src/store/gameStore.multiplayer.test.ts
+++ b/src/store/gameStore.multiplayer.test.ts
@@ -129,6 +129,68 @@ describe('multiplayer: lifecycle and authority', () => {
     expect(money).toBe(47) // £17 + £30 loan
   })
 
+  test("act returns the actor's own fresh view + version (DB-as-bus fast path)", async () => {
+    const { host, guest } = await freshGame()
+    const view = await getGameView(host.token, 0, host.seatSecret)
+    const v0 = view!.version
+    const current = ctxOf(view!).currentPlayerIndex
+    const other = current === 0 ? 1 : 0
+    const creds = current === 0 ? host : guest
+    const otherCreds = other === 0 ? host : guest
+
+    const res = await actInGame(host.token, current, creds.seatSecret, {
+      type: 'TAKE_LOAN',
+    })
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('unreachable')
+
+    // The response carries the engine's OWN authoritative view + bumped
+    // version, so the client applies its result in POST time (no poll wait).
+    expect(res.version).toBeGreaterThan(v0)
+    expect(res.view.version).toBe(res.version)
+    expect(res.view.you).toBe(current)
+
+    // Same viewFor path as an SSE frame — hidden info stays filtered: the
+    // actor's OWN act-response never contains another seat's real cards.
+    const rctx = ctxOf(res.view)
+    expect(
+      rctx.players[current]!.hand.every((c) => !c.id.startsWith('hidden-')),
+    ).toBe(true)
+    expect(
+      rctx.players[other]!.hand.every((c) => c.id.startsWith('hidden-')),
+    ).toBe(true)
+    expect(rctx.drawPile.every((c) => c.id.startsWith('hidden-'))).toBe(true)
+
+    // Wire-level: none of the other seat's REAL card ids leak into any card
+    // zone of the actor's response view.
+    const otherView = await getGameView(
+      host.token,
+      other,
+      otherCreds.seatSecret,
+    )
+    const otherRealHand = ctxOf(otherView!).players[other]!.hand.map(
+      (c) => c.id,
+    )
+    const actorZones = [
+      ...rctx.players.flatMap((p) => p.hand),
+      ...rctx.drawPile,
+    ].map((c) => c.id)
+    for (const id of otherRealHand) {
+      expect(actorZones).not.toContain(id)
+    }
+  })
+
+  test('chat returns the sender view + version with the new message', async () => {
+    const { host } = await freshGame()
+    const before = await getGameView(host.token, 0, host.seatSecret)
+    const res = await sendChat(host.token, 0, host.seatSecret, 'well played')
+    expect(res.ok).toBe(true)
+    if (!res.ok) throw new Error('unreachable')
+    expect(res.version).toBeGreaterThan(before!.version)
+    expect(res.view.version).toBe(res.version)
+    expect(res.view.messages.at(-1)?.text).toBe('well played')
+  })
+
   test('host can release a seat; a new player reclaims it', async () => {
     const { host } = await freshGame()
     await expect(
@@ -229,7 +291,7 @@ describe('multiplayer: table talk', () => {
     // A real message lands for BOTH seats, with sender name and id.
     const versionBefore = (await loadGame(host.token))!.version
     const sent = await sendChat(host.token, 0, host.seatSecret, '  hello  ')
-    expect(sent).toStrictEqual({ ok: true })
+    expect(sent.ok).toBe(true)
     const hostView = await getGameView(host.token, 0, host.seatSecret)
     const guestView = await getGameView(
       host.token,


### PR DESCRIPTION
## What

Implements the approved realtime-sync architecture — the captain's "brass Vercel fix" — from decision doc `brass-realtime-arch-d6` §4 ("DB-as-bus over bounded SSE"), backed by the measured diagnosis in `brass-mp-latency-f2`. **The `games.version` column is the event bus; the app is no longer assumed single-instance.** No new vendors, no WebSockets, no LISTEN/NOTIFY (decision doc §5 respected).

## Root cause (measured)

On Vercel the per-process `broadcast` bus never reaches the SSE stream (different function instances — 4/4 broadcasts lost), and the stream was killed at the 10s default `maxDuration`. Effective delivery cadence was ~13.7s → perceived ~7–10s lag.

## Changes (per the decision doc's file-level sketch)

- **`stream/route.ts`**: `maxDuration=300`; sends `retry: 1500` on open; replaces the passive per-process `subscribe` wait with a **~1.2s `loadVersion()` DB poll** that re-derives the full per-seat view on change (deduped by version). Keeps the in-process bus as a same-instance **fast path**; closes cleanly at ~290s so EventSource reconnects; **re-kicks a stalled AI** each tick.
- **`act/route.ts` + `chat/route.ts`**: return `{ok, view, version}` (the actor's own `viewFor` — **server-authoritative, not optimistic**); `maxDuration=300`; wrap `kickAiTurns` in `waitUntil()` (`@vercel/functions`) so a serverless instance survives a multi-step AI turn.
- **`store.ts`**: new `loadVersion(token)` (SELECT version only).
- **`game.ts`**: `kickAiTurns` returns its runner promise (for `waitUntil`); bus comment updated to "fast path only; the DB poll is the guarantee".
- **`mp-game.tsx`**: applies act/chat response views through one version-guarded `applyView` path (identical to an SSE frame). `use-in-flight.ts` needs no change — the act-response view bumps `version`, which settles the intent (verified).
- **Tests**: `gameStore.multiplayer.test.ts` asserts the act/chat view shape + that the actor's own response never leaks another seat's real cards; `e2e/multiplayer.spec.ts` asserts the `retry:` line.
- **AGENTS.md**: replaces the stale "single-instance" note with the DB-as-bus model.

## Vercel

**Fluid compute enabled** on project `brass-birmingham` via API (`fluid: false → true`; default function timeout auto-raised `10s → 300s`) — required for `maxDuration=300` on Hobby.

## Verification

- 37 unit/wire files (294 tests, 4 skipped) pass against the Neon `dev` branch, including the 2 new act/chat-view-shape + hidden-info tests.
- `e2e/multiplayer.spec.ts` passes locally (two browsers, live convergence, `retry: 1500` wire assertion, hidden-info hygiene).
- `pnpm build` clean; `pnpm typecheck` clean.

**Latency note:** before (prod, measured in the latency scout report) ≈ mean ~7s, range ~1.5–14.7s. After (design target, validated by the local two-browser e2e converging within the test's action timeouts): actor ~1s (act-response view applied in POST time), opponents ≤~2s (1.2s poll + payload). The PR's Vercel preview is the definitive proof — see checklist below.

## Preview check (SSO-gated)

Exercise a quick 2-player game on the preview URL and confirm perceived sync is ~1–2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiplayer updates now arrive more reliably across server instances.
  * Player actions and chat messages immediately return the latest game view.
  * Added reconnect guidance and improved recovery for interrupted real-time sessions.

* **Bug Fixes**
  * Improved synchronization of AI turns and game state.
  * Strengthened protection against exposing hidden card information.
  * Improved handling of incomplete or delayed event-stream messages.

* **Tests**
  * Expanded multiplayer coverage for real-time updates, reconnection behavior, returned views, versioning, and hidden information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->