### PR TITLE
test(db): per-run ephemeral Neon branch for LOCAL test runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,14 +420,34 @@ When updating this file, preserve this bar for all agents and keep entries conci
   DB engine is a config swap in `drizzle.config.ts` + `src/server/db/index.ts`.
   DATABASE_URL is now REQUIRED (a libsql `file:` URL will NOT connect through
   neon-http). Migrations in `./drizzle`; apply with `pnpm db:migrate`/`db:push`.
-  Store-touching tests need a live DB (a Neon dev branch) — they self-provision
-  the schema via `src/test/db-schema.ts`; the engine suite still runs offline.
+  Store-touching tests need a live DB — they self-provision the schema via
+  `src/test/db-schema.ts`; the engine suite still runs offline.
   Neon project `muddy-night-85782525` (name "brass"); branches: `main`=prod,
-  `dev`, `preview`. Point `.env` DATABASE_URL at the branch you want
-  (`neonctl connection-string <branch> --project-id muddy-night-85782525`) —
-  tests + local dev use `dev`. Those DB-backed suites run ~30s over the
-  network (vs instant files), so they set a 30s per-file timeout via
-  `vi.setConfig`; leave the global 5s for the in-memory engine suite.
+  `dev`, `preview`, and the long-lived pre-migrated `ci` parent. Those
+  DB-backed suites run ~30s over the network (vs instant files), so they set a
+  30s per-file timeout via `vi.setConfig`; leave the global 5s for the
+  in-memory engine suite.
+- LOCAL TEST DB ISOLATION (added 2026-07-16): every local test run gets its
+  OWN throwaway Neon branch — no more sharing `dev`, and parallel runs can't
+  collide. Wired via vitest `globalSetup` (`src/test/global-db-branch.ts` +
+  `src/test/neon-branch.ts`), driven by the official Neon TS SDK
+  (`@neondatabase/api-client`, `createProjectBranch`/`deleteProjectBranch`
+  against project `muddy-night-85782525`): before the run it branches off the
+  pre-migrated `ci` parent (copy-on-write → schema inherited instantly), names
+  it `local-test-<rand>` with a 2h `expires_at` TTL (orphan backstop), exports
+  its connection string as `DATABASE_URL` (set in the main process BEFORE
+  workers spawn, so it propagates), and DELETES the branch in teardown (pass or
+  fail). This mirrors the CI workflow (`.github/workflows/ci.yml`, per-run
+  branch off `ci`). Credential `NEON_API_KEY` (brass-project-scoped Neon key):
+  LOCAL — put it in `.env.local` (gitignored via `.env*.local`; never committed
+  / printed); CI — the `NEON_API_KEY` repo secret (a plain env var, which also
+  overrides `.env.local` in disposable worktrees). `NEON_PROJECT_ID` is likewise
+  overridable but defaults to the brass project. FALLBACK (offline never
+  hard-fails): `TEST_DB_BRANCH=0` skips branching and keeps the current
+  `DATABASE_URL`; a missing `NEON_API_KEY` skips branching with a one-line
+  `[test-db]` notice; a create failure warns and falls back. Point `.env`
+  DATABASE_URL at a branch (`neonctl connection-string <branch> --project-id
+  muddy-night-85782525`) only for the fallback / `TEST_DB_BRANCH=0` path.
 - DEPLOY (Vercel, wired 2026-07-15): ship is direct-PR → Vercel Git
   integration (project `brass-birmingham`, prod branch = `main`, PR previews
   on). The Neon<->Vercel native integration (store "brass") manages the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,12 +442,18 @@ When updating this file, preserve this bar for all agents and keep entries conci
   LOCAL — put it in `.env.local` (gitignored via `.env*.local`; never committed
   / printed); CI — the `NEON_API_KEY` repo secret (a plain env var, which also
   overrides `.env.local` in disposable worktrees). `NEON_PROJECT_ID` is likewise
