### PR TITLE
feat(mp): normalize chat into its own table (out of the game jsonb)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -414,9 +414,11 @@ When updating this file, preserve this bar for all agents and keep entries conci
   so a serverless instance isn't frozen out from under a multi-step AI turn,
   and the stream poll re-kicks a stalled AI each tick. Do NOT add
   WebSockets/LISTEN-NOTIFY/an external pub-sub (decision doc §5). Wire tests:
-  `gameStore.multiplayer.test.ts` (act/chat view shape + hidden-info) +
-  `e2e/multiplayer.spec.ts` (raw SSE `retry:` line).
-- `store.ts` is the single seam (load/save/sweep/loadVersion by token); the
+  `gameStore.multiplayer.test.ts` (act/chat view shape + hidden-info + chat
+  seq delivery / bounded tail / `getChatDelta`) + `e2e/multiplayer.spec.ts`
+  (raw SSE `retry:` line + the `event: chat` increment frame).
+- `store.ts` is the single seam (load/save/sweep + chat append/tail + the
+  cheap `(version, maxSeq)` poll `loadVersionAndSeq`, by token); the
   DB engine is a config swap in `drizzle.config.ts` + `src/server/db/index.ts`.
   DATABASE_URL is now REQUIRED (a libsql `file:` URL will NOT connect through
   neon-http). Migrations in `./drizzle`; apply with `pnpm db:migrate`/`db:push`.
@@ -442,11 +444,25 @@ When updating this file, preserve this bar for all agents and keep entries conci
   "create a branch per preview deployment". Previews sit behind Vercel
   Deployment Protection (SSO) — viewable only when logged into the Vercel
   account.
-- Chat + turn notifications (2026-07-15): messages live ON the game record
-  (`store.ts ChatMessage`, capped 200×500 chars; POST /api/mp/chat auths
-  like act; only authed seats receive them in `viewFor`). Turn notifications
-  derive from SSE frames via `mp/turnNotify.ts` (`didBecomeMyTurn` — never
-  fires on the first frame); permission is asked only from the header bell.
+- Chat (normalized out 2026-07-16): chat lives in its OWN append-only
+  `chat_messages` table (PK = game token + monotonic per-game `seq`, which is
+  the wire `id`), NOT the game jsonb row. A POST /api/mp/chat appends ONE row
+  and does NOT rewrite the game row or bump the engine `version`, so a chat
+  line never fans a full ~26KB per-seat state frame (the DB-as-bus reason).
+  Delivery: the stream poll watches the pair `(version, maxSeq)` in one round
+  trip (`loadVersionAndSeq`) — a `version` bump → full `data:` view frame (now
+  also carrying the recent chat tail, `CHAT_TAIL_LIMIT`=50); only `maxSeq`
+  moved → a bounded `event: chat` increment (`getChatDelta`, authed-only,
+  no snapshot). The client merges chat by `id`==seq (idempotent) via
+  `applyView`/`applyChatDelta` in `mp-game.tsx`; full history stays in the
+  table (swept when the game is), the view only ever ships the tail.
+  Migration 0001 backfills the old jsonb `games.messages` (now vestigial —
+  kept only so the backfill stays re-runnable; drop once pre-migration games
+  age out under the 7-day TTL). Chat is public to seated players; there is no
+  seat-private channel. POST /api/mp/chat auths like act; spectators get no
+  chat in `viewFor`. Turn notifications derive from SSE frames via
+  `mp/turnNotify.ts` (`didBecomeMyTurn` — never fires on the first frame);
+  permission is asked only from the header bell.
 - Seat reclaim: refresh re-authenticates from localStorage; a LOST secret
   is recovered via the host-only "Seats" → Release, then re-claim from the
   invite link. GOTCHA: only the credentialed SSE stream may clear creds on

