### PR TITLE
fix(engine): refuse network/develop actions the player cannot afford

### DIFF
--- a/src/store/gameStore.integration.test.ts
+++ b/src/store/gameStore.integration.test.ts
@@ -10,6 +10,7 @@ import type { CityId } from '../data/board'
 import { gameStore } from './gameStore'
 
 let activeActors: ReturnType<typeof createActor>[] = []
+let moneyInvariantViolations: string[] = []
 
 afterEach(() => {
   activeActors.forEach((actor) => {
@@ -18,6 +19,9 @@ afterEach(() => {
     } catch {}
   })
   activeActors = []
+  const violations = moneyInvariantViolations
+  moneyInvariantViolations = []
+  expect(violations).toEqual([])
 })
 
 const PLAYER_TEMPLATES = [
@@ -50,6 +54,17 @@ const PLAYER_TEMPLATES = [
 const startGame = (playerCount: number) => {
   const actor = createActor(gameStore)
   activeActors.push(actor)
+  // Global invariant: Brass has no debt, so no event may ever leave a player
+  // with a negative treasury (see gameStore.money.test.ts). Violations are
+  // collected rather than thrown - a throw inside a subscriber does not
+  // propagate out of send() - and asserted in afterEach.
+  actor.subscribe((snapshot) => {
+    for (const player of (snapshot as any).context.players) {
+      if (player.money < 0) {
+        moneyInvariantViolations.push(`${player.name} has £${player.money}`)
+      }
+    }
+  })
   actor.start()
   const players = PLAYER_TEMPLATES.slice(0, playerCount).map((p) => ({
     ...p,

--- a/src/store/gameStore.money.test.ts
+++ b/src/store/gameStore.money.test.ts
@@ -1,0 +1,205 @@
+// Invariant: player.money >= 0 at all times. Brass has no debt, so an action
+// whose total cost exceeds the treasury is illegal and must be refused before
+// commit. Regression suite for the network/develop paths, which committed the
+// cost unconditionally (a player with £2 could build a £3 canal link → -£1).
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import type { IndustryType } from '../data/cards'
+import { gameStore } from './gameStore'
+
+let activeActors: ReturnType<typeof createActor>[] = []
+afterEach(() => {
+  activeActors.forEach((actor) => {
+    try {
+      actor.stop()
+    } catch {}
+  })
+  activeActors = []
+})
+
+const setupGame = () => {
+  const actor = createActor(gameStore)
+  activeActors.push(actor)
+  actor.subscribe({ error: () => {} })
+  actor.start()
+  const players = [
+    {
+      id: '1',
+      name: 'Teo',
+      color: 'red' as const,
+      character: 'Richard Arkwright' as const,
+      money: 17,
+      victoryPoints: 0,
+      income: 10,
+      industryTilesOnMat: {} as any,
+    },
+    {
+      id: '2',
+      name: 'Jules',
+      color: 'blue' as const,
+      character: 'Eliza Tinsley' as const,
+      money: 17,
+      victoryPoints: 0,
+      income: 10,
+      industryTilesOnMat: {} as any,
+    },
+  ]
+  actor.send({ type: 'START_GAME', players })
+  return { actor }
+}
+
+describe('money invariant: treasury can never go negative', () => {
+  test('canal link with £2 is illegal and refused; money unchanged', () => {
+    const { actor } = setupGame()
+    let snapshot = actor.getSnapshot()
+    const idx = snapshot.context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 2 })
+    snapshot = actor.getSnapshot()
+    const card = snapshot.context.players[idx]!.hand[0]!
+
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+    snapshot = actor.getSnapshot()
+
+    // Guard rejects up front, so UI / multiplayer / AI driver all inherit it
+    expect(
+      snapshot.can({ type: 'SELECT_LINK', from: 'birmingham', to: 'coventry' }),
+    ).toBe(false)
+
+    // Defense in depth: even if the guard is bypassed, nothing commits
+    actor.send({ type: 'SELECT_LINK', from: 'birmingham', to: 'coventry' })
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    const player = snapshot.context.players[idx]!
+    expect(player.money).toBe(2)
+    expect(
+      player.links.some(
+        (l) =>
+          (l.from === 'birmingham' && l.to === 'coventry') ||
+          (l.from === 'coventry' && l.to === 'birmingham'),
+      ),
+    ).toBe(false)
+  })
+
+  test('boundary: exactly £3 for a £3 canal link is legal and ends at £0', () => {
+    const { actor } = setupGame()
+    let snapshot = actor.getSnapshot()
+    const idx = snapshot.context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 3 })
+    snapshot = actor.getSnapshot()
+    const card = snapshot.context.players[idx]!.hand[0]!
+
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+    snapshot = actor.getSnapshot()
+    expect(
+      snapshot.can({ type: 'SELECT_LINK', from: 'birmingham', to: 'coventry' }),
+    ).toBe(true)
+
+    actor.send({ type: 'SELECT_LINK', from: 'birmingham', to: 'coventry' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.can({ type: 'CONFIRM' })).toBe(true)
+
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    const player = snapshot.context.players[idx]!
+    expect(player.money).toBe(0)
+    expect(
+      player.links.some(
+        (l) =>
+          (l.from === 'birmingham' && l.to === 'coventry') ||
+          (l.from === 'coventry' && l.to === 'birmingham'),
+      ),
+    ).toBe(true)
+  })
+
+  // The guard-vs-execution seam: cost scales with the resources an action
+  // consumes, so affordability must be judged on the resolved total, not on a
+  // base the player happens to be able to cover.
+  test('develop: £2 affords one tile of iron but not two', () => {
+    const developTiles = (money: number, industryTypes: IndustryType[]) => {
+      const { actor } = setupGame()
+      let snapshot = actor.getSnapshot()
+      const idx = snapshot.context.currentPlayerIndex
+      actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money })
+      snapshot = actor.getSnapshot()
+      const card = snapshot.context.players[idx]!.hand[0]!
+      actor.send({ type: 'DEVELOP' })
+      actor.send({ type: 'SELECT_CARD', cardId: card.id })
+      actor.send({ type: 'SELECT_TILES_FOR_DEVELOP', industryTypes })
+      snapshot = actor.getSnapshot()
+      const canConfirm = snapshot.can({ type: 'CONFIRM' })
+      actor.send({ type: 'CONFIRM' })
+      return {
+        canConfirm,
+        moneyAfter: actor.getSnapshot().context.players[idx]!.money,
+      }
+    }
+
+    // One tile costs £2 of market iron — affordable, and lands exactly at £0
+    expect(developTiles(2, ['cotton'])).toEqual({
+      canConfirm: true,
+      moneyAfter: 0,
+    })
+
+    // Two tiles cost £4 — refused, with the treasury untouched
+    expect(developTiles(2, ['cotton', 'manufacturer'])).toEqual({
+      canConfirm: false,
+      moneyAfter: 2,
+    })
+  })
+
+  test('develop with £0 and market-priced iron is refused; money unchanged', () => {
+    const { actor } = setupGame()
+    let snapshot = actor.getSnapshot()
+    const idx = snapshot.context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 0 })
+    snapshot = actor.getSnapshot()
+    const card = snapshot.context.players[idx]!.hand[0]!
+
+    actor.send({ type: 'DEVELOP' })
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+    snapshot = actor.getSnapshot()
+    actor.send({ type: 'SELECT_TILES_FOR_DEVELOP', industryTypes: ['cotton'] })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.selectedTilesForDevelop).toEqual(['cotton'])
+    expect(snapshot.can({ type: 'CONFIRM' })).toBe(false)
+
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.players[idx]!.money).toBe(0)
+  })
+
+  test('build already validates funds (the pattern the other paths now mirror)', () => {
+    const { actor } = setupGame()
+    let snapshot = actor.getSnapshot()
+    const idx = snapshot.context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 0 })
+    snapshot = actor.getSnapshot()
+    const locationCard = snapshot.context.players[idx]!.hand.find(
+      (c) => c.type === 'location',
+    )
+    if (!locationCard) return
+
+    actor.send({ type: 'BUILD' })
+    actor.send({ type: 'SELECT_CARD', cardId: locationCard.id })
+    snapshot = actor.getSnapshot()
+    for (const industryType of [
+      'coal',
+      'brewery',
+      'iron',
+      'cotton',
+      'manufacturer',
+      'pottery',
+    ] as const) {
+      if (snapshot.can({ type: 'SELECT_INDUSTRY_TYPE', industryType })) {
+        actor.send({ type: 'SELECT_INDUSTRY_TYPE', industryType })
+        break
+      }
+    }
+    snapshot = actor.getSnapshot()
+    if (snapshot.can({ type: 'CONFIRM' })) actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.players[idx]!.money).toBe(0)
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -945,6 +945,13 @@ export const gameStore = setup({
 
       const totalCost = linkCost + coalCost
 
+      if (currentPlayer.money < totalCost) {
+        return {
+          lastError: `Insufficient funds. Cost: £${totalCost}, Available: £${currentPlayer.money}`,
+          errorContext: 'network' as const,
+        }
+      }
+
       // Get player state after coal consumption, if any
       const playerAfterCoal =
         context.era === 'rail' && coalResult
@@ -1152,6 +1159,13 @@ export const gameStore = setup({
 
       totalCost += coalCost
 
+      if (currentPlayer.money < totalCost) {
+        return {
+          lastError: `Insufficient funds. Cost: £${totalCost}, Available: £${currentPlayer.money}`,
+          errorContext: 'network' as const,
+        }
+      }
+
       // Get final player state with beer consumption applied
       const finalPlayerAfterBeer =
         beerResult.updatedPlayers[context.currentPlayerIndex]!
@@ -1312,6 +1326,13 @@ export const gameStore = setup({
       const ironCost = ironResult.ironCost
       const updatedPlayersFromIron = ironResult.updatedPlayers
       const updatedIronMarket = ironResult.updatedIronMarket
+
+      if (currentPlayer.money < ironCost) {
+        return {
+          lastError: `Insufficient funds. Cost: £${ironCost}, Available: £${currentPlayer.money}`,
+          errorContext: 'develop' as const,
+        }
+      }
 
       const updatedHand = removeCardFromHand(
         currentPlayer,
@@ -2370,6 +2391,12 @@ export const gameStore = setup({
         return false
       }
 
+      const linkCost =
+        context.era === 'canal'
+          ? GAME_CONSTANTS.CANAL_LINK_COST
+          : GAME_CONSTANTS.RAIL_LINK_COST
+      let coalCost = 0
+
       // Check coal availability for rail era links
       if (context.era === 'rail') {
         const coalResult = consumeCoalFromSources(
@@ -2380,9 +2407,11 @@ export const gameStore = setup({
         if (!coalResult.success) {
           return false
         }
+        coalCost = coalResult.coalCost
       }
 
-      return true
+      // Brass has no debt: the player must be able to pay the full cost
+      return getCurrentPlayer(context).money >= linkCost + coalCost
     },
     canBuildLink: ({ context, event }) => {
       if (event.type !== 'SELECT_LINK' && event.type !== 'SELECT_SECOND_LINK') {
@@ -2403,6 +2432,16 @@ export const gameStore = setup({
       }
 
       const currentPlayer = getCurrentPlayer(context)
+
+      // Brass has no debt. Coal cost isn't known until a link is picked, so
+      // this only gates on the base cost; hasSelectedLink checks cost + coal.
+      const baseLinkCost =
+        context.era === 'canal'
+          ? GAME_CONSTANTS.CANAL_LINK_COST
+          : GAME_CONSTANTS.RAIL_LINK_COST
+      if (currentPlayer.money < baseLinkCost) {
+        return false
+      }
 
       // Exception: If player has no industries or links on board, can build anywhere
       const hasNoTilesOnBoard =
@@ -2609,8 +2648,15 @@ export const gameStore = setup({
     hasSelectedSecondLink: ({ context }) => context.selectedSecondLink !== null,
 
     hasSelectedTilesForDevelop: ({ context }) => {
+      const canAffordIron = (tileCount: number) =>
+        getCurrentPlayer(context).money >=
+        consumeIronFromSources(context, tileCount).ironCost
+
       // Allow confirmation if tiles are selected OR for backward compatibility
-      if (context.selectedTilesForDevelop.length > 0) return true
+      if (context.selectedTilesForDevelop.length > 0) {
+        // Brass has no debt: the iron for the selected tiles must be payable
+        return canAffordIron(context.selectedTilesForDevelop.length)
+      }
 
       // For backward compatibility, check if there are any developable tiles
       const currentPlayer = getCurrentPlayer(context)
@@ -2631,7 +2677,8 @@ export const gameStore = setup({
             (tile) => industryType !== 'pottery' || !tile.hasLightbulbIcon,
           )
         if (developableTiles.length > 0) {
-          return true
+          // The auto-select fallback develops exactly one tile
+          return canAffordIron(1)
         }
       }
       return false
@@ -2655,7 +2702,53 @@ export const gameStore = setup({
         // No merchant beer for Network actions
       )
 
-      return beerCheckResult.success
+      if (!beerCheckResult.success) {
+        return false
+      }
+
+      // Brass has no debt: £15 plus the coal for both links must be payable
+      const firstCoal = consumeCoalFromSources(
+        context,
+        context.selectedLink.from,
+        1,
+      )
+      if (!firstCoal.success) {
+        return false
+      }
+      // Mirror execution: the second link is on the board (and so part of the
+      // player's network) before its coal is sourced
+      const playerWithLinks = firstCoal.updatedPlayers[
+        context.currentPlayerIndex
+      ]!
+      const secondCoal = consumeCoalFromSources(
+        {
+          ...context,
+          players: updatePlayerInList(
+            firstCoal.updatedPlayers,
+            context.currentPlayerIndex,
+            {
+              ...playerWithLinks,
+              links: [
+                ...playerWithLinks.links,
+                { ...context.selectedLink, type: 'rail' as const },
+                { ...context.selectedSecondLink, type: 'rail' as const },
+              ],
+            },
+          ),
+          coalMarket: firstCoal.updatedCoalMarket,
+        },
+        context.selectedSecondLink.from,
+        1,
+      )
+      if (!secondCoal.success) {
+        return false
+      }
+
+      const totalCost =
+        GAME_CONSTANTS.RAIL_DOUBLE_LINK_COST +
+        firstCoal.coalCost +
+        secondCoal.coalCost
+      return getCurrentPlayer(context).money >= totalCost
     },
   },
 }).createMachine({


### PR DESCRIPTION
## The bug

The network (link-building) and develop actions **never validated affordability**: their guards ignored money entirely and the execute-actions subtracted the cost unconditionally. Brass has no debt, but a player with £2 could build a £3 canal link and land at **−£1** — observed in a live game.

Build already validates correctly (`money < totalCost` → "Insufficient funds", action not consumed), which is partly why this survived: the most common spend path *looks* like affordability is enforced, and every layer above (UI, multiplayer server, AI driver) gates on `can()`, so they all inherited the hole.

**Invariant now enforced: `player.money >= 0` at all times.** An action whose total cost exceeds the treasury is illegal and is refused before commit.

## The fix

Mirrors the Build pattern at two layers:

**Guards** — so `can()` rejects up front, and UI / multiplayer / AI driver all inherit it:
- `canBuildLink` — requires the base link cost (coal cost isn't known at selection time).
- `hasSelectedLink` — requires cost + coal, reusing the coal probe it already ran.
- `canCompleteDoubleLink` — requires £15 + both links' coal.
- `hasSelectedTilesForDevelop` — probes the iron cost for the selected tiles.

**Execute-actions** — defense in depth, since guard and execution can disagree here. They return the `lastError`/`errorContext` shape without consuming the action, never throwing inside `assign`.

## Tests

New `gameStore.money.test.ts` pins the invariant:
- Unaffordable canal link: `can(SELECT_LINK)` is false, and a forced attempt leaves money and the board untouched.
- **Boundary:** exactly £3 for a £3 link is still legal and ends at £0 (guards against over-blocking).
- Develop refused when market iron is unaffordable.
- **The guard-vs-execution seam:** £2 affords one develop tile of iron (£2, lands at £0) but not two (£4, refused).
- Build's existing validation, as the reference pattern.

Verified these fail against the unfixed engine and pass with the fix; the boundary and build cases pass both ways. The integration driver also asserts `money >= 0` after every event (violations are collected rather than thrown — a throw inside an XState subscriber does not propagate out of `send()`).

**Local check:** typecheck and lint clean; 283 engine tests pass. The two DB-backed suites (`gameStore.multiplayer`, `mp-ai`) couldn't run locally — no `DATABASE_URL`/`NEON_API_KEY` in this worktree — so they're left to CI's per-run Neon branch.

## Notes

- **The live game is unaffected and self-healing** — negative money is just a number to the engine (no crashes; turn-order and affordability comparisons behave sanely), and income at round end restores a positive treasury. No intervention needed; this change prevents recurrence.
- Adjacent issue found while testing, **not fixed here** (out of scope): rail-era market coal requires a network connection to a merchant through built links, but era-end wipes all links — so the first rail link of the era can be unbuildable for want of coal. This made a rail-era affordability seam test unreachable through the test event surface; the develop iron seam covers the same guard-vs-execution logic instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)