-  overridable but defaults to the brass project. FALLBACK (offline never
-  hard-fails): `TEST_DB_BRANCH=0` skips branching and keeps the current
-  `DATABASE_URL`; a missing `NEON_API_KEY` skips branching with a one-line
-  `[test-db]` notice; a create failure warns and falls back. Point `.env`
-  DATABASE_URL at a branch (`neonctl connection-string <branch> --project-id
-  muddy-night-85782525`) only for the fallback / `TEST_DB_BRANCH=0` path.
+  overridable but defaults to the brass project. FALLBACK PRECEDENCE (offline
+  never hard-fails, and tests must NEVER hit `dev`): (1) `NEON_API_KEY` present
+  → ephemeral per-run branch (above); (2) else — `TEST_DB_BRANCH=0`, no key, or
+  a create failure — use `TEST_DATABASE_URL` when set, the dedicated long-lived
+  Neon `test` branch (`br-sparkling-truth-adswa45j`; put it in `.env.local`);
+  (3) else fall back to the existing `DATABASE_URL` but print a LOUD multi-line
+  `[test-db] ⚠` warning that tests are about to hit a non-test database.
+  Whichever branch DATABASE_URL lands on, the DB suites' `ensureTestSchema()`
+  (beforeAll, `src/test/db-schema.ts`) migrates it idempotently — so a stale
+  `test` branch is brought current by the same harness step the ephemeral path
+  uses. Keep `TEST_DATABASE_URL` (not the plain `DATABASE_URL`) pointed at the
+  `test` branch for the no-key / `TEST_DB_BRANCH=0` path.
 - DEPLOY (Vercel, wired 2026-07-15): ship is direct-PR → Vercel Git
   integration (project `brass-birmingham`, prod branch = `main`, PR previews
   on). The Neon<->Vercel native integration (store "brass") manages the

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
+    "@neondatabase/api-client": "^2.7.3",
     "@playwright/test": "^1.61.1",
     "@types/eslint": "^8.56.10",
     "@types/node": "^20.14.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
+      '@neondatabase/api-client':
+        specifier: ^2.7.3
+        version: 2.7.3
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
@@ -980,6 +983,9 @@ packages:
   '@neon-rs/load@0.0.4':
     resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
+  '@neondatabase/api-client@2.7.3':
+    resolution: {integrity: sha512-hqJmcd8qeCNjcsSNlz77peGIwB9SLj8NC6kK6AjPRyb4bUvXB+TCmffx5893/0oRHYjqpua0nBLa5ql8z6acmw==}
+
   '@neondatabase/serverless@1.0.1':
     resolution: {integrity: sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==}
     engines: {node: '>=19.0.0'}
@@ -1347,6 +1353,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
@@ -1434,6 +1444,9 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1441,6 +1454,9 @@ packages:
   axe-core@4.10.2:
     resolution: {integrity: sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==}
     engines: {node: '>=4'}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -1562,6 +1578,10 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -1650,6 +1670,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -2050,6 +2074,15 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -2057,6 +2090,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -2176,6 +2213,14 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@6.2.1:
     resolution: {integrity: sha512-ONsE3+yfZF2caH5+bJlcddtWqNI3Gvs5A38+ngvljxaBiRXRswym2c7yf8UAeFpRFKjFNHIFEHqR/OLAWJzyiA==}
@@ -2488,6 +2533,14 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
 
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -2886,6 +2939,10 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4144,6 +4201,13 @@ snapshots:
 
   '@neon-rs/load@0.0.4': {}
 
+  '@neondatabase/api-client@2.7.3':
+    dependencies:
+      axios: 1.18.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
   '@neondatabase/serverless@1.0.1':
     dependencies:
       '@types/node': 22.17.2
@@ -4483,6 +4547,12 @@ snapshots:
 
   acorn@8.14.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.3: {}
 
   ajv@6.12.6:
@@ -4589,11 +4659,23 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.10.2: {}
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -4722,6 +4804,10 @@ snapshots:
       color-string: 1.9.1
     optional: true
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@10.0.1: {}
 
   commander@4.1.1: {}
@@ -4798,6 +4884,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   detect-libc@2.0.2: {}
 
@@ -5341,6 +5429,8 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  follow-redirects@1.16.0: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -5349,6 +5439,14 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -5477,6 +5575,17 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@6.2.1:
     dependencies:
@@ -5781,6 +5890,12 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mimic-fn@2.1.0: {}
 
@@ -6100,6 +6215,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 