--- a/drizzle/0001_needy_peter_quill.sql
+++ b/drizzle/0001_needy_peter_quill.sql
@@ -1,0 +1,31 @@
+CREATE TABLE "chat_messages" (
+	"token" text NOT NULL,
+	"seq" integer NOT NULL,
+	"seat_id" integer NOT NULL,
+	"name" text NOT NULL,
+	"text" text NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "chat_messages_token_seq_pk" PRIMARY KEY("token","seq")
+);
+--> statement-breakpoint
+CREATE INDEX "chat_messages_token_idx" ON "chat_messages" USING btree ("token");
+--> statement-breakpoint
+-- Backfill: migrate chat that used to live in the vestigial games.messages
+-- jsonb array into the normalized table. The old per-message `id` was already
+-- a per-game monotonic counter, so it maps 1:1 onto `seq`. ON CONFLICT makes
+-- this idempotent (safe to re-run against a shared dev branch). The
+-- games.messages column is intentionally KEPT (not dropped) so this statement
+-- stays re-runnable; it can be dropped once all pre-migration games have aged
+-- out under the 7-day TTL.
+INSERT INTO "chat_messages" ("token", "seq", "seat_id", "name", "text", "created_at")
+SELECT g."token",
+       (elem->>'id')::int,
+       (elem->>'seatId')::int,
+       elem->>'name',
+       elem->>'text',
+       elem->>'at'
+FROM "games" g
+CROSS JOIN LATERAL jsonb_array_elements(g."messages") AS elem
+WHERE g."messages" IS NOT NULL
+  AND jsonb_typeof(g."messages") = 'array'
+ON CONFLICT ("token", "seq") DO NOTHING;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,161 @@
+{
+  "id": "211a142d-2fd6-4bb3-a205-4a8bfb751330",
+  "prevId": "69cb57c5-90cb-4c5b-96b1-b15cef447570",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_token_idx": {
+          "name": "chat_messages_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_messages_token_seq_pk": {
+          "name": "chat_messages_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lobby'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seats": {
+          "name": "seats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai": {
+          "name": "ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1784133438969,
       "tag": "0000_green_yellow_claw",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1784155157521,
+      "tag": "0001_needy_peter_quill",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/multiplayer.spec.ts
+++ b/e2e/multiplayer.spec.ts
@@ -157,6 +157,53 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
   )
   expect(ctx.drawPile.every((c) => c.id.startsWith('hidden-'))).toBe(true)
 
+  /* ---- chat delta on the wire: a NEW chat line arrives as an `event: chat`
+     increment (NOT a full-state `data:` view frame), proving a message never
+     costs a full ~26KB per-seat frame under the DB-as-bus poll ---- */
+  const [chatWire] = await Promise.all([
+    guest.evaluate(
+      async ({ token }) => {
+        const creds = JSON.parse(localStorage.getItem(`bb-mp-${token}`)!) as {
+          seatId: number
+          seatSecret: string
+        }
+        const res = await fetch(
+          `/api/mp/stream?token=${token}&seat=${creds.seatId}&secret=${encodeURIComponent(creds.seatSecret)}`,
+        )
+        const reader = res.body!.getReader()
+        let text = ''
+        // Read for up to ~8s or until the chat increment frame lands.
+        for (let i = 0; i < 60 && !/event: chat\n/.test(text); i++) {
+          const { value, done } = await reader.read()
+          if (done) break
+          text += new TextDecoder().decode(value)
+        }
+        await reader.cancel()
+        return text
+      },
+      { token },
+    ),
+    // Send a fresh line from the host once the guest's raw stream is open.
+    (async () => {
+      await guest.waitForTimeout(1500)
+      await host.getByTestId('chat-input').fill('wire-delta-check')
+      await host.getByTestId('chat-send').click()
+    })(),
+  ])
+  // The increment rides its own SSE event and carries only the new message —
+  // there is no engine snapshot in a chat frame.
+  expect(chatWire).toContain('event: chat')
+  const chatStart = chatWire.indexOf('event: chat')
+  const dataLine = chatWire.slice(chatStart).match(/data: (.+)\n/)
+  const delta = JSON.parse(dataLine![1]!) as {
+    chatSeq: number
+    messages: Array<{ id: number; text: string }>
+    snapshot?: unknown
+  }
+  expect(delta.snapshot).toBeUndefined() // chat frame ≠ full-state frame
+  expect(delta.messages.at(-1)!.text).toBe('wire-delta-check')
+  expect(delta.chatSeq).toBe(delta.messages.at(-1)!.id)
+
   await hostCtx.close()
   await guestCtx.close()
 })

--- a/src/app/api/mp/stream/route.ts
+++ b/src/app/api/mp/stream/route.ts
@@ -3,19 +3,33 @@
 // DB-AS-BUS MODEL. On serverless there is no single long-lived process, so
 // this stream is NOT a passive push subscriber — it is a server-side polling
 // loop with an open pipe to the client. The delivery GUARANTEE is a cheap
-// `loadVersion` DB poll every ~1.2s: the `games.version` column IS the event
-// bus, and any instance can read it. The in-process `subscribe()` bus is kept
-// only as a same-instance FAST PATH (zero-latency when the writer and this
-// stream share a Fluid-reused instance); every push is deduped by version so
-// the bus and the poll never double-send.
+// `(version, maxSeq)` DB poll every ~1.2s: the `games.version` column IS the
+// event bus for game state, and `MAX(chat_messages.seq)` is the bus for chat.
+// Any instance can read the pair. The in-process `subscribe()` bus is kept only
+// as a same-instance FAST PATH (zero-latency when the writer and this stream
+// share a Fluid-reused instance); pushes are deduped by version/seq so the bus
+// and the poll never double-send.
+//
+// Two frame kinds, so a chat line never costs a full ~26KB state frame:
+//   • default `data:` frame — the full per-seat view (version-guarded), sent
+//     when `version` moved OR on every (re)connect (carries current state +
+//     the recent chat tail).
+//   • `event: chat` frame — a bounded chat increment, sent when ONLY `maxSeq`
+//     moved; the client merges its messages by id (seq-idempotent).
 //
 // The stream is bounded by design: it closes cleanly just before `maxDuration`
 // and the client's EventSource reconnects (a `retry` hint shortens the gap).
 // The first frame on every (re)connect is the full current view, and the
-// client's version guard makes overlap/reorder harmless.
+// client's version/seq guards make overlap/reorder harmless.
 import { type NextRequest } from 'next/server'
-import { getGameView, kickAiTurns, subscribe } from '~/server/mp/game'
-import { loadGame, loadVersion } from '~/server/mp/store'
+import {
+  CHAT_TAIL_LIMIT,
+  getChatDelta,
+  getGameView,
+  kickAiTurns,
+  subscribe,
+} from '~/server/mp/game'
+import { loadGame, loadVersionAndSeq } from '~/server/mp/store'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -55,7 +69,10 @@ export async function GET(req: NextRequest) {
   const stream = new ReadableStream({
     start(controller) {
       let open = true
-      let lastSent = -1
+      // Two independent cursors: the last engine version pushed as a full
+      // frame, and the highest chat seq the client has been told about.
+      let lastVersion = -1
+      let lastSeq = 0
       let pollTimer: ReturnType<typeof setTimeout> | undefined
 
       const write = (chunk: string) => {
@@ -81,39 +98,64 @@ export async function GET(req: NextRequest) {
       }
 
       // Serialize pushes so the bus fast-path and the poll loop can't race on
-      // `lastSent` and double-send the same version.
-      let pushing: Promise<void> = Promise.resolve()
-      const pushIfNewer = () => {
-        pushing = pushing
+      // the cursors and double-send. One `syncNow` reconciles both cursors:
+      // a full view frame when `version` moved, else a bounded chat increment
+      // when only `maxSeq` moved.
+      let syncing: Promise<void> = Promise.resolve()
+      const syncNow = () => {
+        syncing = syncing
           .then(async () => {
             if (!open) return
-            const view = await getGameView(token, seatId, secret)
-            if (view && view.version > lastSent) {
-              lastSent = view.version
-              write(`data: ${JSON.stringify(view)}\n\n`)
+            const vs = await loadVersionAndSeq(token)
+            if (!vs) return
+            if (vs.version > lastVersion) {
+              // Full frame: current per-seat state + the recent chat tail.
+              const view = await getGameView(token, seatId, secret)
+              if (view && view.version > lastVersion) {
+                lastVersion = view.version
+                const tailMax = view.messages.at(-1)?.id ?? 0
+                if (tailMax > lastSeq) lastSeq = tailMax
+                write(`data: ${JSON.stringify(view)}\n\n`)
+              }
+            } else if (vs.maxSeq > lastSeq) {
+              // Only chat moved: push a bounded increment (or, for a spectator
+              // / stale secret, send nothing but advance the cursor so we don't
+              // re-query every tick).
+              const delta = await getChatDelta(
+                token,
+                seatId,
+                secret,
+                lastSeq,
+                CHAT_TAIL_LIMIT,
+              )
+              if (delta && delta.messages.length > 0) {
+                lastSeq = delta.chatSeq
+                write(`event: chat\ndata: ${JSON.stringify(delta)}\n\n`)
+              } else {
+                lastSeq = vs.maxSeq
+              }
             }
           })
           .catch(() => {
             // a transient load/filter error must not break the pipe
           })
-        return pushing
+        return syncing
       }
 
       // Reconnect hint first, then the full current view.
       write(`retry: ${RETRY_HINT_MS}\n\n`)
       unsub = subscribe(token, () => {
-        void pushIfNewer()
+        void syncNow()
       })
-      void pushIfNewer()
+      void syncNow()
 
-      // The guarantee: poll the version column; re-derive & push on change,
-      // and re-kick a stalled AI turn (idempotent — no-op if running/human).
+      // The guarantee: poll (version, maxSeq); push on change, and re-kick a
+      // stalled AI turn (idempotent — no-op if running/human).
       const poll = async () => {
         if (!open) return
         try {
           void kickAiTurns(token)
-          const v = await loadVersion(token)
-          if (v !== null && v > lastSent) await pushIfNewer()
+          await syncNow()
         } catch {
           // a transient DB blip must not kill the stream; next tick retries
         }

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -84,12 +84,47 @@ interface GameViewWire {
   ai?: AiViewWire
 }
 
+/** A chat increment pushed on the `event: chat` SSE frame (see stream route). */
+interface ChatDeltaWire {
+  version: number
+  chatSeq: number
+  messages: ChatMessageWire[]
+}
+
 interface Creds {
   seatId: number
   seatSecret: string
 }
 
 const credsKey = (token: string) => `bb-mp-${token}`
+
+/** Keep the client's chat memory bounded; the recent tail on a full frame is
+ *  smaller than this, so a reconnect never loses already-seen lines. */
+const CLIENT_CHAT_CAP = 200
+
+/**
+ * Merge chat lines by `id` (== per-game seq): idempotent union, sorted, capped.
+ * Returns the SAME array reference when nothing new arrived so callers can
+ * no-op. This is why a duplicated/reordered chat frame (delta or full-frame
+ * tail) is harmless — the id set converges regardless of arrival order.
+ */
+function mergeChat(
+  current: ChatMessageWire[] = [],
+  incoming: ChatMessageWire[] = [],
+): ChatMessageWire[] {
+  if (incoming.length === 0) return current
+  const byId = new Map<number, ChatMessageWire>()
+  for (const m of current) byId.set(m.id, m)
+  let changed = false
+  for (const m of incoming) {
+    if (!byId.has(m.id)) {
+      byId.set(m.id, m)
+      changed = true
+    }
+  }
+  if (!changed) return current
+  return [...byId.values()].sort((a, b) => a.id - b.id).slice(-CLIENT_CHAT_CAP)
+}
 
 function loadCreds(token: string): Creds | null {
   try {
@@ -140,12 +175,35 @@ export function MpGame({ token }: { token: string }) {
     setCredsLoaded(true)
   }, [token])
 
-  // Single apply path for every authoritative view — SSE frames AND the fresh
-  // view returned by an act/chat POST. Guarded by `version`: only a strictly
-  // newer view replaces the current one, so a late/duplicate frame arriving
-  // after the act response (or vice-versa) can never regress the state.
+  // Single apply path for every authoritative full view — SSE `data:` frames
+  // AND the fresh view returned by an act/chat POST. The engine snapshot is
+  // guarded by `version` (only a strictly newer view replaces it, so a
+  // late/duplicate frame can never regress state); chat merges by id at ANY
+  // version, since a chat line no longer bumps the engine version.
   const applyView = useCallback((incoming: GameViewWire) => {
-    setView((cur) => (!cur || incoming.version > cur.version ? incoming : cur))
+    setView((cur) => {
+      if (!cur) return incoming
+      if (incoming.version > cur.version) {
+        return {
+          ...incoming,
+          messages: mergeChat(cur.messages, incoming.messages),
+        }
+      }
+      // same-or-older engine version: only the chat tail may carry news
+      const merged = mergeChat(cur.messages, incoming.messages)
+      return merged === cur.messages ? cur : { ...cur, messages: merged }
+    })
+  }, [])
+
+  // A chat increment (`event: chat`) — merge its messages into the current
+  // view without touching the engine snapshot/version. Ignored before the
+  // first full frame (the stream always sends that full frame first).
+  const applyChatDelta = useCallback((delta: ChatDeltaWire) => {
+    setView((cur) => {
+      if (!cur) return cur
+      const merged = mergeChat(cur.messages, delta.messages)
+      return merged === cur.messages ? cur : { ...cur, messages: merged }
+    })
   }, [])
 
   // Live view over SSE; EventSource reconnects on its own after drops and
@@ -176,6 +234,15 @@ export function MpGame({ token }: { token: string }) {
       }
       applyView(parsed)
     }
+    // Bounded chat increments arrive on their own event so a chat line never
+    // rides a full-state frame (see stream route). Merged by id, idempotent.
+    es.addEventListener('chat', (e) => {
+      if (closed) return
+      setStreamFailing(false)
+      applyChatDelta(
+        JSON.parse((e as MessageEvent).data as string) as ChatDeltaWire,
+      )
+    })
     es.onerror = () => {
       if (!closed) setStreamFailing(true)
     }
@@ -183,7 +250,7 @@ export function MpGame({ token }: { token: string }) {
       closed = true
       es.close()
     }
-  }, [token, creds, credsLoaded, applyView])
+  }, [token, creds, credsLoaded, applyView, applyChatDelta])
 
   if (!credsLoaded || (!view && !streamFailing)) {
     return (

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,19 +1,31 @@
-import { integer, jsonb, pgTable, text } from 'drizzle-orm/pg-core'
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  primaryKey,
+  text,
+} from 'drizzle-orm/pg-core'
 import type { ChatMessage, GameRecord, SeatRecord } from '../mp/store'
 
 /**
  * One row per networked multiplayer game, keyed by its unguessable token.
  *
- * The whole `GameRecord` lives here: scalar columns for the fields we might
- * ever query/sweep on (phase, version, timestamps) and `jsonb` columns for
- * the structured payloads — the persisted XState `snapshot`, the `seats`, the
- * chat `messages`, and the AI move-log/usage. Chat lives IN the row (not a
- * separate table) because the store's public interface loads/saves the whole
- * record atomically: a single upsert keeps that seam intact and every write
- * consistent. Timestamps are ISO-8601 `text` (not `timestamp`) so the row
- * maps 1:1 onto `GameRecord`, whose fields are strings — no Date<->string
- * conversion in the store, and ISO strings sort chronologically for the TTL
- * sweep.
+ * The `GameRecord` lives here: scalar columns for the fields we might ever
+ * query/sweep on (phase, version, timestamps) and `jsonb` columns for the
+ * structured payloads — the persisted XState `snapshot`, the `seats`, and the
+ * AI move-log/usage. A single upsert writes the whole record atomically.
+ * Timestamps are ISO-8601 `text` (not `timestamp`) so the row maps 1:1 onto
+ * `GameRecord`, whose fields are strings — no Date<->string conversion in the
+ * store, and ISO strings sort chronologically for the TTL sweep.
+ *
+ * Chat is deliberately NOT in this row (see `chatMessages` below): it moved to
+ * its own append-only table so a chat line no longer rewrites this row nor
+ * bumps `version` (which under DB-as-bus sync would fan a full ~26KB per-seat
+ * state frame to every viewer). The `messages` jsonb column is VESTIGIAL —
+ * kept only so pre-migration rows still parse and their chat can be backfilled
+ * (migration `0001`); the live path never reads or writes it, and it can be
+ * dropped once all such games have aged out under the 7-day TTL.
  *
  * This is on a real (Neon/Postgres) DB, not local disk, which is the point:
  * game state — including chat — now survives an ephemeral-box redeploy, which
@@ -30,8 +42,39 @@ export const games = pgTable('games', {
   seats: jsonb('seats').notNull().$type<SeatRecord[]>(),
   /** persisted XState snapshot of the authoritative engine (null in lobby) */
   snapshot: jsonb('snapshot').$type<unknown>(),
-  /** per-game table talk (null in records from before the chat feature) */
+  /** DEPRECATED — chat now lives in `chatMessages`. Retained only for
+   *  backfilling pre-migration rows; never read/written by the live path. */
   messages: jsonb('messages').$type<ChatMessage[]>(),
   /** present when the table has AI seats: their move log + spend counter */
   ai: jsonb('ai').$type<GameRecord['ai']>(),
 })
+
+/**
+ * Table talk, normalized OUT of the game row: one row per chat line, keyed by
+ * game `token` + a monotonically increasing per-game `seq`. Appending a
+ * message inserts ONE small row — it does not touch the `games` row, so it
+ * never bumps the engine `version` and never triggers a full-state SSE frame.
+ *
+ * The composite PK `(token, seq)` gives the per-game monotonic ordering the
+ * client dedupes/orders on (`seq` is the message id on the wire), and the
+ * `token` index makes the poll's `MAX(seq)` and the "since seq" tail cheap.
+ * Chat is public to seated players; there is no seat-private channel, so no
+ * per-seat filtering is needed on the chat rows themselves (the game view
+ * still gates whether an unauthenticated viewer sees any chat at all).
+ */
+export const chatMessages = pgTable(
+  'chat_messages',
+  {
+    token: text('token').notNull(),
+    /** monotonically increasing per game; the message id on the wire */
+    seq: integer('seq').notNull(),
+    seatId: integer('seat_id').notNull(),
+    name: text('name').notNull(),
+    text: text('text').notNull(),
+    createdAt: text('created_at').notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.token, t.seq] }),
+    index('chat_messages_token_idx').on(t.token),
+  ],
+)

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -29,7 +29,10 @@ import {
   type ChatMessage,
   type GameRecord,
   type SeatRecord,
+  appendChatMessage,
+  loadChatSince,
   loadGame,
+  loadRecentChat,
   saveGame,
   sweepStaleGames,
 } from './store'
@@ -284,6 +287,9 @@ export function viewFor(
   game: GameRecord,
   seatId: number | null,
   seatSecret: string | null,
+  /** the recent chat tail (loaded from `chat_messages`); shown to seated
+   *  players only — chat is public to the table but not to spectators */
+  chatTail: ChatMessage[] = [],
 ): GameView {
   const seat =
     seatId !== null && seatSecret !== null ? game.seats[seatId] : undefined
@@ -299,7 +305,7 @@ export function viewFor(
       authed && game.snapshot !== null
         ? filterSnapshotForSeat(game.snapshot, seatId!)
         : null,
-    messages: authed ? (game.messages ?? []) : [],
+    messages: authed ? chatTail : [],
     ...(ai ? { ai } : {}),
   }
 }
@@ -503,17 +509,31 @@ export async function actInGame(
     // Return the actor's OWN fresh per-seat view so the client applies its
     // authoritative result in POST time (~1s) instead of waiting for the next
     // SSE poll tick. This is the engine's real result (viewFor filters hidden
-    // info exactly as an SSE frame does), NOT an optimistic prediction.
+    // info exactly as an SSE frame does), NOT an optimistic prediction. The
+    // chat tail rides along so the actor's view stays consistent with chat.
+    const chatTail = await loadRecentChat(token, CHAT_TAIL_LIMIT)
     return {
       ok: true,
-      view: viewFor(game, seatId, seatSecret),
+      view: viewFor(game, seatId, seatSecret, chatTail),
       version: game.version,
     }
   })
 }
 
 export const CHAT_MAX_LENGTH = 500
