### PR TITLE
fix(mp): stop the SSE poll's per-tick full-row read (Neon egress leak)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,10 @@ when the pin changes.
 **Formatting:**
 - `pnpm format:write` - Format files with Prettier
 - `pnpm format:check` - Check formatting with Prettier
+- GOTCHA: the enforced style is **Biome** (single quotes, no semicolons; `pnpm lint`
+  is what CI runs). Prettier's config disagrees (double quotes, semicolons), so
+  `pnpm format:write` rewrites the WHOLE repo to a different style — do NOT run it.
+  Format touched files with `pnpm exec biome format --write <files>` instead.
 
 ## Architecture
 
@@ -412,7 +416,15 @@ When updating this file, preserve this bar for all agents and keep entries conci
   version-guarded path (`applyView` in `mp-game.tsx`). `kickAiTurns` returns
   its runner promise; the act/chat routes `waitUntil()` it (`@vercel/functions`)
   so a serverless instance isn't frozen out from under a multi-step AI turn,
-  and the stream poll re-kicks a stalled AI each tick. Do NOT add
+  and the stream poll re-kicks a stalled AI each tick. EGRESS (fixed
+  2026-07-16): the per-tick `kickAiTurns` must NOT read the full game row — it
+  used to `loadGame` (incl. the 28–65KB snapshot jsonb) on EVERY poll tick, even
+  for human-turn/finished/no-AI games, which burned ~4GB of Neon egress in ~2
+  days. It now gates on the cheap `loadAiPeek` (phase + seats + a jsonb-extracted
+  `currentPlayerIndex`, <1KB) via `isAiSeatTurn`, and only falls through to the
+  full `loadGame` in `runAiTurns` when it is genuinely an AI's turn (pinned by
+  `src/server/mp/egress.test.ts`, ~98% smaller per tick). The client also pauses
+  its EventSource after 60s hidden (`mp-game.tsx`). Do NOT add
   WebSockets/LISTEN-NOTIFY/an external pub-sub (decision doc §5). Wire tests:
   `gameStore.multiplayer.test.ts` (act/chat view shape + hidden-info + chat
   seq delivery / bounded tail / `getChatDelta`) + `e2e/multiplayer.spec.ts`

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -169,11 +169,37 @@ export function MpGame({ token }: { token: string }) {
   const [credsLoaded, setCredsLoaded] = useState(false)
   const [view, setView] = useState<GameViewWire | null>(null)
   const [streamFailing, setStreamFailing] = useState(false)
+  // The SSE stream drives a ~1.2s server-side DB poll for its whole lifetime.
+  // A tab left open on a dormant game therefore keeps polling Neon forever —
+  // the bulk of the egress leak. Close the stream once the tab has been hidden
+  // for a grace period and reopen it when the tab is shown again; the first
+  // frame on reopen is the full current view, so nothing is missed.
+  const [streamPaused, setStreamPaused] = useState(false)
 
   useEffect(() => {
     setCreds(loadCreds(token))
     setCredsLoaded(true)
   }, [token])
+
+  // Pause the live stream on a persistently hidden tab (60s grace, so a quick
+  // tab switch doesn't churn the connection). Resume immediately on show.
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    let hideTimer: ReturnType<typeof setTimeout> | undefined
+    const onVisibility = () => {
+      if (document.hidden) {
+        hideTimer = setTimeout(() => setStreamPaused(true), 60_000)
+      } else {
+        if (hideTimer) clearTimeout(hideTimer)
+        setStreamPaused(false)
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibility)
+    return () => {
+      if (hideTimer) clearTimeout(hideTimer)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [])
 
   // Single apply path for every authoritative full view — SSE `data:` frames
   // AND the fresh view returned by an act/chat POST. The engine snapshot is
@@ -213,6 +239,8 @@ export function MpGame({ token }: { token: string }) {
   // stream must never wipe freshly-claimed credentials.
   useEffect(() => {
     if (!credsLoaded) return
+    // Hidden-tab pause: hold the connection closed until the tab is shown.
+    if (streamPaused) return
     const myCreds = creds
     const qs = new URLSearchParams({ token })
     if (myCreds) {
@@ -250,7 +278,7 @@ export function MpGame({ token }: { token: string }) {
       closed = true
       es.close()
     }
-  }, [token, creds, credsLoaded, applyView, applyChatDelta])
+  }, [token, creds, credsLoaded, streamPaused, applyView, applyChatDelta])
 
   if (!credsLoaded || (!view && !streamFailing)) {
     return (

--- a/src/server/mp/egress.test.ts
+++ b/src/server/mp/egress.test.ts
@@ -1,0 +1,144 @@
+// Neon-egress regression: the SSE poll re-kicks the AI turn-runner every
+// ~1.2s per open tab. It MUST decide "is it an AI seat's turn?" from a cheap
+// peek (phase + seats + currentPlayerIndex) and only read the full game row
+// (with its 28–65KB snapshot jsonb) when it genuinely is an AI's turn.
+// Before the fix, every idle tick — human-turn, finished, or no-AI games —
+// read and discarded the whole snapshot, burning ~4GB of egress in ~2 days.
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import { ensureTestSchema } from '../../test/db-schema'
+import { isAiSeatTurn, kickAiTurns } from './game'
+import { type AiPeek, type SeatRecord } from './store'
+
+/* ---------------- pure decision (no DB) ---------------- */
+
+const human = (seatId: number): SeatRecord => ({
+  seatId,
+  name: `P${seatId}`,
+  color: 'red',
+  character: 'Eliza Tinsley',
+  claimed: true,
+  secretHash: 'x',
+  kind: 'human',
+})
+
+const ai = (seatId: number): SeatRecord => ({
+  seatId,
+  name: 'The Apprentice',
+  color: 'blue',
+  character: 'George Stephenson',
+  claimed: true,
+  secretHash: null,
+  kind: 'ai',
+  aiTier: 'apprentice',
+})
+
+const peek = (over: Partial<AiPeek>): AiPeek => ({
+  phase: 'playing',
+  version: 1,
+  seats: [human(0), ai(1)],
+  currentPlayerIndex: 1,
+  ...over,
+})
+
+describe('isAiSeatTurn — the cheap-path decision', () => {
+  test('true only when a seated AI is the current player', () => {
+    expect(isAiSeatTurn(peek({ currentPlayerIndex: 1 }))).toBe(true)
+  })
+
+  test('false on a human turn (do not read the full row)', () => {
+    expect(isAiSeatTurn(peek({ currentPlayerIndex: 0 }))).toBe(false)
+  })
+
+  test('false for a game with zero AI seats', () => {
+    expect(
+      isAiSeatTurn(
+        peek({ seats: [human(0), human(1)], currentPlayerIndex: 0 }),
+      ),
+    ).toBe(false)
+  })
+
+  test('false when the game is finished', () => {
+    expect(isAiSeatTurn(peek({ phase: 'over' }))).toBe(false)
+  })
+
+  test('false in the lobby / before a snapshot exists', () => {
+    expect(
+      isAiSeatTurn(peek({ phase: 'lobby', currentPlayerIndex: null })),
+    ).toBe(false)
+  })
+
+  test('false when the peek is missing or the index is out of range', () => {
+    expect(isAiSeatTurn(null)).toBe(false)
+    expect(isAiSeatTurn(peek({ currentPlayerIndex: 5 }))).toBe(false)
+  })
+})
+
+/* ---------------- empirical egress (DB-backed) ---------------- */
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
+
+beforeAll(async () => {
+  process.env.BB_AI_MOCK = '1'
+  await ensureTestSchema()
+})
+
+afterAll(() => {
+  delete process.env.BB_AI_MOCK
+})
+
+describe('poll-tick egress', () => {
+  test('loadAiPeek omits the snapshot and is far smaller than the full row', async () => {
+    const { createGame } = await import('./game')
+    const store = await import('./store')
+    const host = await createGame('Ada', 2, ['apprentice'])
+
+    const peekRow = await store.loadAiPeek(host.token)
+    const full = await store.loadGame(host.token)
+    expect(peekRow).not.toBeNull()
+    expect(full).not.toBeNull()
+
+    // The peek carries phase + seats + the current index, and NOTHING else
+    // (no snapshot jsonb — that is the whole point).
+    expect(peekRow!.phase).toBe('playing')
+    expect(peekRow!.seats.length).toBe(2)
+    expect(peekRow!.currentPlayerIndex).toBe(
+      (full!.snapshot as { context: { currentPlayerIndex: number } }).context
+        .currentPlayerIndex,
+    )
+    expect(peekRow as unknown as { snapshot?: unknown }).not.toHaveProperty(
+      'snapshot',
+    )
+
+    // Empirical wire cost: the full row is dominated by the snapshot; the peek
+    // is a fraction of it. (neon-http ships jsonb as JSON text, so the
+    // stringified size is the wire size.)
+    const peekBytes = JSON.stringify(peekRow).length
+    const fullBytes = JSON.stringify(full).length
+    expect(peekBytes).toBeLessThan(2_000)
+    expect(fullBytes).toBeGreaterThan(peekBytes * 4)
+    console.log(
+      `[egress] per-tick full-load=${fullBytes}B  cheap-peek=${peekBytes}B  ` +
+        `saved=${(100 * (1 - peekBytes / fullBytes)).toFixed(1)}%`,
+    )
+  })
+
+  test('kicking a no-AI game never reads the full game row', async () => {
+    const store = await import('./store')
+    const { createGame, joinGame } = await import('./game')
+    // A 2-human game with both seats claimed → actively playing, human's turn.
+    const host = await createGame('Ada', 2, [])
+    await joinGame(host.token, 'Bea')
+    // Let the creation/join kicks settle so the aiRunning dedup is clear.
+    await new Promise((r) => setTimeout(r, 200))
+
+    const loadGameSpy = vi.spyOn(store, 'loadGame')
+    const loadAiPeekSpy = vi.spyOn(store, 'loadAiPeek')
+    await kickAiTurns(host.token)
+
+    // The cheap peek decided "not an AI's turn" — the full row was never read.
+    expect(loadAiPeekSpy).toHaveBeenCalled()
+    expect(loadGameSpy).not.toHaveBeenCalled()
+    loadGameSpy.mockRestore()
+    loadAiPeekSpy.mockRestore()
+  })
+})

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -26,10 +26,12 @@ import {
   isAiTierId,
 } from '../ai/types'
 import {
+  type AiPeek,
   type ChatMessage,
   type GameRecord,
   type SeatRecord,
   appendChatMessage,
+  loadAiPeek,
   loadChatSince,
   loadGame,
   loadRecentChat,
@@ -609,19 +611,39 @@ export async function getChatDelta(
 /* ---------------- the AI turn runner ---------------- */
 
 /**
+ * Decide, from the CHEAP peek (no snapshot jsonb), whether the AI turn-runner
+ * should even start: only when the game is actively playing, has an AI seat,
+ * and the current player is that AI seat. A human-turn, lobby, finished, or
+ * all-human game returns false — so the caller never pays the full-row read.
+ */
+export function isAiSeatTurn(peek: AiPeek | null): boolean {
+  if (!peek) return false
+  if (peek.phase !== 'playing') return false
+  if (peek.currentPlayerIndex === null) return false
+  if (!peek.seats.some((s) => s.kind === 'ai')) return false
+  const seat = peek.seats[peek.currentPlayerIndex]
+  return !!seat && seat.kind === 'ai' && !!seat.aiTier
+}
+
+/**
  * Start the AI turn-runner for this game unless one is already in flight, and
  * return the promise that settles when the current run finishes. Safe to call
  * from anywhere (create/join/act/stream-connect) — it no-ops instantly when
  * the current player is human or the game is over. Callers on a serverless
  * request path should `waitUntil(kickAiTurns(token))` so the instance isn't
  * frozen out from under the (detached) runner after the response returns.
+ *
+ * EGRESS: the poll (`stream/route.ts`) re-kicks every ~1.2s per open tab. The
+ * gate below is a CHEAP peek (`loadAiPeek`, <1KB) — the full-row `loadGame`
+ * inside `runAiTurns` (28–65KB) is paid ONLY when it is genuinely an AI's
+ * turn. Before this, every idle tick read the whole snapshot and discarded it.
  */
 export function kickAiTurns(token: string): Promise<void> {
   const existing = aiPromise.get(token)
   if (existing) return existing
   if (aiRunning.has(token)) return Promise.resolve()
   aiRunning.add(token)
-  const p = runAiTurns(token)
+  const p = maybeRunAiTurns(token)
     .catch(() => {
       // the runner never propagates — a failed decision is logged in-game
     })
@@ -632,6 +654,13 @@ export function kickAiTurns(token: string): Promise<void> {
     })
   aiPromise.set(token, p)
   return p
+}
+
+/** Cheap gate → full runner. Reads only the peek unless it's an AI's turn. */
+async function maybeRunAiTurns(token: string): Promise<void> {
+  const peek = await loadAiPeek(token)
+  if (!isAiSeatTurn(peek)) return
+  await runAiTurns(token)
 }
 
 /** Model calls per AI turn before the driver goes safety-first (cost cap). */

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -138,6 +138,50 @@ export async function loadVersionAndSeq(
   return { version: row.version, maxSeq: Number(row.maxSeq) }
 }
 
+/** The cheap "is it an AI seat's turn?" peek: phase + version + seats + the
+ *  current player index, WITHOUT the 28–65KB `snapshot` jsonb. The SSE poll
+ *  re-kicks the AI turn-runner every ~1.2s per open tab; before this it read
+ *  the whole game row (incl. snapshot) on every tick even for human-turn,
+ *  finished, or no-AI games — the bulk of the Neon egress leak. Here we pull
+ *  only `snapshot#>>'{context,currentPlayerIndex}'` as a scalar and the small
+ *  `seats` array, so a poll tick on an idle game costs <1KB instead of tens of
+ *  KB. The full `loadGame` (snapshot included) is paid ONLY once it is
+ *  genuinely an AI's turn. Returns null for an unknown/malformed token. */
+export interface AiPeek {
+  phase: GameRecord['phase']
+  version: number
+  seats: SeatRecord[]
+  /** null in the lobby (no snapshot yet) */
+  currentPlayerIndex: number | null
+}
+
+export async function loadAiPeek(token: string): Promise<AiPeek | null> {
+  if (!TOKEN_RE.test(token)) return null
+  const rows = await db
+    .select({
+      phase: games.phase,
+      version: games.version,
+      seats: games.seats,
+      // Extract the scalar from the jsonb server-side so the (large) snapshot
+      // never crosses the wire. `#>>` on a NULL snapshot (lobby) yields NULL.
+      currentPlayerIndex: sql<
+        number | null
+      >`(${games.snapshot} #>> '{context,currentPlayerIndex}')::int`,
+    })
+    .from(games)
+    .where(eq(games.token, token))
+    .limit(1)
+  const row = rows[0]
+  if (!row) return null
+  return {
+    phase: row.phase,
+    version: row.version,
+    seats: row.seats,
+    currentPlayerIndex:
+      row.currentPlayerIndex === null ? null : Number(row.currentPlayerIndex),
+  }
+}
+
 /* ---------------- chat (normalized out of the game row) ---------------- */
 
 const CHAT_SEQ_RETRIES = 6


### PR DESCRIPTION
## Problem

Diagnosis `brass-neon-egress-f1` traced ~4 GB of Neon egress (80% of the 5 GB free allowance, in ~2 days) to the SSE stream's server-side DB poll. Every open `/g/<token>` tab makes the stream poll Neon every ~1.2 s, and **each tick called `kickAiTurns` → `runAiTurns`, which opened with `loadGame` — a full `SELECT *` including the 28–65 KB `snapshot` jsonb**. That full row crossed the wire on every tick even for human-turn, finished, and no-AI games, then got discarded. The intended design was a *cheap version check* per tick; the AI re-kick betrayed it.

## Fix

1. **Cheap gate on the AI re-kick** (~98% of the problem). New `loadAiPeek` (`store.ts`) reads only `phase` + `seats` + a jsonb-extracted `currentPlayerIndex` (`snapshot#>>'{context,currentPlayerIndex}'` as a scalar) — the snapshot never crosses the wire. `kickAiTurns` now gates on the pure `isAiSeatTurn` predicate and only falls through to the full `loadGame` in `runAiTurns` when it is **genuinely an AI's turn**. Zero AI seats or a finished game → decided from the cheap read, no full load.
2. **Pause the client EventSource on hidden tabs** (`mp-game.tsx`): close the stream after 60 s hidden, reopen on show (the first frame on reopen is the full current view, so nothing is missed). Kills the left-open-overnight tail.
3. **No behavior change for AI games**: the `aiRunning` dedup is unchanged; real AI turns still fire promptly (proven by the existing `mp-ai.test.ts` end-to-end AI-turn test).

## Egress: before → after (per poll tick, empirically measured)

| | before | after |
|---|---:|---:|
| `kickAiTurns` peek | **26,715 B** (full row incl. snapshot) | **399 B** (`loadAiPeek`) |
| `loadVersionAndSeq` | ~0.3 KB | ~0.3 KB |
| **per-tick total** | **~27 KB** | **~0.7 KB** |

**98.5% reduction** on the AI peek (logged by the egress test: `full-load=26715B cheap-peek=399B saved=98.5%`). At the same usage, month-scale egress drops from ~4 GB toward ~60 MB — the 5 GB allowance becomes effectively unreachable.

## Tests

New `src/server/mp/egress.test.ts`:
- **Pure decision matrix** (no DB): `isAiSeatTurn` is true only when a seated AI is the current player; false for human-turn, no-AI, finished, lobby, and out-of-range/missing.
- **Empirical (DB-backed)**: `loadAiPeek` omits the snapshot, matches the full game's `currentPlayerIndex`, and is >4× smaller than the full row (logs the byte counts).
- **No full load on a no-AI game**: spies confirm a kick reads `loadAiPeek` but never `loadGame`.

Positive path (gate lets a real AI turn through) is covered by the existing `mp-ai.test.ts` "after the human acts, the AI takes its whole turn on its own" — passing.

Verified locally: `egress.test.ts`, `mp-ai.test.ts`, `gameStore.multiplayer.test.ts` all green; `pnpm typecheck` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)