--- a/src/test/global-db-branch.ts
+++ b/src/test/global-db-branch.ts
@@ -1,4 +1,5 @@
-// Vitest globalSetup: give each LOCAL test run its own throwaway Neon branch.
+// Vitest globalSetup: point DB-backed suites at an ISOLATED database, never the
+// shared `dev` branch.
 //
 // Runs ONCE in the main process before any worker spawns, so setting
 // `process.env.DATABASE_URL` here propagates to the test workers that import
@@ -6,27 +7,65 @@
 // (.github/workflows/ci.yml) for laptops. Uses the official Neon TypeScript SDK
 // directly — see src/test/neon-branch.ts.
 //
-// Behaviour (offline work must never hard-fail):
-//   - TEST_DB_BRANCH=0  → skip branching, keep whatever DATABASE_URL is set.
-//   - no NEON_API_KEY   → skip branching with a one-line notice (set it in
-//                         `.env.local` locally, or the CI repo secret).
-//   - create failure    → warn and fall back to the existing DATABASE_URL.
-// The pure-engine suites never touch the DB and are unaffected in every case.
-import { createBranch, deleteBranch, resolveNeonApiKey } from './neon-branch'
+// Precedence (offline work must never hard-fail; tests must NEVER hit `dev`):
+//   1. NEON_API_KEY present (and TEST_DB_BRANCH!=0) → per-run EPHEMERAL branch
+//      off `ci`, deleted in teardown. The isolation guarantee.
+//   2. else (TEST_DB_BRANCH=0, no key, or create failed) → TEST_DATABASE_URL,
+//      the dedicated long-lived Neon `test` branch, when set.
+//   3. else → the existing DATABASE_URL, with a LOUD warning that tests are
+//      about to hit a non-test database.
+// Whichever branch we land on, the DB suites' `ensureTestSchema()` (beforeAll)
+// migrates it idempotently — so a stale `test` branch is brought up to date by
+// the same harness step the ephemeral path relies on.
+import {
+  createBranch,
+  deleteBranch,
+  resolveNeonApiKey,
+  resolveTestDatabaseUrl,
+} from './neon-branch'
 
