### PR TITLE
fix(ui): let the right panel scroll instead of collapsing the journal

### DIFF
--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -27,7 +27,7 @@ import { computeHoverCities } from '../hover-highlight'
 import { GameOverScreen } from '../overlays'
 import { PlayerLedger } from '../player-ledger'
 import { PlayerRail } from '../player-rail'
-import { JournalPanel, MarketsPanel } from '../side-panels'
+import { CollapsiblePanel, JournalPanel, MarketsPanel } from '../side-panels'
 import { didBecomeMyTurn, playTurnChime, titleForTurn } from './turnNotify'
 import { useInFlight } from './use-in-flight'
 
@@ -1296,8 +1296,11 @@ function AiMindPanel({
     .filter((e) => e.rationale !== null || e.fallback)
     .slice(-8)
   return (
-    <div className="bb2-panel flex flex-col gap-2 p-4" data-testid="ai-mind">
-      <span className="bb2-panel-title">The rival&rsquo;s journal</span>
+    <CollapsiblePanel
+      title="The rival’s journal"
+      testId="ai-mind-toggle"
+      panelTestId="ai-mind"
+    >
       {entries.length === 0 ? (
         <p className="text-[12px]" style={{ color: 'rgba(231,215,177,.45)' }}>
           The AI has not moved yet.
@@ -1349,6 +1352,6 @@ function AiMindPanel({
         {ai.usage.calls === 1 ? 'call' : 'calls'}
         {ai.usage.fallbacks > 0 ? ` · ${ai.usage.fallbacks} fallbacks` : ''}
       </p>
-    </div>
+    </CollapsiblePanel>
   )
 }

--- a/src/components/side-panels.tsx
+++ b/src/components/side-panels.tsx
@@ -200,7 +200,7 @@ export function JournalPanel({
 }) {
   const recent = logs.slice(-40).reverse()
   return (
-    <div className="bb2-panel flex min-h-0 flex-1 flex-col gap-2 p-3">
+    <div className="bb2-panel flex min-h-[220px] flex-1 flex-col gap-2 p-3">
       <span className="bb2-panel-title">Journal</span>
       <div className="bb2-log min-h-0 flex-1 space-y-0.5 overflow-y-auto pr-1">
         {recent.map((entry, i) => (

--- a/src/components/side-panels.tsx
+++ b/src/components/side-panels.tsx
@@ -1,8 +1,54 @@
 'use client'
 
 // Right-dock reference panels: the coal & iron exchanges and the journal.
+import { type ReactNode, useState } from 'react'
 import { type GameState, type LogEntry, type Player } from '~/store/gameStore'
 import { PLAYER_FILL } from './board/board-map'
+
+/* ---------------- collapsible shell ---------------- */
+
+// The collapse affordance the chat panel established (`ChatPanel` in
+// mp/mp-game.tsx): the title row doubles as the toggle, caret on the right.
+export function CollapsiblePanel({
+  title,
+  testId,
+  panelTestId,
+  defaultOpen = true,
+  openClassName = '',
+  children,
+}: {
+  title: string
+  testId?: string
+  panelTestId?: string
+  defaultOpen?: boolean
+  // Applied only while open — layout that must not reserve space for content
+  // that isn't rendered (e.g. the journal's min-height floor).
+  openClassName?: string
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div
+      className={`bb2-panel flex flex-col gap-2 p-3 ${open ? openClassName : ''}`}
+      data-testid={panelTestId}
+      data-open={open}
+    >
+      <button
+        type="button"
+        className="flex flex-none items-center justify-between"
+        data-testid={testId}
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className="bb2-panel-title">{title}</span>
+        <span style={{ color: 'rgba(231,215,177,.5)', fontSize: 11 }}>
+          {open ? '▾' : '▸'}
+        </span>
+      </button>
+      {open && children}
+    </div>
+  )
+}
 
 /* ---------------- markets ---------------- */
 
@@ -98,8 +144,7 @@ export function MarketsPanel({
   ironMarket: GameState['ironMarket']
 }) {
   return (
-    <div className="bb2-panel flex flex-col gap-3 p-3">
-      <span className="bb2-panel-title">The Exchanges</span>
+    <CollapsiblePanel title="The Exchanges" testId="markets-toggle">
       <div className="flex gap-5">
         <MarketTrack
           title="Coal"
@@ -114,7 +159,7 @@ export function MarketsPanel({
           cubeStroke="#7c3d1c"
         />
       </div>
-    </div>
+    </CollapsiblePanel>
   )
 }
 
@@ -200,8 +245,14 @@ export function JournalPanel({
 }) {
   const recent = logs.slice(-40).reverse()
   return (
-    <div className="bb2-panel flex min-h-[220px] flex-1 flex-col gap-2 p-3">
-      <span className="bb2-panel-title">Journal</span>
+    <CollapsiblePanel
+      title="Journal"
+      testId="journal-toggle"
+      // A floor, so a tall dock can't squeeze the journal to nothing — the
+      // aside overflows and scrolls instead. Collapsed it is only its header,
+      // so it must not claim the space then.
+      openClassName="min-h-[220px] flex-1"
+    >
       <div className="bb2-log min-h-0 flex-1 space-y-0.5 overflow-y-auto pr-1">
         {recent.map((entry, i) => (
           <div
@@ -221,6 +272,6 @@ export function JournalPanel({
           </p>
         )}
       </div>
-    </div>
+    </CollapsiblePanel>
   )
 }


### PR DESCRIPTION
Hotfix + the captain's follow-on scope, in one PR.

**Preview:** https://brass-birmingham-git-fm-brass-pa-60a27d-julius-retzers-projects.vercel.app/?demo — behind Vercel Deployment Protection, so open it while logged into the Vercel account. Try it at a short window height while on turn.

---

## 1. The right panel wouldn't scroll

> "the journal and the whole right panel is not scrollable. If user is on turn, they can't scroll to see the journal."

**Root cause.** The side panel `<aside>` (identical in `game.tsx` and `mp/mp-game.tsx`) already carried `lg:overflow-y-auto`. It never fired.

`JournalPanel`'s root was `bb2-panel flex min-h-0 flex-1 …`. With `flex-1` (`flex: 1 1 0%`) plus `min-h-0`, the journal could shrink to zero — so it absorbed every height change instead of letting the column overflow. The aside's content always fit exactly, `overflow-y-auto` had nothing to scroll, and no scrollbar appeared. On turn this bites hardest: the `ActionDock` grows, the journal yields the space and collapses out of reach.

**Fix.** Give the journal a min-height floor so the aside genuinely overflows and its **existing** `overflow-y-auto` takes over — the whole right side scrolls, not just the journal. The journal keeps its own inner log scroll for long histories.

## 2. Collapsible right-panel widgets

Reuses the affordance `ChatPanel` already established — title row doubles as the toggle, caret on the right — extracted as `CollapsiblePanel` and applied to **markets**, **journal**, and the **AI rival's journal**. No new mechanism, no restyling.

All default open, so the panel looks and behaves exactly as today until a player collapses something. The journal's min-height floor rides on the shell's open-only class: collapsed, it must shrink to its header rather than keep claiming `flex-1`.

`ChatPanel` keeps its own implementation — it has an unread badge, defaults closed, and is the pattern being borrowed from. Rewriting it would have been churn for no gain.

## Verification

Measured in a real browser at 1280×620 on turn (`/?demo`):

| | before-shape | after |
| :-- | :-- | :-- |
| aside content vs box | fit exactly → no scroll | 818px in a 424px box → scrolls |
| journal height | collapsed toward 0 | holds its 220px floor, 40 entries |
| journal reachable | no | yes, scrolls fully into view |
| collapsed panel | n/a | 44px header; aside content 818→439px |

Board, hand tray, and player rail unaffected.

- `pnpm typecheck` — clean
- `pnpm lint` (Biome) — clean
- `pnpm test` — **passes on CI** against this head commit
- `pnpm exec playwright test` — 17 passed. The 2 DB-backed specs (`ai-opponent`, `multiplayer`) fail locally for lack of a `DATABASE_URL` in the disposable worktree; `ai-opponent` dies at `era-plate` during game creation, before any panel assertion.

`claude-review` is red for a pre-existing reason unrelated to this PR: "Claude Code is not installed on this repository" (the GitHub App isn't installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible panels for the AI journal, exchanges, and journal sections.
  * Panels include titled toggle controls with expand/collapse indicators.
  * Preserved each panel’s existing content and layout when expanded.
  * Journal panel height and scrolling behavior now adapt to its expanded state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->