-export const CHAT_HISTORY_CAP = 200
+/** The recent chat tail carried in a game view — full history stays in the
+ *  `chat_messages` table; a frame never ships more than this. */
+export const CHAT_TAIL_LIMIT = 50
+
+/** A chat increment pushed on the SSE stream when ONLY chat moved (the engine
+ *  `version` is unchanged). The client merges `messages` by `id` (== seq) into
+ *  its current view — idempotent, so a dropped/duplicated/reordered delta is
+ *  harmless, exactly like the version-guarded full frame. */
+export interface ChatDelta {
+  version: number
+  chatSeq: number
+  messages: ChatMessage[]
+}
 
 export async function sendChat(
   token: string,
@@ -534,27 +554,56 @@ export async function sendChat(
     if (trimmed.length === 0) {
       return { ok: false, error: 'Empty message' }
     }
-    const messages = game.messages ?? []
-    const message: ChatMessage = {
-      id: (messages[messages.length - 1]?.id ?? 0) + 1,
+    // Append ONE small row — this does NOT rewrite the game row nor bump the
+    // engine `version`, so it triggers a bounded chat increment rather than a
+    // full-state frame to every viewer.
+    await appendChatMessage(
+      token,
       seatId,
-      name: seat.name ?? `Player ${seatId + 1}`,
-      text: trimmed,
-      at: new Date().toISOString(),
-    }
-    game.messages = [...messages, message].slice(-CHAT_HISTORY_CAP)
-    game.version++
-    game.updatedAt = new Date().toISOString()
-    await saveGame(game)
+      seat.name ?? `Player ${seatId + 1}`,
+      trimmed,
+      new Date().toISOString(),
+    )
+    // Same-instance fast path: nudge any co-located streams to push the
+    // increment now; the ~1.2s (version, maxSeq) poll is the guarantee.
     broadcast(token)
-    // Same shape as actInGame: the sender applies its own fresh view (which
-    // includes the new message) immediately, rather than waiting for a poll.
+    // The sender applies its own fresh view (with the new message in the tail)
+    // immediately. `version` is unchanged; the client merges chat by id.
+    const chatTail = await loadRecentChat(token, CHAT_TAIL_LIMIT)
     return {
       ok: true,
-      view: viewFor(game, seatId, seatSecret),
+      view: viewFor(game, seatId, seatSecret, chatTail),
       version: game.version,
     }
   })