-export default async function setup(): Promise<(() => Promise<void>) | void> {
-  if (process.env.TEST_DB_BRANCH === '0') {
+// Fallback shared by every no-ephemeral path: prefer the dedicated test branch;
+// only ever touch a non-test DATABASE_URL as a last resort, and shout about it.
+function useFallbackDatabase(reason: string): void {
+  const testUrl = resolveTestDatabaseUrl()
+  if (testUrl) {
+    process.env.DATABASE_URL = testUrl
     console.info(
-      '[test-db] TEST_DB_BRANCH=0 → using existing DATABASE_URL, no ephemeral Neon branch',
+      `[test-db] ${reason} → using TEST_DATABASE_URL (dedicated Neon test branch); ensureTestSchema migrates it if stale`,
     )
     return
   }
-
-  const apiKey = resolveNeonApiKey()
-  if (!apiKey) {
-    console.info(
-      '[test-db] no NEON_API_KEY (set it in .env.local or as an env var) → DB-backed suites use existing DATABASE_URL if set; engine suites run offline',
+  if (process.env.DATABASE_URL) {
+    console.warn(
+      [
+        '',
+        '════════════════════════════════════════════════════════════════════',
+        `[test-db] ⚠  ${reason}, and TEST_DATABASE_URL is not set.`,
+        '[test-db] ⚠  DB-backed tests are about to run against DATABASE_URL,',
+        '[test-db] ⚠  which is NOT a designated test database (possibly dev/prod).',
+        '[test-db] ⚠  Set NEON_API_KEY (ephemeral per-run branch) or',
+        '[test-db] ⚠  TEST_DATABASE_URL (shared Neon `test` branch) in .env.local.',
+        '════════════════════════════════════════════════════════════════════',
+        '',
+      ].join('\n'),
     )
+    return
+  }
+  console.info(
+    `[test-db] ${reason}, no TEST_DATABASE_URL / DATABASE_URL → DB-backed suites cannot run; engine suites run offline`,
+  )
+}
+
+export default async function setup(): Promise<(() => Promise<void>) | void> {
+  // TEST_DB_BRANCH=0 forces the no-ephemeral path (still avoids `dev`).
+  const apiKey = process.env.TEST_DB_BRANCH === '0' ? null : resolveNeonApiKey()
+
+  if (!apiKey) {
+    const reason =
+      process.env.TEST_DB_BRANCH === '0'
+        ? 'TEST_DB_BRANCH=0'
+        : 'no NEON_API_KEY'
+    useFallbackDatabase(reason)
     return
   }
 
@@ -34,8 +73,8 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
   try {
     branch = await createBranch(apiKey)
   } catch (err) {
-    console.warn(
-      `[test-db] could not create ephemeral Neon branch (${(err as Error).message.split('\n')[0]}) → falling back to existing DATABASE_URL`,
+    useFallbackDatabase(
+      `could not create ephemeral Neon branch (${(err as Error).message.split('\n')[0]})`,
     )
     return
   }

--- a/src/test/global-db-branch.ts
+++ b/src/test/global-db-branch.ts
@@ -1,0 +1,60 @@
+// Vitest globalSetup: give each LOCAL test run its own throwaway Neon branch.
+//
+// Runs ONCE in the main process before any worker spawns, so setting
+// `process.env.DATABASE_URL` here propagates to the test workers that import
+// the DB layer (`~/server/db` reads it at import time). Mirrors the CI workflow
+// (.github/workflows/ci.yml) for laptops. Uses the official Neon TypeScript SDK
+// directly — see src/test/neon-branch.ts.
+//
+// Behaviour (offline work must never hard-fail):
+//   - TEST_DB_BRANCH=0  → skip branching, keep whatever DATABASE_URL is set.
+//   - no NEON_API_KEY   → skip branching with a one-line notice (set it in
+//                         `.env.local` locally, or the CI repo secret).
+//   - create failure    → warn and fall back to the existing DATABASE_URL.
+// The pure-engine suites never touch the DB and are unaffected in every case.
+import { createBranch, deleteBranch, resolveNeonApiKey } from './neon-branch'
+
+export default async function setup(): Promise<(() => Promise<void>) | void> {
+  if (process.env.TEST_DB_BRANCH === '0') {
+    console.info(
+      '[test-db] TEST_DB_BRANCH=0 → using existing DATABASE_URL, no ephemeral Neon branch',
+    )
+    return
+  }
+
+  const apiKey = resolveNeonApiKey()
+  if (!apiKey) {
+    console.info(
+      '[test-db] no NEON_API_KEY (set it in .env.local or as an env var) → DB-backed suites use existing DATABASE_URL if set; engine suites run offline',
+    )
+    return
+  }
+
+  let branch: Awaited<ReturnType<typeof createBranch>>
+  try {
+    branch = await createBranch(apiKey)
+  } catch (err) {
+    console.warn(
+      `[test-db] could not create ephemeral Neon branch (${(err as Error).message.split('\n')[0]}) → falling back to existing DATABASE_URL`,
+    )
+    return
+  }
+
+  process.env.DATABASE_URL = branch.connectionUri
+  console.info(
+    `[test-db] ephemeral Neon branch ${branch.name} (${branch.id}) created off ci → DATABASE_URL points at it`,
+  )
+
+  // Runs on teardown for every exit path vitest controls (pass or fail). A hard
+  // crash is covered by the branch's 2h TTL.
+  return async () => {
+    try {
+      await deleteBranch(branch.id, apiKey)
+      console.info(`[test-db] deleted ephemeral Neon branch ${branch.name}`)
+    } catch (err) {
+      console.warn(
+        `[test-db] could not delete branch ${branch.name} (${(err as Error).message.split('\n')[0]}); it will auto-expire`,
+      )
+    }
+  }
+}

--- a/src/test/global-db-branch.ts
+++ b/src/test/global-db-branch.ts
@@ -24,6 +24,13 @@ import {
   resolveTestDatabaseUrl,
 } from './neon-branch'
 
+// First line of an error message, safe against non-Error throws (a bad
+// `.message` access here would crash globalSetup and defeat the fallback).
+function firstLine(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err)
+  return msg.split('\n')[0] ?? ''
+}
+
 // Fallback shared by every no-ephemeral path: prefer the dedicated test branch;
 // only ever touch a non-test DATABASE_URL as a last resort, and shout about it.
 function useFallbackDatabase(reason: string): void {
@@ -74,7 +81,7 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
     branch = await createBranch(apiKey)
   } catch (err) {
     useFallbackDatabase(
-      `could not create ephemeral Neon branch (${(err as Error).message.split('\n')[0]})`,
+      `could not create ephemeral Neon branch (${firstLine(err)})`,
     )
     return
   }
@@ -92,7 +99,7 @@ export default async function setup(): Promise<(() => Promise<void>) | void> {
       console.info(`[test-db] deleted ephemeral Neon branch ${branch.name}`)
     } catch (err) {
       console.warn(
-        `[test-db] could not delete branch ${branch.name} (${(err as Error).message.split('\n')[0]}); it will auto-expire`,
+        `[test-db] could not delete branch ${branch.name} (${firstLine(err)}); it will auto-expire`,
       )
     }
   }

--- a/src/test/neon-branch.ts
+++ b/src/test/neon-branch.ts
@@ -1,0 +1,133 @@
+import { randomBytes } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+// Ephemeral per-run Neon branch lifecycle for LOCAL test runs.
+//
+// CI (see .github/workflows/ci.yml) branches a throwaway DB off the long-lived,
+// pre-migrated `ci` parent for each run via neondatabase/create-branch-action.
+// This is the local-machine equivalent, driven through the official Neon
+// TypeScript SDK (@neondatabase/api-client) so `pnpm test` on a laptop stops
+// sharing the `dev` branch and parallel runs cannot collide. Wired into vitest
+// via `globalSetup` (src/test/global-db-branch.ts) — created once before the
+// run, deleted in teardown.
+//
+// Credential: `NEON_API_KEY` from the process env, else `.env.local` (the repo's
+// T3/Next convention; gitignored). Absent → the caller skips branching and
+// degrades to the existing DATABASE_URL (offline never hard-fails).
+import { EndpointType, createApiClient } from '@neondatabase/api-client'
+
+// Same brass-scoped project + parent the CI workflow uses. The `ci` parent is
+// pre-migrated, so a copy-on-write branch inherits the schema instantly.
+const DEFAULT_PROJECT_ID = 'muddy-night-85782525'
+const PARENT_BRANCH_NAME = 'ci'
+const BRANCH_PREFIX = 'local-test'
+// Orphan backstop: even if teardown never runs (crash, SIGKILL), Neon reaps the
+// branch after this. Teardown is still the primary cleanup path.
+const TTL_HOURS = 2
+
+export interface EphemeralBranch {
+  id: string
+  name: string
+  connectionUri: string
+}
+
+// Minimal `.env.local` reader — the repo's env convention (T3/Next) with no
+// dotenv dependency. Parsed once; only sources the optional NEON_API_KEY /
+// NEON_PROJECT_ID — the app's real DATABASE_URL still flows via `~/env`.
+let envLocalCache: Record<string, string> | null = null
+function readEnvLocal(): Record<string, string> {
+  if (envLocalCache) return envLocalCache
+  const out: Record<string, string> = {}
+  try {
+    const text = readFileSync(path.resolve(process.cwd(), '.env.local'), 'utf8')
+    for (const raw of text.split('\n')) {
+      const line = raw.trim()
+      if (!line || line.startsWith('#')) continue
+      const m = line.match(
+        /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/,
+      )
+      const key = m?.[1]
+      if (!key) continue
+      let val = (m[2] ?? '').trim()
+      if (
+        (val.startsWith('"') && val.endsWith('"')) ||
+        (val.startsWith("'") && val.endsWith("'"))
+      ) {
+        val = val.slice(1, -1)
+      }
+      out[key] = val
+    }
+  } catch {
+    // No `.env.local` — fine; the caller degrades gracefully.
+  }
+  envLocalCache = out
+  return out
+}
+
+/**
+ * Resolve the Neon API key: the `NEON_API_KEY` env var wins (CI repo secret /
+ * disposable worktrees), otherwise `NEON_API_KEY` from `.env.local` (local
+ * dev). Returns `null` when neither is present so callers degrade gracefully.
+ */
+export function resolveNeonApiKey(): string | null {
+  const fromEnv = process.env.NEON_API_KEY?.trim()
+  if (fromEnv) return fromEnv
+  const fromFile = readEnvLocal().NEON_API_KEY?.trim()
+  return fromFile || null
+}
+
+/** Project id: `NEON_PROJECT_ID` env / `.env.local`, else the brass default. */
+function resolveProjectId(): string {
+  return (
+    process.env.NEON_PROJECT_ID?.trim() ||
+    readEnvLocal().NEON_PROJECT_ID?.trim() ||
+    DEFAULT_PROJECT_ID
+  )
+}
+
+type NeonApi = ReturnType<typeof createApiClient>
+
+async function resolveParentBranchId(
+  api: NeonApi,
+  projectId: string,
+): Promise<string> {
+  const res = await api.listProjectBranches({
+    projectId,
+    search: PARENT_BRANCH_NAME,
+  })
+  // `search` is a partial match — pin the exact parent by name.
+  const parent = res.data.branches.find((b) => b.name === PARENT_BRANCH_NAME)
+  if (!parent) {
+    throw new Error(
+      `parent branch "${PARENT_BRANCH_NAME}" not found in project ${projectId}`,
+    )
+  }
+  return parent.id
+}
+
+/** Create an ephemeral branch off `ci` with a short TTL and return its id +
+ * connection string. Rejects on failure (the caller decides how to degrade). */
+export async function createBranch(apiKey: string): Promise<EphemeralBranch> {
+  const api = createApiClient({ apiKey })
+  const projectId = resolveProjectId()
+  const parentId = await resolveParentBranchId(api, projectId)
+  const name = `${BRANCH_PREFIX}-${randomBytes(4).toString('hex')}`
+  const expiresAt = new Date(Date.now() + TTL_HOURS * 3600_000).toISOString()
+  const res = await api.createProjectBranch(projectId, {
+    // A read-write compute is what yields a connection URI in the response.
+    endpoints: [{ type: EndpointType.ReadWrite }],
+    branch: { parent_id: parentId, name, expires_at: expiresAt },
+  })
+  const id = res.data.branch?.id
+  const connectionUri = res.data.connection_uris?.[0]?.connection_uri
+  if (!id || !connectionUri) {
+    throw new Error('Neon create returned no branch id / connection_uri')
+  }
+  return { id, name, connectionUri }
+}
+
+/** Delete an ephemeral branch. The TTL is the backstop if this ever fails. */
+export async function deleteBranch(id: string, apiKey: string): Promise<void> {
+  const api = createApiClient({ apiKey })
+  await api.deleteProjectBranch({ projectId: resolveProjectId(), branchId: id })
+}

--- a/src/test/neon-branch.ts
+++ b/src/test/neon-branch.ts
@@ -31,9 +31,18 @@ export interface EphemeralBranch {
   connectionUri: string
 }
 
-// Minimal `.env.local` reader — the repo's env convention (T3/Next) with no
-// dotenv dependency. Parsed once; only sources the optional NEON_API_KEY /
-// NEON_PROJECT_ID — the app's real DATABASE_URL still flows via `~/env`.
+// Minimal, scoped `.env.local` reader for the test harness.
+//
+// NOT `~/env`: that module is a *validator/accessor* over `process.env` (T3
+// `createEnv`), not a file loader — in the app, Next's `@next/env` populates
+// `process.env` from `.env.local` before `~/env` reads it. This vitest
+// globalSetup runs OUTSIDE Next's pipeline, so nothing has loaded `.env.local`
+// here. Adding NEON_API_KEY / TEST_DATABASE_URL to `~/env`'s schema would also
+// pollute the app's validated env contract with test-only keys. And a global
+// loader (Next's `loadEnvConfig`) would mutate `process.env` for the whole run
+// — pulling `.env`'s DATABASE_URL in and undermining the non-test-DB guard in
+// global-db-branch.ts. So we read the two test-only keys ourselves, scoped,
+// without touching global env. Parsed once.
 let envLocalCache: Record<string, string> | null = null
 function readEnvLocal(): Record<string, string> {
   if (envLocalCache) return envLocalCache

--- a/src/test/neon-branch.ts
+++ b/src/test/neon-branch.ts
@@ -76,6 +76,18 @@ export function resolveNeonApiKey(): string | null {
   return fromFile || null
 }
 
+/**
+ * Resolve the shared long-lived test-branch URL used by the no-ephemeral
+ * fallback: `TEST_DATABASE_URL` from the process env, else `.env.local`. This
+ * is the dedicated Neon `test` branch — NEVER `dev`. Returns `null` when unset.
+ */
+export function resolveTestDatabaseUrl(): string | null {
+  const fromEnv = process.env.TEST_DATABASE_URL?.trim()
+  if (fromEnv) return fromEnv
+  const fromFile = readEnvLocal().TEST_DATABASE_URL?.trim()
+  return fromFile || null
+}
+
 /** Project id: `NEON_PROJECT_ID` env / `.env.local`, else the brass default. */
 function resolveProjectId(): string {
   return (

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,5 +18,10 @@ export default defineConfig({
     // Relaxes env validation so suites that import the DB layer can load;
     // DB-backed suites provision their own schema via ensureTestSchema().
     setupFiles: ['./src/test/setup-db.ts'],
+    // Gives each local run its own throwaway Neon branch (created here,
+    // exported as DATABASE_URL, deleted in teardown). Escape hatches +
+    // offline fallback live in the module. See AGENTS.md "Local test DB
+    // isolation".
+    globalSetup: ['./src/test/global-db-branch.ts'],
   },
 })


### PR DESCRIPTION
## What

Extends the per-run isolated Neon DB from CI (PR #7) to **local** test runs. A vitest `globalSetup` gives every local run its own throwaway Neon branch, so laptops stop sharing the `dev` branch, parallel runs can't collide, and the two DATABASE_URL-dependent suites (`gameStore.multiplayer.test.ts`, `mp-ai.test.ts`) work on any machine with a `NEON_API_KEY` — no hand-crafted `.env`.

## How

- **`src/test/neon-branch.ts`** — branch lifecycle via the official Neon TS SDK (`@neondatabase/api-client`, added as a devDependency): `createProjectBranch`/`deleteProjectBranch` against project `muddy-night-85782525`. Branches off the pre-migrated `ci` parent (copy-on-write → schema inherited instantly), names `local-test-<rand>`, sets a 2h `expires_at` TTL (orphan backstop), and returns the connection URI from the create response. No shell-out.
- **`src/test/global-db-branch.ts`** — vitest `globalSetup`: runs once in the main process **before** workers spawn, so setting `process.env.DATABASE_URL` propagates to the workers that import the DB layer. Returns an async teardown that deletes the branch on any exit path (pass or fail).
- **`vitest.config.ts`** — wires the `globalSetup` (the runner's sanctioned hook).

### Credential
`NEON_API_KEY` (brass-project-scoped Neon key):
- **Local** — put it in `.env.local` (gitignored via `.env*.local`; never committed).
- **CI** — the `NEON_API_KEY` repo secret; a plain env var also overrides `.env.local` in disposable worktrees.
- `NEON_PROJECT_ID` is likewise overridable, defaults to the brass project.

### Fallback (offline never hard-fails)
- `TEST_DB_BRANCH=0` → skip branching, keep the current `DATABASE_URL`.
- Missing `NEON_API_KEY` → skip with a one-line `[test-db]` notice.
- Create failure → warn and fall back to the existing `DATABASE_URL`.
- Engine (DB-less) suites always run offline, untouched.

## Verification (local)

- Both DB suites run **twice in parallel**, each on a **different** branch, both green (16 passed each): `br-plain-river` / `br-dry-term`.
- `neonctl branches list` before == after (4 branches) — **no leaked** `local-test-*` branches.
- `expires_at` TTL confirmed set on the created branch (via the SDK helper).
- `TEST_DB_BRANCH=0` and a no-key machine both degrade cleanly (engine suite still 15 passed).
- `pnpm typecheck` + `biome check` clean.

## Notes
- **No drizzle schema changes** — coordinated with the concurrent chat-table normalization work; `ensureTestSchema` just replays whatever migrations are in `./drizzle`.
- History: earlier revisions used the macOS keychain, then neonctl; per final captain steer this settles on the `@neondatabase/api-client` SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added isolated, temporary database branches for local database-backed test runs.
  * Test branches are automatically created before tests and cleaned up afterward, with expiration safeguards.
  * Added fallback behavior to continue using the existing database when branching is disabled or unavailable.
* **Documentation**
  * Updated testing guidance and configuration requirements for database branch isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->