### PR TITLE
test(develop): un-skip pottery lightbulb regression test; extract isDevelopable helper

### DIFF
--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -11,6 +11,7 @@ import {
   type GameStoreSnapshot,
   type Player,
 } from '~/store/gameStore'
+import { isDevelopable } from '~/store/shared/gameUtils'
 import { CardChip } from './cards'
 import {
   BuildIcon,
@@ -125,14 +126,12 @@ function DevelopTilePicker({
   const developable = INDUSTRY_TYPES.filter((t) => {
     const tiles = currentPlayer.industryTilesOnMat[t] || []
     return tiles.some(
-      (tw) =>
-        tw.quantityAvailable > 0 &&
-        !(t === 'pottery' && tw.tile.hasLightbulbIcon),
+      (tw) => tw.quantityAvailable > 0 && isDevelopable(tw.tile),
     )
   })
   const available = (t: IndustryType) =>
     (currentPlayer.industryTilesOnMat[t] || [])
-      .filter((tw) => !(t === 'pottery' && tw.tile.hasLightbulbIcon))
+      .filter((tw) => isDevelopable(tw.tile))
       .reduce((n, tw) => n + tw.quantityAvailable, 0)
   const total = Object.values(counts).reduce((a, b) => a + (b ?? 0), 0)
   const selection = developable.flatMap((t) =>

--- a/src/store/gameStore.develop.test.ts
+++ b/src/store/gameStore.develop.test.ts
@@ -390,89 +390,21 @@ describe('Game Store - Develop Actions', () => {
     // Test skipped - needs proper tile management implementation
   })
 
-  test.skip('develop action - pottery with lightbulb icon cannot be developed', () => {
-    // SKIPPED: TEST_SET_PLAYER_STATE doesn't support industryTilesOnMat property
+  test('develop action - pottery with lightbulb icon cannot be developed', () => {
+    // A fresh game already seeds every player with the full pottery set
+    // (pottery_1..5, with levels 1 and 3 flagged hasLightbulbIcon), so no
+    // special TEST_SET_PLAYER_STATE plumbing is needed.
     const { actor } = setupGame()
 
-    // Set up player with pottery tile that has lightbulb icon
-    actor.send({
-      type: 'TEST_SET_PLAYER_STATE',
-      playerId: 0,
-      money: 50,
-    })
+    const potteryQuantity = (level: number) =>
+      actor
+        .getSnapshot()
+        .context.players[0]!.industryTilesOnMat.pottery.find(
+          (t) => t.tile.level === level,
+        )!.quantityAvailable
 
-    // TODO: Implement proper tile management for testing
-    /*
-    industryTilesOnMat: {
-        pottery: [
-          {
-            id: 'pottery_1',
-            type: 'pottery',
-            level: 1,
-            cost: 5,
-            victoryPoints: 1,
-            incomeSpaces: 1,
-            linkScoringIcons: 1,
-            coalRequired: 1,
-            ironRequired: 0,
-            beerRequired: 1,
-            beerProduced: 0,
-            coalProduced: 0,
-            ironProduced: 0,
-            canBuildInCanalEra: true,
-            canBuildInRailEra: true,
-            hasLightbulbIcon: true, // Cannot be developed!
-            incomeAdvancement: 2,
-          },
-          {
-            id: 'pottery_2',
-            type: 'pottery',
-            level: 2,
-            cost: 7,
-            victoryPoints: 2,
-            incomeSpaces: 1,
-            linkScoringIcons: 1,
-            coalRequired: 1,
-            ironRequired: 0,
-            beerRequired: 1,
-            beerProduced: 0,
-            coalProduced: 0,
-            ironProduced: 0,
-            canBuildInCanalEra: true,
-            canBuildInRailEra: true,
-            hasLightbulbIcon: false,
-            incomeAdvancement: 2,
-          },
-        ],
-        coal: [
-          {
-            id: 'coal_1',
-            type: 'coal',
-            level: 1,
-            cost: 5,
-            victoryPoints: 1,
-            incomeSpaces: 1,
-            linkScoringIcons: 1,
-            coalRequired: 0,
-            ironRequired: 0,
-            beerRequired: 0,
-            beerProduced: 0,
-            coalProduced: 2,
-            ironProduced: 0,
-            canBuildInCanalEra: true,
-            canBuildInRailEra: false,
-            hasLightbulbIcon: false,
-            incomeAdvancement: 2,
-          },
-        ],
-      },
-    })
-
-    let snapshot = actor.getSnapshot()
-    const initialPotteryTiles =
-      snapshot.context.players[0]!.industryTilesOnMat.pottery.length
-    const initialCoalTiles =
-      snapshot.context.players[0]!.industryTilesOnMat.coal.length
+    expect(potteryQuantity(1)).toBe(1)
+    expect(potteryQuantity(3)).toBe(1)
 
     // Perform develop action
     actor.send({ type: 'DEVELOP' })
@@ -481,28 +413,23 @@ describe('Game Store - Develop Actions', () => {
     const card = actor.getSnapshot().context.players[0]!.hand[0]!
     actor.send({ type: 'SELECT_CARD', cardId: card.id })
 
-    // Try to develop pottery with lightbulb - should be blocked or skip to other tiles
-    actor.send({ type: 'CONFIRM' }) // Move to confirmingDevelop state
-    actor.send({ type: 'CONFIRM' }) // Actually execute the develop action
-    snapshot = actor.getSnapshot()
+    // Deliberately try to develop two pottery tiles - if unguarded, this
+    // would hit the lowest-level tile (pottery_1) first.
+    actor.send({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['pottery', 'pottery'],
+    })
+    actor.send({ type: 'CONFIRM' })
 
-    const finalPotteryTiles =
-      snapshot.context.players[0]!.industryTilesOnMat.pottery.length
-    const finalCoalTiles =
-      snapshot.context.players[0]!.industryTilesOnMat.coal.length
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
 
-    // If pottery tile was removed, it should NOT be the one with lightbulb
-    if (finalPotteryTiles < initialPotteryTiles) {
-      const removedPotteryTiles =
-        snapshot.context.players[0]!.industryTilesOnMat.pottery
-      // Lightbulb pottery should still be present
-      expect(
-        removedPotteryTiles.some((tile) => tile.hasLightbulbIcon === true),
-      ).toBe(true)
-    }
-
-    */
-    // Test skipped - needs proper tile management implementation
+    // Lightbulb tiles (levels 1 and 3) must remain untouched; the engine
+    // must skip past them to the next non-lightbulb tiles instead.
+    expect(potteryQuantity(1)).toBe(1)
+    expect(potteryQuantity(3)).toBe(1)
+    expect(potteryQuantity(2)).toBe(0)
+    expect(potteryQuantity(4)).toBe(0)
   })
 
   test('develop action - can develop 1 or 2 tiles consuming 1 iron each', () => {

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -62,6 +62,7 @@ import {
   getCardDescription,
   getCurrentPlayer,
   incomeAfterFlip,
+  isDevelopable,
   isFirstRound,
   isLocationInPlayerNetwork,
   removeCardFromHand,
@@ -1349,9 +1350,7 @@ export const gameStore = setup({
           const developableTiles = tilesWithQuantity
             .filter((t) => t.quantityAvailable > 0)
             .map((t) => t.tile)
-            .filter(
-              (tile) => industryType !== 'pottery' || !tile.hasLightbulbIcon,
-            )
+            .filter(isDevelopable)
           if (developableTiles.length > 0) {
             availableTypes.push(industryType)
           }
@@ -1396,9 +1395,7 @@ export const gameStore = setup({
         const developableTiles = tilesWithQuantity
           .filter((t) => t.quantityAvailable > 0)
           .map((t) => t.tile)
-          .filter(
-            (tile) => industryType !== 'pottery' || !tile.hasLightbulbIcon,
-          )
+          .filter(isDevelopable)
 
         if (developableTiles.length > 0) {
           // Decrement quantity of the lowest level tile
@@ -1568,7 +1565,7 @@ export const gameStore = setup({
                 const tile = tileWithQty.tile
 
                 // Skip pottery tiles with lightbulb icon
-                if (tile.type === 'pottery' && tile.hasLightbulbIcon) {
+                if (!isDevelopable(tile)) {
                   continue
                 }
 
@@ -1587,9 +1584,7 @@ export const gameStore = setup({
                 .filter((t) => t.quantityAvailable > 0)
                 .map((t) => t.tile)
                 .find(
-                  (t) =>
-                    t.level === lowestLevel &&
-                    !(t.type === 'pottery' && t.hasLightbulbIcon),
+                  (t) => t.level === lowestLevel && isDevelopable(t),
                 )
 
               if (tileToRemove) {
@@ -2076,9 +2071,7 @@ export const gameStore = setup({
         const developableTiles = tilesWithQuantity
           .filter((t) => t.quantityAvailable > 0)
           .map((t) => t.tile)
-          .filter(
-            (tile) => industryType !== 'pottery' || !tile.hasLightbulbIcon,
-          )
+          .filter(isDevelopable)
 
         if (developableTiles.length > 0) {
           validTiles.push(industryType)
@@ -2753,9 +2746,7 @@ export const gameStore = setup({
         const developableTiles = tilesWithQuantity
           .filter((t) => t.quantityAvailable > 0)
           .map((t) => t.tile)
-          .filter(
-            (tile) => industryType !== 'pottery' || !tile.hasLightbulbIcon,
-          )
+          .filter(isDevelopable)
         if (developableTiles.length > 0) {
           // The auto-select fallback develops exactly one tile
           return canAffordIron(1)

--- a/src/store/shared/gameUtils.ts
+++ b/src/store/shared/gameUtils.ts
@@ -15,6 +15,16 @@ import {
   advanceIncomeSpaces,
   incomeLevelForSpace,
 } from '../../data/incomeTrack'
+import type { IndustryTile } from '../../data/industryTiles'
+
+/**
+ * Pottery tiles showing the lightbulb icon (levels 1 and 3) can only be
+ * removed from a Player Mat via Build, never via Develop (rulebook p.7,
+ * "Potteries and the Lightbulb Icon").
+ */
+export function isDevelopable(tile: Pick<IndustryTile, 'type' | 'hasLightbulbIcon'>): boolean {
+  return tile.type !== 'pottery' || !tile.hasLightbulbIcon
+}
 
 /**
  * Marker movement for a FLIPPED tile: advance by the tile's printed


### PR DESCRIPTION
## Summary
- Un-skips `gameStore.develop.test.ts:393` (pottery lightbulb Develop test) — a fresh game already seeds the full pottery set, so no `TEST_SET_PLAYER_STATE` plumbing was needed. Drives `DEVELOP` → `SELECT_CARD` → `SELECT_TILES_FOR_DEVELOP` → `CONFIRM` and asserts the lightbulb tiles (pottery levels 1 & 3) are never removed.
- Extracts the duplicated `industryType !== 'pottery' || !tile.hasLightbulbIcon` check into a single `isDevelopable(tile)` helper (`src/store/shared/gameUtils.ts`), used at all 6+ call sites in `gameStore.ts` and `action-dock.tsx`. Pure refactor, no behavior change.

Per scout finding in `report.md` §6 — this hardens the already-correct pottery Develop rule against future regression.

## Test plan
- [x] `pnpm vitest run src/store/gameStore.develop.test.ts` — new test passes
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 299 passed, 3 skipped (2 pre-existing DB-backed suite failures unrelated to this change, need live DATABASE_URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected development tile selection so pottery tiles with the lightbulb icon are not treated as developable.
  * Updated development actions, merchant bonuses, and tile eligibility checks to consistently apply the correct rules.
  * Confirmed valid pottery tiles can still be developed without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->