+}
+
+/**
+ * The chat increment for a seat since `sinceSeq` — authenticated (chat is for
+ * seated players only, never spectators), bounded to `limit`. Returns null
+ * when the caller isn't a valid seat or there is nothing new, so the stream
+ * pushes only real, authorized increments.
+ */
+export async function getChatDelta(
+  token: string,
+  seatId: number | null,
+  seatSecret: string | null,
+  sinceSeq: number,
+  limit: number,
+): Promise<ChatDelta | null> {
+  const game = await loadGame(token)
+  if (!game) return null
+  const seat =
+    seatId !== null && seatSecret !== null ? game.seats[seatId] : undefined
+  const authed = !!seat && secretMatches(seatSecret!, seat.secretHash)
+  if (!authed) return null
+  const messages = await loadChatSince(token, sinceSeq, limit)
+  if (messages.length === 0) return null
+  return {
+    version: game.version,
+    chatSeq: messages[messages.length - 1]!.id,
+    messages,
+  }
 }
 
 /* ---------------- the AI turn runner ---------------- */
@@ -702,5 +751,9 @@ export async function getGameView(
 ): Promise<GameView | null> {
   const game = await loadGame(token)
   if (!game) return null
-  return viewFor(game, seatId, seatSecret)
+  // The full frame (every SSE (re)connect and every act response) carries the
+  // recent chat tail so a fresh/reconnecting client starts with current state
+  // + recent chat in one frame. `viewFor` discards it for spectators.
+  const chatTail = await loadRecentChat(token, CHAT_TAIL_LIMIT)
+  return viewFor(game, seatId, seatSecret, chatTail)
 }

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -4,15 +4,16 @@
 // token). This is the single seam between the multiplayer service and
 // persistence: load/save/sweep the whole `GameRecord` by token. Moving off
 // per-file JSON to the DB is what lets game state — including chat — survive
-// a redeploy on an ephemeral box. The chat `messages` and the AI log live IN
-// the row (JSON columns), so a single upsert writes the whole record
-// atomically, replacing the old tmp+rename file trick. Swapping the DB engine
-// later is a config change in `drizzle.config.ts` + `src/server/db/index.ts`,
-// not a rewrite of this module.
-import { eq, lt } from 'drizzle-orm'
+// a redeploy on an ephemeral box. The AI log lives IN the row (a JSON column),
+// so a single upsert writes the whole record atomically, replacing the old
+// tmp+rename file trick. CHAT is the exception: it lives in its OWN append-only
+// `chat_messages` table (see below) so a message never rewrites the game row
+// nor bumps `version`. Swapping the DB engine later is a config change in
+// `drizzle.config.ts` + `src/server/db/index.ts`, not a rewrite of this module.
+import { and, asc, desc, eq, gt, lt, notInArray, sql } from 'drizzle-orm'
 import { type AiLogEntry, type AiTierId, type AiUsageTotals } from '../ai/types'
 import { db } from '../db'
-import { games } from '../db/schema'
+import { chatMessages, games } from '../db/schema'
 
 export interface SeatRecord {
   seatId: number
@@ -28,10 +29,8 @@ export interface SeatRecord {
   aiTier?: AiTierId
 }
 
-/** One chat line — game id = the enclosing record, plus sender + text +
- * timestamp. Stored as a JSON column on the game row (loaded/saved with the
- * whole record); no separate table because there is exactly one access
- * pattern: the entire record at once. */
+/** One chat line. `id` is the per-game monotonic `seq` from `chat_messages`
+ * (the wire id the client dedupes/orders on); `at` is the ISO created_at. */
 export interface ChatMessage {
   id: number
   seatId: number
@@ -49,8 +48,6 @@ export interface GameRecord {
   seats: SeatRecord[]
   /** persisted XState snapshot of the authoritative engine (null in lobby) */
   snapshot: unknown | null
-  /** per-game table talk (absent in records from before the feature) */
-  messages?: ChatMessage[]
   /** present when the table has AI seats: their move log + spend counter */
   ai?: {
     log: AiLogEntry[]
@@ -74,8 +71,10 @@ function rowToRecord(row: GameRow): GameRecord {
     version: row.version,
     seats: row.seats,
     snapshot: row.snapshot ?? null,
+    // `messages` is the vestigial jsonb column — never surfaced on the record
+    // anymore (chat lives in `chat_messages`); it exists only for the 0001
+    // backfill of pre-migration rows.
     // JSON NULL comes back as null; the record shape uses optional/undefined
-    ...(row.messages != null ? { messages: row.messages } : {}),
     ...(row.ai != null ? { ai: row.ai } : {}),
   }
 }
@@ -89,7 +88,9 @@ function recordToRow(game: GameRecord): GameRow {
     version: game.version,
     seats: game.seats,
     snapshot: game.snapshot ?? null,
-    messages: game.messages ?? null,
+    // Never write chat back into the game row — it is normalized out. Leaving
+    // this null lets any stale backfilled jsonb clear on the next save.
+    messages: null,
     ai: game.ai ?? null,
   }
 }
@@ -106,21 +107,129 @@ export async function loadGame(token: string): Promise<GameRecord | null> {
 }
 
 /**
- * Read ONLY the monotonic `version` for a game — the cheap DB poll that lets
- * the SSE stream act as a "server-side polling loop with an open pipe". This
- * is the delivery guarantee for cross-instance updates on serverless (the
- * in-process bus in `game.ts` is only a same-instance fast path): the stream
- * selects this every ~1.2s and re-derives the full per-seat view on change.
- * Returns null for an unknown/malformed token.
+ * Read the cheap poll pair `(version, maxSeq)` for a game in ONE round trip —
+ * the game's engine `version` and the highest chat `seq`. This is the delivery
+ * guarantee that lets the SSE stream act as a "server-side polling loop with an
+ * open pipe" (the in-process bus in `game.ts` is only a same-instance fast
+ * path): the stream selects this every ~1.2s and, on change, pushes a full
+ * per-seat view when `version` moved or a bounded chat increment when only
+ * `maxSeq` moved. Returns null for an unknown/malformed token.
  */
-export async function loadVersion(token: string): Promise<number | null> {
+export async function loadVersionAndSeq(
+  token: string,
+): Promise<{ version: number; maxSeq: number } | null> {
   if (!TOKEN_RE.test(token)) return null
+  // Correlated subquery for MAX(seq) built with the query builder (NOT a raw
+  // `sql` template): the builder qualifies `chat_messages.token = games.token`,
+  // whereas a raw template renders both columns unqualified — a `token=token`
+  // tautology that would return the GLOBAL max. Keeps it one round trip;
+  // COALESCE folds the no-chat case (NULL) to 0 so the caller never special-cases it.
+  const maxSeqSub = db
+    .select({ m: sql<number>`coalesce(max(${chatMessages.seq}), 0)` })
+    .from(chatMessages)
+    .where(eq(chatMessages.token, games.token))
   const rows = await db
-    .select({ version: games.version })
+    .select({ version: games.version, maxSeq: sql<number>`(${maxSeqSub})` })
     .from(games)
     .where(eq(games.token, token))
     .limit(1)
-  return rows[0]?.version ?? null
+  const row = rows[0]
+  if (!row) return null
+  return { version: row.version, maxSeq: Number(row.maxSeq) }
+}
+
+/* ---------------- chat (normalized out of the game row) ---------------- */
+
+const CHAT_SEQ_RETRIES = 6
+
+function rowToChat(row: typeof chatMessages.$inferSelect): ChatMessage {
+  return {
+    id: row.seq,
+    seatId: row.seatId,
+    name: row.name,
+    text: row.text,
+    at: row.createdAt,
+  }
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  for (let e = err; e; e = (e as { cause?: unknown }).cause) {
+    const { code, message } = e as { code?: string; message?: string }
+    if (
+      code === '23505' ||
+      /duplicate key|unique constraint/i.test(message ?? '')
+    )
+      return true
+  }
+  return false
+}
+
+/**
+ * Append one chat line and return it with its allocated per-game `seq`. The
+ * next `seq` is `MAX(seq)+1` for the token; the composite PK `(token, seq)`
+ * makes a lost race (two instances allocating the same seq) a unique-violation
+ * that we simply retry — the per-process game lock already serializes the
+ * common same-instance case, so the retry loop only ever fires cross-instance.
+ */
+export async function appendChatMessage(
+  token: string,
+  seatId: number,
+  name: string,
+  text: string,
+  createdAt: string,
+): Promise<ChatMessage> {
+  if (!TOKEN_RE.test(token)) throw new Error('Malformed game token')
+  for (let attempt = 0; attempt < CHAT_SEQ_RETRIES; attempt++) {
+    const maxRows = await db
+      .select({ max: sql<number>`coalesce(max(${chatMessages.seq}), 0)` })
+      .from(chatMessages)
+      .where(eq(chatMessages.token, token))
+    const nextSeq = Number(maxRows[0]?.max ?? 0) + 1
+    try {
+      const inserted = await db
+        .insert(chatMessages)
+        .values({ token, seq: nextSeq, seatId, name, text, createdAt })
+        .returning()
+      return rowToChat(inserted[0]!)
+    } catch (err) {
+      if (isUniqueViolation(err) && attempt < CHAT_SEQ_RETRIES - 1) continue
+      throw err
+    }
+  }
+  throw new Error('Could not allocate a chat sequence number')
+}
+
+/** The recent tail (last `limit`, ascending by seq) — the bounded slice the
+ *  game view carries so a frame never ships unbounded history. */
+export async function loadRecentChat(
+  token: string,
+  limit: number,
+): Promise<ChatMessage[]> {
+  if (!TOKEN_RE.test(token)) return []
+  const rows = await db
+    .select()
+    .from(chatMessages)
+    .where(eq(chatMessages.token, token))
+    .orderBy(desc(chatMessages.seq))
+    .limit(limit)
+  return rows.reverse().map(rowToChat)
+}
+
+/** Messages strictly newer than `sinceSeq` (ascending, capped at `limit`) —
+ *  the increment the stream pushes when only chat moved. */
+export async function loadChatSince(
+  token: string,
+  sinceSeq: number,
+  limit: number,
+): Promise<ChatMessage[]> {
+  if (!TOKEN_RE.test(token)) return []
+  const rows = await db
+    .select()
+    .from(chatMessages)
+    .where(and(eq(chatMessages.token, token), gt(chatMessages.seq, sinceSeq)))
+    .orderBy(asc(chatMessages.seq))
+    .limit(limit)
+  return rows.map(rowToChat)
 }
 
 export async function saveGame(game: GameRecord): Promise<void> {
@@ -156,4 +265,14 @@ export async function sweepStaleGames(now = Date.now()): Promise<void> {
   // so a string `<` comparison is a correct TTL cutoff.
   const cutoff = new Date(now - GAME_TTL_MS).toISOString()
   await db.delete(games).where(lt(games.updatedAt, cutoff))
+  // Chat rows are tied to game lifetime; drop any now-orphaned by the sweep
+  // above (anti-join is cheap at this scale and keeps deletion in one place).
+  await db
+    .delete(chatMessages)
+    .where(
+      notInArray(
+        chatMessages.token,
+        db.select({ token: games.token }).from(games),
+      ),
+    )
 }

--- a/src/store/gameStore.multiplayer.test.ts
+++ b/src/store/gameStore.multiplayer.test.ts
@@ -3,14 +3,23 @@
 import { beforeAll, describe, expect, test, vi } from 'vitest'
 import {
   CHAT_MAX_LENGTH,
+  CHAT_TAIL_LIMIT,
   actInGame,
   createGame,
+  getChatDelta,
   getGameView,
   joinGame,
   releaseSeat,
   sendChat,
 } from '../server/mp/game'
-import { loadGame, saveGame } from '../server/mp/store'
+import {
+  appendChatMessage,
+  loadChatSince,
+  loadGame,
+  loadRecentChat,
+  loadVersionAndSeq,
+  saveGame,
+} from '../server/mp/store'
 import { ensureTestSchema } from '../test/db-schema'
 
 // Every test here drives several sequential round-trips to a real (network)
@@ -180,13 +189,16 @@ describe('multiplayer: lifecycle and authority', () => {
     }
   })
 
-  test('chat returns the sender view + version with the new message', async () => {
+  test('chat returns the sender view + the new message, WITHOUT bumping the engine version', async () => {
     const { host } = await freshGame()
     const before = await getGameView(host.token, 0, host.seatSecret)
     const res = await sendChat(host.token, 0, host.seatSecret, 'well played')
     expect(res.ok).toBe(true)
     if (!res.ok) throw new Error('unreachable')
-    expect(res.version).toBeGreaterThan(before!.version)
+    // Chat is normalized out of the game row: the returned version is the
+    // UNCHANGED engine version (no full-state frame), and the sender's own
+    // view already carries the new line in its bounded tail.
+    expect(res.version).toBe(before!.version)
     expect(res.view.version).toBe(res.version)
     expect(res.view.messages.at(-1)?.text).toBe('well played')
   })
@@ -306,8 +318,10 @@ describe('multiplayer: table talk', () => {
       name: 'Ada',
       text: 'hello', // trimmed
     })
-    // chat bumps the version so SSE clients refresh
-    expect((await loadGame(host.token))!.version).toBe(versionBefore + 1)
+    // chat is normalized OUT of the game row: a message inserts one
+    // chat_messages row and does NOT rewrite the game record nor bump the
+    // engine version (that's the whole point — no full-state frame per line).
+    expect((await loadGame(host.token))!.version).toBe(versionBefore)
 
     // Long messages are capped at CHAT_MAX_LENGTH characters.
     await sendChat(host.token, 1, guest.seatSecret, 'x'.repeat(2000))
@@ -320,6 +334,103 @@ describe('multiplayer: table talk', () => {
     const anon = await getGameView(host.token, null, null)
     expect(anon!.messages).toStrictEqual([])
   })
+})
+
+describe('multiplayer: chat delivery over the (version, maxSeq) poll', () => {
+  test('per-game seq increases monotonically; the poll pair tracks it without bumping version', async () => {
+    const { host, guest } = await freshGame()
+    const base = await loadVersionAndSeq(host.token)
+    expect(base).not.toBeNull()
+    expect(base!.maxSeq).toBe(0) // no chat yet
+
+    const a = await sendChat(host.token, 0, host.seatSecret, 'one')
+    const b = await sendChat(host.token, 1, guest.seatSecret, 'two')
+    expect(a.ok && b.ok).toBe(true)
+    if (!a.ok || !b.ok) throw new Error('unreachable')
+    // ids are the monotonic per-game seq
+    expect(a.view.messages.at(-1)!.id).toBe(1)
+    expect(b.view.messages.at(-1)!.id).toBe(2)
+
+    // The cheap poll pair sees the new max seq but the SAME engine version:
+    // the stream pushes a chat increment, never a full-state frame, for chat.
+    const poll = await loadVersionAndSeq(host.token)
+    expect(poll!.version).toBe(base!.version)
+    expect(poll!.maxSeq).toBe(2)
+  })
+
+  test('getChatDelta returns only messages since a seq, and only to seated players', async () => {
+    const { host, guest } = await freshGame()
+    await sendChat(host.token, 0, host.seatSecret, 'm1')
+    await sendChat(host.token, 1, guest.seatSecret, 'm2')
+    await sendChat(host.token, 0, host.seatSecret, 'm3')
+
+    // Increment since seq 1 → messages 2 and 3 only, ascending, chatSeq = 3.
+    const delta = await getChatDelta(host.token, 0, host.seatSecret, 1, 50)
+    expect(delta).not.toBeNull()
+    expect(delta!.chatSeq).toBe(3)
+    expect(delta!.messages.map((m) => m.id)).toEqual([2, 3])
+    expect(delta!.messages.map((m) => m.text)).toEqual(['m2', 'm3'])
+
+    // Caught up (since the max) → nothing to send.
+    expect(await getChatDelta(host.token, 0, host.seatSecret, 3, 50)).toBeNull()
+
+    // A spectator / wrong secret never gets a chat increment.
+    expect(await getChatDelta(host.token, null, null, 0, 50)).toBeNull()
+    expect(await getChatDelta(host.token, 0, 'wrong-secret', 0, 50)).toBeNull()
+  })
+
+  test('store-level increment: loadChatSince mirrors what the stream pushes', async () => {
+    const { host, guest } = await freshGame()
+    await sendChat(host.token, 0, host.seatSecret, 'x1')
+    await sendChat(host.token, 1, guest.seatSecret, 'x2')
+    const since1 = await loadChatSince(host.token, 1, 50)
+    expect(since1.map((m) => m.id)).toEqual([2])
+    expect(await loadChatSince(host.token, 2, 50)).toHaveLength(0)
+  })
+})
+
+describe('multiplayer: the chat tail carried in a view is bounded', () => {
+  test('a view ships only the recent CHAT_TAIL_LIMIT lines; full history stays in the table', async () => {
+    const { host, guest } = await freshGame()
+    const total = CHAT_TAIL_LIMIT + 15
+    // Exercise the real send path for the first two (seq allocation + view),
+    // then bulk-seed the rest straight through the store's appendChatMessage
+    // (same seq allocation, fewer round trips) so the test stays under budget.
+    await sendChat(host.token, 0, host.seatSecret, 'msg-1')
+    await sendChat(host.token, 1, guest.seatSecret, 'msg-2')
+    for (let i = 3; i <= total; i++) {
+      const asHost = i % 2 === 1
+      const msg = await appendChatMessage(
+        host.token,
+        asHost ? 0 : 1,
+        asHost ? 'Ada' : 'Brunel',
+        `msg-${i}`,
+        new Date(2026, 0, 1, 0, 0, i).toISOString(),
+      )
+      expect(msg.id).toBe(i) // seq stays monotonic through both paths
+    }
+
+    // The seat view (a full frame / reconnect frame) carries only the tail…
+    const view = await getGameView(host.token, 0, host.seatSecret)
+    expect(view!.messages).toHaveLength(CHAT_TAIL_LIMIT)
+    // …and it is the LAST CHAT_TAIL_LIMIT, in order, ending at the newest id.
+    expect(view!.messages.at(-1)!.id).toBe(total)
+    expect(view!.messages.at(-1)!.text).toBe(`msg-${total}`)
+    expect(view!.messages[0]!.id).toBe(total - CHAT_TAIL_LIMIT + 1)
+    const ids = view!.messages.map((m) => m.id)
+    expect(ids).toEqual([...ids].sort((p, q) => p - q))
+
+    // The bounded tail is a VIEW concern only — the table keeps everything.
+    const everything = await loadRecentChat(host.token, total + 100)
+    expect(everything).toHaveLength(total)
+    expect(everything[0]!.id).toBe(1)
+
+    // A reconnecting client's first frame == the current state + recent tail,
+    // so it never has to page history to render the conversation.
+    const reconnectFrame = await getGameView(host.token, 1, guest.seatSecret)
+    expect(reconnectFrame!.messages).toHaveLength(CHAT_TAIL_LIMIT)
+    expect(reconnectFrame!.messages.at(-1)!.id).toBe(total)
+  }, 90_000) // seeds > CHAT_TAIL_LIMIT rows over the network — extra headroom
 })
 
 describe('multiplayer: persistence survives a redeploy', () => {
@@ -358,12 +469,16 @@ describe('multiplayer: persistence survives a redeploy', () => {
     const after = await loadGame(host.token)
     expect(after).not.toBeNull()
 
-    // Whole record is identical — phase, version, seats, snapshot, and chat.
+    // Whole game record is identical — phase, version, seats, snapshot.
     expect(after).toStrictEqual(before)
     expect(after!.phase).toBe('playing')
     expect(after!.snapshot).toBeTruthy()
-    expect(after!.messages).toHaveLength(2)
-    expect(after!.messages!.map((m) => m.text)).toEqual([
+    // Chat now lives in its OWN table, so it survives the reload independently
+    // of the game row — read it back through the seat view (the record itself
+    // no longer carries chat).
+    const chatView = await getGameView(host.token, 0, host.seatSecret)
+    expect(chatView!.messages).toHaveLength(2)
+    expect(chatView!.messages.map((m) => m.text)).toEqual([
       'good game',
       'you too',
     ])


### PR DESCRIPTION
## What & why

Chat lived inside the single `games`-row jsonb, so every message rewrote the whole row, bumped the engine `version`, and — under the new DB-as-bus sync ([PR #8](https://github.com/julius-retzer/brass-birmingham/pull/8)) — fanned a full **~26KB per-seat state frame** to every viewer. Chat history also grew that row (and every frame) unboundedly for the life of a game.

This normalizes chat into its own **append-only `chat_messages` table**, keyed by game token + a monotonically increasing per-game `seq` (which is the message id on the wire). A chat POST now appends **one small row** — it does **not** rewrite the game row nor bump the engine `version`.

The DB-as-bus contracts from [the architecture decision](https://github.com/julius-retzer/brass-birmingham) (versioned idempotent full-view frames, per-seat filtering, the ~1.2s poll) are preserved.

## Design

**Table** (`chat_messages`, migration `0001`): PK `(token, seq)` + a `token` index; columns `seat_id`, `name`, `text`, `created_at`. `seq = MAX(seq)+1` per token, allocated under the per-process game lock with a retry on the (rare, cross-instance) unique-violation.

**Delivery** — the stream poll now watches the **pair `(version, maxSeq)`** in one round trip (`loadVersionAndSeq`, a correlated subquery):
- `version` moved → full per-seat `data:` view frame (unchanged shape), now also carrying the recent chat **tail** (`CHAT_TAIL_LIMIT = 50`).
- only `maxSeq` moved → a bounded **`event: chat`** increment (`getChatDelta`, authed-only, no snapshot) — a chat line never costs a full-state frame.
- act/chat POST responses still return the actor's own fresh view (+ tail) — the "act returns the result" principle.

**Bounded payload / reconnect** — a view only ever ships the last 50 lines; full history stays in the table. The client merges chat by `id == seq` (`applyView` / `applyChatDelta`), so duplicates/reordering across a reconnect are harmless — same idempotency principle as the version guard. The first frame on (re)connect carries current state + recent chat.

**Hidden info** — verified in code: chat is public to *seated players only*; there is no seat-private channel. Spectators still receive no chat.

**Migration safety** — `0001` backfills the old jsonb `games.messages` into the table (`ON CONFLICT DO NOTHING`, idempotent; verified end-to-end that a pre-migration row's chat migrates with `seq`/seat/text/timestamp intact). The `games.messages` column is intentionally **kept vestigial** — so the backfill stays re-runnable (this repo's test-schema applier re-runs every migration each run) — and can be dropped once all pre-migration games age out under the 7-day TTL. **No data loss for active games.** Chat rows are swept when their game is.

## Tests

- Extended the DB-backed wire suite (`gameStore.multiplayer.test.ts`): monotonic seq + the poll pair advancing **without** a version bump; `getChatDelta` since/authed-only; reconnect chat tail; **bounded-tail cap** (view ships 50, table keeps all). Updated the two existing chat tests that asserted the old version-bump behavior.
- Extended the raw-SSE e2e (`multiplayer.spec.ts`): asserts a new line arrives as an **`event: chat`** increment frame carrying the message and **no snapshot**.
- `pnpm typecheck` clean; full unit suite (298 passed) and all 19 e2e green.

> Note: the two `DATABASE_URL`-dependent suites need a Neon connection locally (they skip visibly without one); CI provisions per-run branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat is now delivered in real time through incremental updates, without refreshing the full game state.
  * Recent chat remains available when reconnecting or reloading a game.
  * Chat history is preserved during redeployments and migrations.

* **Bug Fixes**
  * Prevented chat activity from unnecessarily changing the game state version.
  * Improved synchronization to avoid duplicate or missing chat messages.
  * Spectators no longer receive private chat content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->