### PR TITLE
feat(mp): a refused move says exactly what is missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,25 @@ When updating this file, preserve this bar for all agents and keep entries conci
   server validates seat + turn + an event whitelist (never TEST_*/TRIGGER_*),
   executes on the real engine, persists, broadcasts. The client's local
   actor is READ-ONLY (rebuilt per SSE broadcast just for matches/can).
+  `actInGame` owns only the I/O — the whitelist/turn/guard/execute DECISION
+  lives in `mp/intent.ts` (`applyIntent`), which imports no DB and is
+  therefore tested offline (`intent.test.ts`) while the rest of the mp suite
+  needs Neon. `game.ts` imports `rehydrate` from there; don't re-fork it.
+- REFUSALS NAME WHAT IS MISSING (2026-07-16, captain's requirement): a
+  refused intent answers with the exact reason ("Not enough money: you have
+  £2, a canal link costs £3.", "Needs 1 beer — no connected brewery has
+  beer."), never a generic failure. Two paths, both in `applyIntent`: a
+  guard rejection (`can()` false) is explained by `src/store/refusal.ts`
+  (`explainRefusal`), which re-derives the cause by calling the SAME
+  validators the guards call (`validateSale`, `consumeCoalFromSources`,
+  `GAME_CONSTANTS` costs) — NEVER re-implement a rule there, and return null
+  to fall back to the generic string rather than guess; an execution failure
+  reports `context.lastError` verbatim. A refusal is NEVER persisted, so the
+  reason reaches only the acting player's POST response (`filterSnapshotForSeat`
+  also nulls `lastError` for foreign seats as defence in depth). The client
+  renders it via `mp/refusal.ts` (`refusalToShow`, pure — pinned without a
+  DOM, like `turnNotify.ts`). If a guard starts refusing something new, teach
+  `explainRefusal` about it in the same commit.
 - HIDDEN INFO IS FILTERED SERVER-SIDE in `filterSnapshotForSeat`: foreign
   hands, the draw pile, and foreign in-flight selections become `hidden-*`
   placeholders (lengths preserved — guards need counts). Wire-level tests:

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "typecheck": "tsc --noEmit",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
-    "test": "vitest run src/store/gameStore.*.test.ts src/data/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts",
-    "test:watch": "vitest src/store/gameStore.*.test.ts src/data/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts",
+    "test": "vitest run src/store/gameStore.*.test.ts src/data/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/mp/*.test.ts",
+    "test:watch": "vitest src/store/gameStore.*.test.ts src/data/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/mp/*.test.ts",
     "test:all": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -18,6 +18,7 @@ import {
   type Player,
   gameStore,
 } from '~/store/gameStore'
+import { explainRefusal } from '~/store/refusal'
 import { refreshEmbeddedTileStats } from '~/store/saveMigration'
 import { ActionDock, SELLABLE, getHandSelection } from '../action-dock'
 import { linkKey } from '../board/board-data'
@@ -1036,18 +1037,27 @@ function MpTable({
       )
       return
     }
+    // The client gates the click itself, so the server's refusal reason would
+    // never be reached for an illegal route. Ask the SAME explainer the server
+    // uses — everything it needs (money, links, era) is public state already
+    // in this frame — so the player is told what is missing either way.
     if (pickingSecondLink) {
-      if (state.can({ type: 'SELECT_SECOND_LINK', from, to })) {
-        send({ type: 'SELECT_SECOND_LINK', from, to })
-      } else {
-        toast.error('That route cannot be your second rail.')
+      const event = { type: 'SELECT_SECOND_LINK', from, to } as const
+      if (state.can(event)) send(event)
+      else {
+        toast.error(
+          explainRefusal(ctx, event) ??
+            'That route cannot be your second rail.',
+        )
       }
       return
     }
-    if (state.can({ type: 'SELECT_LINK', from, to })) {
-      send({ type: 'SELECT_LINK', from, to })
-    } else {
-      toast.error('That route cannot be claimed right now.')
+    const event = { type: 'SELECT_LINK', from, to } as const
+    if (state.can(event)) send(event)
+    else {
+      toast.error(
+        explainRefusal(ctx, event) ?? 'That route cannot be claimed right now.',
+      )
     }
   }
 

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -28,6 +28,7 @@ import { GameOverScreen } from '../overlays'
 import { PlayerLedger } from '../player-ledger'
 import { PlayerRail } from '../player-rail'
 import { CollapsiblePanel, JournalPanel, MarketsPanel } from '../side-panels'
+import { UNREACHABLE, refusalToShow } from './refusal'
 import { didBecomeMyTurn, playTurnChime, titleForTurn } from './turnNotify'
 import { useInFlight } from './use-in-flight'
 
@@ -780,12 +781,12 @@ function MpTable({
             version?: number
           }
           if (!body.ok) {
-            // The server rejected the intent — no frame is coming, so settle
-            // now; the existing error toast still surfaces the reason.
+            // The server refused the intent — no frame is coming, so settle
+            // now and show the server's EXACT reason (what is missing: the
+            // money, the beer, the connection, whose turn it is).
             settle()
-            if (body.error && event.type !== 'CLEAR_ERROR') {
-              toast.error(body.error)
-            }
+            const refusal = refusalToShow(body, event.type)
+            if (refusal) toast.error(refusal)
           } else if (body.view) {
             // Server-authoritative fast path: apply the engine's OWN fresh view
             // from the POST response (same version-guarded apply path as an SSE
@@ -798,7 +799,7 @@ function MpTable({
           // pending: the resulting SSE frame settles it via the version bump.
         } catch {
           settle()
-          toast.error('Could not reach the game server')
+          toast.error(UNREACHABLE)
         }
       })()
     },

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -1046,7 +1046,7 @@ function MpTable({
       if (state.can(event)) send(event)
       else {
         toast.error(
-          explainRefusal(ctx, event) ??
+          explainRefusal(state, event) ??
             'That route cannot be your second rail.',
         )
       }
@@ -1056,7 +1056,8 @@ function MpTable({
     if (state.can(event)) send(event)
     else {
       toast.error(
-        explainRefusal(ctx, event) ?? 'That route cannot be claimed right now.',
+        explainRefusal(state, event) ??
+          'That route cannot be claimed right now.',
       )
     }
   }

--- a/src/components/mp/refusal.test.ts
+++ b/src/components/mp/refusal.test.ts
@@ -1,0 +1,37 @@
+// Pins what the acting client puts on screen when the server refuses a move.
+// The reason must reach the player verbatim — a refusal that says only "that
+// failed" is the bug this plumbing exists to fix (captain, 2026-07-16).
+import { describe, expect, it } from 'vitest'
+import { FALLBACK_REFUSAL, refusalToShow } from './refusal'
+
+describe('refusalToShow', () => {
+  it('renders the server reason verbatim, whatever is missing', () => {
+    // The four refusal classes the server is required to explain.
+    const reasons = [
+      'Not enough money: you have £2, a canal link costs £3.',
+      'Needs 1 beer — no connected brewery has beer.',
+      'No canal connection to wolverhampton: neither walsall nor wolverhampton is in your network.',
+      'Not your turn — waiting on Ada.',
+    ]
+    for (const error of reasons) {
+      expect(refusalToShow({ ok: false, error }, 'SELECT_LINK')).toBe(error)
+    }
+  })
+
+  it('shows nothing when the move was accepted', () => {
+    expect(refusalToShow({ ok: true }, 'SELECT_LINK')).toBeNull()
+  })
+
+  it('falls back when the server refuses without a reason', () => {
+    expect(refusalToShow({ ok: false }, 'BUILD')).toBe(FALLBACK_REFUSAL)
+    expect(refusalToShow({ ok: false, error: '   ' }, 'BUILD')).toBe(
+      FALLBACK_REFUSAL,
+    )
+  })
+
+  it('stays silent about CLEAR_ERROR, which the player never asked for', () => {
+    expect(
+      refusalToShow({ ok: false, error: 'boom' }, 'CLEAR_ERROR'),
+    ).toBeNull()
+  })
+})

--- a/src/components/mp/refusal.ts
+++ b/src/components/mp/refusal.ts
@@ -1,0 +1,39 @@
+// What the acting client shows when an intent comes back refused.
+//
+// The server answers every rejected intent with the EXACT reason (see
+// src/server/mp/intent.ts) — "Not enough money: you have £2, a canal link
+// costs £3." rather than a generic failure. This module decides what to put
+// on screen for a given response, kept pure so it can be pinned without a DOM
+// (same shape as turnNotify.ts).
+//
+// Only the acting player ever sees a refusal: a refusal is the POST's own
+// response body, never persisted and never broadcast, so it cannot reach
+// another seat's frame.
+
+/** The `/api/mp/act` response, as far as surfacing a refusal cares. */
+export interface ActResponse {
+  ok: boolean
+  error?: string
+}
+
+/** Shown when the server refused but gave no reason (older server, or a
+ *  refusal path that has not been taught to explain itself). */
+export const FALLBACK_REFUSAL = 'That action was refused.'
+
+/** Shown when the POST itself never landed — distinct from a refusal. */
+export const UNREACHABLE = 'Could not reach the game server'
+
+/**
+ * The refusal message to surface for `response`, or null to show nothing.
+ *
+ * `eventType` is needed because CLEAR_ERROR is bookkeeping the player never
+ * asked for — toasting its refusal would be noise about a move they made.
+ */
+export function refusalToShow(
+  response: ActResponse,
+  eventType: string,
+): string | null {
+  if (response.ok) return null
+  if (eventType === 'CLEAR_ERROR') return null
+  return response.error?.trim() ? response.error : FALLBACK_REFUSAL
+}

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -9,8 +9,8 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { createActor } from 'xstate'
 import { gameStore } from '../../store/gameStore'
-import { refreshEmbeddedTileStats } from '../../store/saveMigration'
 import { STEP_SAFETY_BUDGET, aiDecideAndApply } from '../ai/driver'
+import { applyIntent, rehydrate } from './intent'
 import {
   gatewayBaseUrl,
   hasAnthropicKey,
@@ -116,32 +116,6 @@ async function withGameLock<T>(
 
 /* ---------------- engine helpers ---------------- */
 
-// JSON round-trips turn the markets' `maxCubes: Infinity` into null; restore
-// it before the engine sees the snapshot (same fix as the client shell).
-// ALSO run the save migration here: the SERVER is the authority, and a
-// pre-audit game record would otherwise keep playing with stale tile stats
-// and no incomeSpace (whose NaN arithmetic reads as income level 30).
-function rehydrate(snapshot: unknown): unknown {
-  const clone = structuredClone(snapshot) as {
-    context?: {
-      coalMarket?: Array<{ maxCubes: number | null }>
-      ironMarket?: Array<{ maxCubes: number | null }>
-    }
-  }
-  for (const market of [clone.context?.coalMarket, clone.context?.ironMarket]) {
-    if (!Array.isArray(market)) continue
-    for (const row of market) {
-      if (row && row.maxCubes === null) row.maxCubes = Infinity
-    }
-  }
-  try {
-    refreshEmbeddedTileStats(clone)
-  } catch {
-    // a malformed record fails at actor creation, with better context
-  }
-  return clone
-}
-
 const COLORS = ['red', 'blue', 'green', 'yellow'] as const
 const CHARACTERS = [
   'Eliza Tinsley',
@@ -149,31 +123,6 @@ const CHARACTERS = [
   'George Stephenson',
   'Richard Arkwright',
 ] as const
-
-// Player-facing intents only — TEST_*/TRIGGER_* and lifecycle events are
-// server business and must never be accepted off the wire.
-const ALLOWED_EVENTS = new Set([
-  'BUILD',
-  'DEVELOP',
-  'SELL',
-  'TAKE_LOAN',
-  'SCOUT',
-  'NETWORK',
-  'PASS',
-  'SELECT_CARD',
-  'SELECT_LOCATION',
-  'SELECT_INDUSTRY_TYPE',
-  'SELECT_TILES_FOR_DEVELOP',
-  'SELECT_SALE',
-  'SELECT_LINK',
-  'SELECT_SECOND_LINK',
-  'CHOOSE_DOUBLE_LINK_BUILD',
-  'EXECUTE_DOUBLE_NETWORK_ACTION',
-  'BUILD_SECOND_LINK',
-  'CONFIRM',
-  'CANCEL',
-  'CLEAR_ERROR',
-])
 
 /* ---------------- views ---------------- */
 
@@ -230,10 +179,20 @@ export function filterSnapshotForSeat(
       currentPlayerIndex?: number
       selectedCard?: unknown
       selectedCardsForScout?: unknown[]
+      lastError?: string | null
+      errorContext?: string | null
     }
   }
   const ctx = clone.context
   if (!ctx) return clone
+
+  // A refusal reason belongs to the player who caused it. `applyIntent` never
+  // persists one, so this is belt-and-braces: if any path ever does, it must
+  // not ride out in a bystander's frame.
+  if (ctx.currentPlayerIndex !== seatId) {
+    ctx.lastError = null
+    ctx.errorContext = null
+  }
 
   ctx.players?.forEach((p, i) => {
     if (i !== seatId) {
@@ -475,34 +434,14 @@ export async function actInGame(
     if (game.phase !== 'playing' || game.snapshot === null) {
       return { ok: false, error: 'The game has not started' }
     }
-    if (!ALLOWED_EVENTS.has(event.type)) {
-      return { ok: false, error: `Event ${event.type} is not allowed` }
-    }
+    // Turn check, legality and execution all live in the pure seam, which
+    // returns the EXACT reason for a refusal (see intent.ts). A refusal is
+    // never persisted, so the acting player's error can't leak to other seats.
+    const outcome = applyIntent(game.snapshot, seatId, event)
+    if (!outcome.ok) return { ok: false, error: outcome.error }
 
-    const actor = createActor(gameStore, {
-      snapshot: rehydrate(game.snapshot) as never,
-    })
-    actor.start()
-    const before = actor.getSnapshot() as {
-      context: { currentPlayerIndex: number }
-      can: (e: never) => boolean
-      matches: (v: never) => boolean
-    }
-    if (before.context.currentPlayerIndex !== seatId) {
-      actor.stop()
-      return { ok: false, error: 'Not your turn' }
-    }
-    if (!before.can(event as never)) {
-      actor.stop()
-      return { ok: false, error: 'That action is not legal right now' }
-    }
-    actor.send(event as never)
-    const after = actor.getSnapshot()
-    game.snapshot = actor.getPersistedSnapshot()
-    if ((after as { matches: (v: string) => boolean }).matches('gameOver')) {
-      game.phase = 'over'
-    }
-    actor.stop()
+    game.snapshot = outcome.next
+    if (outcome.gameOver) game.phase = 'over'
     game.version++
     game.updatedAt = new Date().toISOString()
     await saveGame(game)

--- a/src/server/mp/intent.test.ts
+++ b/src/server/mp/intent.test.ts
@@ -1,0 +1,262 @@
+// The multiplayer server must tell a refused player exactly what is missing —
+// never a generic "that action is not legal right now" (captain, 2026-07-16).
+//
+// These drive `applyIntent`, the pure decision seam `actInGame` wraps, so the
+// wire contract is pinned without a database.
+import { describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import { type Merchant, gameStore } from '../../store/gameStore'
+import { applyIntent } from './intent'
+
+const players = [
+  {
+    id: '1',
+    name: 'Ada',
+    color: 'red' as const,
+    character: 'Richard Arkwright' as const,
+    money: 17,
+    victoryPoints: 0,
+    income: 10,
+    industryTilesOnMat: {} as never,
+  },
+  {
+    id: '2',
+    name: 'Brunel',
+    color: 'blue' as const,
+    character: 'Eliza Tinsley' as const,
+    money: 17,
+    victoryPoints: 0,
+    income: 10,
+    industryTilesOnMat: {} as never,
+  },
+]
+
+/** A started game, driven through `send`, handed back as a persisted snapshot. */
+const game = () => {
+  const actor = createActor(gameStore)
+  actor.subscribe({ error: () => {} })
+  actor.start()
+  actor.send({ type: 'START_GAME', players })
+  return actor
+}
+
+const cottonTile = {
+  id: 'cotton_1',
+  type: 'cotton' as const,
+  level: 1,
+  canBuildInCanalEra: true,
+  canBuildInRailEra: true,
+  incomeAdvancement: 2,
+  incomeSpaces: 2,
+  victoryPoints: 3,
+  beerRequired: 1,
+  cost: 10,
+  linkScoringIcons: 1,
+  coalRequired: 0,
+  ironRequired: 0,
+  beerProduced: 0,
+  coalProduced: 0,
+  ironProduced: 0,
+  hasLightbulbIcon: false,
+  quantity: 3,
+}
+
+const gloucesterMerchant = (overrides: Partial<Merchant> = {}): Merchant => ({
+  location: 'gloucester',
+  industryIcons: ['cotton', 'manufacturer'],
+  bonusType: 'money',
+  bonusValue: 5,
+  hasBeer: true,
+  ...overrides,
+})
+
+describe('applyIntent — a refusal names what is missing', () => {
+  test('wrong turn names whose turn it is', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    const otherSeat = idx === 0 ? 1 : 0
+    const active = actor.getSnapshot().context.players[idx]!
+
+    const res = applyIntent(actor.getPersistedSnapshot(), otherSeat, {
+      type: 'BUILD',
+    })
+    actor.stop()
+
+    expect(res.ok).toBe(false)
+    expect((res as { error: string }).error).toBe(
+      `Not your turn — waiting on ${active.name}.`,
+    )
+  })
+
+  test('money-short link refusal quotes treasury and cost', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 2 })
+    actor.send({ type: 'NETWORK' })
+    actor.send({
+      type: 'SELECT_CARD',
+      cardId: actor.getSnapshot().context.players[idx]!.hand[0]!.id,
+    })
+
+    const res = applyIntent(actor.getPersistedSnapshot(), idx, {
+      type: 'SELECT_LINK',
+      from: 'worcester',
+      to: 'gloucester',
+    })
+    actor.stop()
+
+    expect(res.ok).toBe(false)
+    // £2 treasury, £3 canal link — both amounts must be in the message.
+    expect((res as { error: string }).error).toBe(
+      'Not enough money: you have £2, a canal link costs £3.',
+    )
+  })
+
+  test('missing beer refusal names the beer, not "invalid sale"', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+
+    // Link worcester–gloucester so the mill reaches the merchant: the sale
+    // must fail on BEER alone, not on connection.
+    actor.send({ type: 'NETWORK' })
+    actor.send({
+      type: 'SELECT_CARD',
+      cardId: actor.getSnapshot().context.players[idx]!.hand[0]!.id,
+    })
+    actor.send({ type: 'SELECT_LINK', from: 'worcester', to: 'gloucester' })
+    actor.send({ type: 'CONFIRM' })
+
+    const seller = actor.getSnapshot().context.currentPlayerIndex
+    // No brewery anywhere and a beerless merchant → nothing can supply beer.
+    actor.send({
+      type: 'TEST_SET_MERCHANTS',
+      merchants: [gloucesterMerchant({ hasBeer: false })],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: seller,
+      money: 20,
+      industries: [
+        {
+          location: 'worcester',
+          type: 'cotton',
+          level: 1,
+          flipped: false,
+          tile: cottonTile,
+          coalCubesOnTile: 0,
+          ironCubesOnTile: 0,
+          beerBarrelsOnTile: 0,
+        } as never,
+      ],
+    })
+    actor.send({ type: 'SELL' })
+    actor.send({
+      type: 'SELECT_CARD',
+      cardId: actor.getSnapshot().context.players[seller]!.hand[0]!.id,
+    })
+
+    const res = applyIntent(actor.getPersistedSnapshot(), seller, {
+      type: 'SELECT_SALE',
+      location: 'worcester',
+      industryType: 'cotton',
+      merchant: 'gloucester',
+    })
+    actor.stop()
+
+    expect(res.ok).toBe(false)
+    expect((res as { error: string }).error).toBe(
+      'Needs 1 beer — no connected brewery has beer.',
+    )
+  })
+
+  test('no-connection link refusal names the unreachable city', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+
+    // Put a tile on the board so the virgin-board "build anywhere" exception
+    // no longer applies, then reach for a link nowhere near it.
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx,
+      money: 30,
+      industries: [
+        {
+          location: 'worcester',
+          type: 'cotton',
+          level: 1,
+          flipped: false,
+          tile: cottonTile,
+          coalCubesOnTile: 0,
+          ironCubesOnTile: 0,
+          beerBarrelsOnTile: 0,
+        } as never,
+      ],
+    })
+    actor.send({ type: 'NETWORK' })
+    actor.send({
+      type: 'SELECT_CARD',
+      cardId: actor.getSnapshot().context.players[idx]!.hand[0]!.id,
+    })
+
+    const res = applyIntent(actor.getPersistedSnapshot(), idx, {
+      type: 'SELECT_LINK',
+      from: 'walsall',
+      to: 'wolverhampton',
+    })
+    actor.stop()
+
+    expect(res.ok).toBe(false)
+    expect((res as { error: string }).error).toBe(
+      'No canal connection to wolverhampton: neither walsall nor wolverhampton is in your network.',
+    )
+  })
+
+  test('a legal move is accepted and returns the next snapshot', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+
+    const res = applyIntent(actor.getPersistedSnapshot(), idx, {
+      type: 'BUILD',
+    })
+    actor.stop()
+
+    expect(res.ok).toBe(true)
+    expect((res as { next: unknown }).next).toBeDefined()
+  })
+
+  test('TEST_* events are refused outright', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    const res = applyIntent(actor.getPersistedSnapshot(), idx, {
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx,
+      money: 999,
+    })
+    actor.stop()
+    expect(res.ok).toBe(false)
+    expect((res as { error: string }).error).toContain('is not allowed')
+  })
+
+  test('a refusal never persists the engine error into shared state', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 2 })
+    actor.send({ type: 'NETWORK' })
+    actor.send({
+      type: 'SELECT_CARD',
+      cardId: actor.getSnapshot().context.players[idx]!.hand[0]!.id,
+    })
+    const before = actor.getPersistedSnapshot()
+
+    const res = applyIntent(before, idx, {
+      type: 'SELECT_LINK',
+      from: 'worcester',
+      to: 'gloucester',
+    })
+    actor.stop()
+
+    expect(res.ok).toBe(false)
+    // No `next` to persist → lastError can never reach another seat's frame.
+    expect(res).not.toHaveProperty('next')
+  })
+})

--- a/src/server/mp/intent.test.ts
+++ b/src/server/mp/intent.test.ts
@@ -211,6 +211,44 @@ describe('applyIntent — a refusal names what is missing', () => {
     )
   })
 
+  // e10d6e8 moved affordability INTO the guards, so develop's iron shortfall
+  // fails at can() — a boolean — exactly like the link case.
+  test('develop refused for iron money names the shortfall', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 1 })
+    actor.send({ type: 'DEVELOP' })
+    let snap = actor.getSnapshot()
+    actor.send({
+      type: 'SELECT_CARD',
+      cardId: snap.context.players[idx]!.hand[0]!.id,
+    })
+    snap = actor.getSnapshot()
+    const tile = snap.context.players[idx]!.industryTilesOnMat
+    const anyType = (Object.keys(tile) as Array<keyof typeof tile>).find(
+      (k) => (tile[k]?.length ?? 0) > 0,
+    )
+    // Asserted, not skipped: if the fixture ever stops offering a developable
+    // tile this test must fail loudly rather than pass having checked nothing.
+    expect(anyType).toBeDefined()
+    actor.send({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: [anyType!],
+    })
+
+    const res = applyIntent(actor.getPersistedSnapshot(), idx, {
+      type: 'CONFIRM',
+    })
+    actor.stop()
+
+    // £1 cannot buy the iron, so the guard must refuse — and say why.
+    expect(res.ok).toBe(false)
+    expect((res as { error: string }).error).toMatch(/Not enough money|iron/i)
+    expect((res as { error: string }).error).not.toBe(
+      'That action is not legal right now.',
+    )
+  })
+
   test('a legal move is accepted and returns the next snapshot', () => {
     const actor = game()
     const idx = actor.getSnapshot().context.currentPlayerIndex
@@ -235,6 +273,83 @@ describe('applyIntent — a refusal names what is missing', () => {
     actor.stop()
     expect(res.ok).toBe(false)
     expect((res as { error: string }).error).toContain('is not allowed')
+  })
+
+  // Path 2: the guard ACCEPTS and execution fails. The engine's actions never
+  // throw — they set lastError and refuse to consume the action. The pre-fix
+  // server persisted that snapshot and answered ok; these pin that it now
+  // refuses, verbatim, and keeps nothing.
+  test('an execution failure is reported verbatim and consumes nothing', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    // £2 buys no industry tile: build's funds check lives in execution
+    // (buildIndustryTile), past the guard.
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 2 })
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: idx,
+      hand: [
+        {
+          id: 'loc_birmingham_1',
+          type: 'location',
+          location: 'birmingham',
+          color: 'other',
+        },
+      ],
+    })
+    actor.send({ type: 'BUILD' })
+    actor.send({ type: 'SELECT_CARD', cardId: 'loc_birmingham_1' })
+    actor.send({ type: 'SELECT_LOCATION', cityId: 'birmingham' })
+    actor.send({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'cotton' })
+
+    const before = actor.getPersistedSnapshot()
+    const moneyBefore = actor.getSnapshot().context.players[idx]!.money
+    const res = applyIntent(before, idx, { type: 'CONFIRM' })
+    actor.stop()
+
+    expect(res.ok).toBe(false)
+    // The engine's own words, naming the shortfall — not "Build action failed".
+    expect((res as { error: string }).error).toContain('Insufficient funds')
+    expect((res as { error: string }).error).toContain('£2')
+    expect(res).not.toHaveProperty('next')
+    expect(moneyBefore).toBe(2)
+  })
+
+  // A record written by the PRE-FIX server can already carry a lastError.
+  // Only a NEWLY set one may refuse the move, or the next legal action would
+  // be rejected with a stale, wrong reason.
+  test('a stale lastError on an old record does not refuse the next legal move', () => {
+    const actor = game()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: idx, money: 2 })
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: idx,
+      hand: [
+        {
+          id: 'loc_birmingham_2',
+          type: 'location',
+          location: 'birmingham',
+          color: 'other',
+        },
+      ],
+    })
+    // Produce a real lastError, then persist it the way the old server did.
+    actor.send({ type: 'BUILD' })
+    actor.send({ type: 'SELECT_CARD', cardId: 'loc_birmingham_2' })
+    actor.send({ type: 'SELECT_LOCATION', cityId: 'birmingham' })
+    actor.send({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'cotton' })
+    actor.send({ type: 'CONFIRM' })
+    const stale = actor.getSnapshot().context.lastError
+    expect(stale).not.toBeNull() // the record now carries a stale reason
+
+    // TAKE_LOAN is legal and does not clear lastError — the exact seam.
+    const res = applyIntent(actor.getPersistedSnapshot(), idx, {
+      type: 'TAKE_LOAN',
+    })
+    actor.stop()
+
+    expect(res.ok).toBe(true)
   })
 
   test('a refusal never persists the engine error into shared state', () => {

--- a/src/server/mp/intent.ts
+++ b/src/server/mp/intent.ts
@@ -1,0 +1,153 @@
+// The multiplayer intent decision — pure, and deliberately free of any DB
+// import so it can be tested offline (the rest of `game.ts` needs Neon).
+//
+// `actInGame` owns the I/O (load the row, authenticate the seat, persist);
+// everything that decides whether a move is ACCEPTED or REFUSED, and with what
+// reason, lives here.
+//
+// Refusal reasons (captain's requirement, 2026-07-16): a refusal must say
+// exactly what is missing. Two distinct refusal paths exist and both must
+// carry a reason:
+//   1. the guard rejects up front (`can()` false) — money-short, no
+//      connection, no beer. The guard is a boolean, so `explainRefusal`
+//      re-derives the cause from the engine's own validators.
+//   2. the guard accepts but EXECUTION fails — the engine's actions never
+//      throw; they set `lastError` and refuse to consume the action. We then
+//      throw the mutated snapshot away and report `lastError` verbatim.
+//
+// Because a refusal never persists, `lastError` never reaches the shared
+// snapshot, so one player's refusal can't leak to another seat.
+import { createActor } from 'xstate'
+import {
+  type GameEvent,
+  type GameState,
+  type GameStoreSnapshot,
+  gameStore,
+} from '../../store/gameStore'
+import { explainRefusal } from '../../store/refusal'
+import { refreshEmbeddedTileStats } from '../../store/saveMigration'
+
+// Events a client may send. Never the TEST_ / TRIGGER_ families — those bypass
+// the rules and must never be reachable from the wire.
+export const ALLOWED_EVENTS = new Set([
+  'BUILD',
+  'DEVELOP',
+  'SELL',
+  'TAKE_LOAN',
+  'SCOUT',
+  'NETWORK',
+  'PASS',
+  'SELECT_CARD',
+  'SELECT_LOCATION',
+  'SELECT_INDUSTRY_TYPE',
+  'SELECT_TILES_FOR_DEVELOP',
+  'SELECT_SALE',
+  'SELECT_LINK',
+  'SELECT_SECOND_LINK',
+  'CHOOSE_DOUBLE_LINK_BUILD',
+  'EXECUTE_DOUBLE_NETWORK_ACTION',
+  'BUILD_SECOND_LINK',
+  'CONFIRM',
+  'CANCEL',
+  'CLEAR_ERROR',
+])
+
+// JSON round-trips turn the markets' `maxCubes: Infinity` into null, so undo
+// it before the engine sees the snapshot (same fix as the client shell).
+// ALSO run the save migration here: the SERVER is the authority, and a
+// pre-audit game record would otherwise keep playing with stale tile stats
+// and no incomeSpace (whose NaN arithmetic reads as income level 30).
+export function rehydrate(snapshot: unknown): unknown {
+  const clone = structuredClone(snapshot) as {
+    context?: {
+      coalMarket?: Array<{ maxCubes: number | null }>
+      ironMarket?: Array<{ maxCubes: number | null }>
+    }
+  }
+  for (const market of [clone.context?.coalMarket, clone.context?.ironMarket]) {
+    if (!Array.isArray(market)) continue
+    for (const row of market) {
+      if (row && row.maxCubes === null) row.maxCubes = Number.POSITIVE_INFINITY
+    }
+  }
+  try {
+    refreshEmbeddedTileStats(clone)
+  } catch {
+    // a malformed record fails at actor creation, with better context
+  }
+  return clone
+}
+
+export type IntentOutcome =
+  | { ok: true; next: unknown; gameOver: boolean }
+  | { ok: false; error: string }
+
+const GENERIC_REFUSAL = 'That action is not legal right now.'
+
+/** Is the machine parked on a step where CONFIRM commits a link? */
+const atLinkConfirm = (snapshot: GameStoreSnapshot) =>
+  snapshot.matches({
+    playing: { action: { networking: 'confirmingLink' } },
+  } as never)
+
+/**
+ * Decide one intent against a persisted snapshot. Never mutates its input.
+ *
+ * Seat AUTHENTICATION is the caller's job; the turn check lives here because
+ * "not your turn" is a refusal reason like any other.
+ */
+export function applyIntent(
+  persisted: unknown,
+  seatId: number,
+  event: { type: string } & Record<string, unknown>,
+): IntentOutcome {
+  if (!ALLOWED_EVENTS.has(event.type)) {
+    return { ok: false, error: `Event ${event.type} is not allowed.` }
+  }
+
+  const actor = createActor(gameStore, {
+    snapshot: rehydrate(persisted) as never,
+  })
+  actor.start()
+  try {
+    const before = actor.getSnapshot() as GameStoreSnapshot
+    const context = before.context as GameState
+
+    if (context.currentPlayerIndex !== seatId) {
+      const active = context.players[context.currentPlayerIndex]
+      return {
+        ok: false,
+        error: active
+          ? `Not your turn — waiting on ${active.name}.`
+          : 'Not your turn.',
+      }
+    }
+
+    if (!before.can(event as never)) {
+      const reason = explainRefusal(
+        context,
+        event as unknown as GameEvent,
+        atLinkConfirm(before),
+      )
+      return { ok: false, error: reason ?? GENERIC_REFUSAL }
+    }
+
+    actor.send(event as never)
+    const after = actor.getSnapshot() as GameStoreSnapshot
+
+    // The guard accepted but execution refused: report the engine's own reason
+    // and DISCARD the snapshot, so the action is not consumed and the error
+    // never becomes shared state.
+    if (after.context.lastError !== null) {
+      return { ok: false, error: after.context.lastError }
+    }
+
+    return {
+      ok: true,
+      next: actor.getPersistedSnapshot(),
+      gameOver: after.matches('gameOver' as never),
+    }
+  } finally {
+    actor.stop()
+  }
+}

--- a/src/server/mp/intent.ts
+++ b/src/server/mp/intent.ts
@@ -84,12 +84,6 @@ export type IntentOutcome =
 
 const GENERIC_REFUSAL = 'That action is not legal right now.'
 
-/** Is the machine parked on a step where CONFIRM commits a link? */
-const atLinkConfirm = (snapshot: GameStoreSnapshot) =>
-  snapshot.matches({
-    playing: { action: { networking: 'confirmingLink' } },
-  } as never)
-
 /**
  * Decide one intent against a persisted snapshot. Never mutates its input.
  *
@@ -124,13 +118,15 @@ export function applyIntent(
     }
 
     if (!before.can(event as never)) {
-      const reason = explainRefusal(
-        context,
-        event as unknown as GameEvent,
-        atLinkConfirm(before),
-      )
+      const reason = explainRefusal(before, event as unknown as GameEvent)
       return { ok: false, error: reason ?? GENERIC_REFUSAL }
     }
+
+    // A record written by the PRE-FIX server may already carry a lastError
+    // (that server persisted execution failures — the bug this closes). Only a
+    // reason this event NEWLY set may refuse it, or the next legal move would
+    // be rejected with a stale, wrong reason.
+    const errorBefore = before.context.lastError
 
     actor.send(event as never)
     const after = actor.getSnapshot() as GameStoreSnapshot
@@ -138,8 +134,9 @@ export function applyIntent(
     // The guard accepted but execution refused: report the engine's own reason
     // and DISCARD the snapshot, so the action is not consumed and the error
     // never becomes shared state.
-    if (after.context.lastError !== null) {
-      return { ok: false, error: after.context.lastError }
+    const errorAfter = after.context.lastError
+    if (errorAfter !== null && errorAfter !== errorBefore) {
+      return { ok: false, error: errorAfter }
     }
 
     return {

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -456,9 +456,10 @@ const SELLABLE_INDUSTRY_TYPES: IndustryType[] = [
   'pottery',
 ]
 
-// Shared validation for a single sale within a Sell action, used by both the
-// canExecuteSale guard and the executeSingleSale action
-const validateSale = (
+// Shared validation for a single sale within a Sell action, used by the
+// canExecuteSale guard, the executeSingleSale action, and `explainRefusal`
+// (src/store/refusal.ts) — which surfaces the `error` the guard discards.
+export const validateSale = (
   context: GameState,
   event: { location: CityId; industryType: IndustryType; merchant: CityId },
 ): {

--- a/src/store/market/marketActions.ts
+++ b/src/store/market/marketActions.ts
@@ -562,7 +562,12 @@ export function consumeBeerFromSources(
       updatedMerchants: context.merchants,
       merchantBonusesCollected: [],
       logDetails,
-      errorMessage: `Insufficient beer available. Required: ${beerRequired}, available: ${beerConsumed}`,
+      // Name what is missing, not just that something is (captain, 2026-07-16):
+      // this string is surfaced verbatim to the refused player.
+      errorMessage:
+        beerConsumed === 0
+          ? `Needs ${beerRequired} beer — no connected brewery has beer.`
+          : `Needs ${beerRequired} beer — only ${beerConsumed} reachable from connected breweries.`,
     }
   }
 

--- a/src/store/market/marketActions.ts
+++ b/src/store/market/marketActions.ts
@@ -563,11 +563,13 @@ export function consumeBeerFromSources(
       merchantBonusesCollected: [],
       logDetails,
       // Name what is missing, not just that something is (captain, 2026-07-16):
-      // this string is surfaced verbatim to the refused player.
+      // this string is surfaced verbatim to the refused player. The partial
+      // case stays source-agnostic — `beerConsumed` may include merchant beer
+      // on a sale path, not only breweries.
       errorMessage:
         beerConsumed === 0
           ? `Needs ${beerRequired} beer — no connected brewery has beer.`
-          : `Needs ${beerRequired} beer — only ${beerConsumed} reachable from connected breweries.`,
+          : `Needs ${beerRequired} beer — only ${beerConsumed} within reach.`,
     }
   }
 

--- a/src/store/refusal.ts
+++ b/src/store/refusal.ts
@@ -9,21 +9,34 @@
 //
 // This module re-derives the reason by calling the SAME validators and probes
 // the guards themselves call (validateSale, consumeCoalFromSources,
-// linkConnectedLocations, GAME_CONSTANTS costs) — it never re-implements a
-// rule. If a guard changes, the explainer changes with it, because both read
-// the same helper. Where an explainer cannot pin the cause it returns null and
-// the caller falls back to a generic string; a wrong reason is worse than a
-// vague one.
+// consumeBeerFromSources, consumeIronFromSources, GAME_CONSTANTS costs). Where
+// an explainer cannot pin the cause it returns null and the caller falls back
+// to a generic string; a wrong reason is worse than a vague one.
+//
+// DRIFT WARNING: the link explainers below are the one place that re-states a
+// guard's structure rather than calling it (`canBuildLink` is a boolean
+// cascade with no shared helper to borrow). They mirror its rejection ORDER so
+// the named cause is the one that actually blocks. If `canBuildLink` grows a
+// check — the documented era/board-graph gap, say — update `explainLink` in
+// the same commit, or it will silently answer with a stale reason.
 //
 // CONTRACT: only call this when `can(event)` is already false. It answers "why
 // would this be refused", not "is this legal" — the machine owns legality.
 import { type CityId, connections, linkConnectedLocations } from '../data/board'
 import { GAME_CONSTANTS } from './constants'
-import { type GameEvent, type GameState, validateSale } from './gameStore'
-import { consumeCoalFromSources } from './market/marketActions'
+import {
+  type GameEvent,
+  type GameState,
+  type GameStoreSnapshot,
+  validateSale,
+} from './gameStore'
+import {
+  consumeBeerFromSources,
+  consumeCoalFromSources,
+  consumeIronFromSources,
+} from './market/marketActions'
 import { getCurrentPlayer } from './shared/gameUtils'
 
-/** £ amounts read better without a trailing `.00`. */
 const money = (amount: number) => `£${amount}`
 
 const linkCostFor = (context: GameState) =>
@@ -122,16 +135,92 @@ const explainSelectedLink = (context: GameState): string | null => {
   return null
 }
 
+/** CONFIRM on a build — canCompleteBuild's coal-reachability check. */
+const explainBuildConfirm = (context: GameState): string | null => {
+  const tile = context.selectedIndustryTile
+  const location = context.selectedLocation
+  if (!tile || !location) return null
+  if (tile.coalRequired > 0) {
+    const coal = consumeCoalFromSources(context, location, tile.coalRequired)
+    if (!coal.success) {
+      return `No coal reachable from ${location} — this ${tile.type} needs ${tile.coalRequired} coal.`
+    }
+  }
+  return null
+}
+
+/** CONFIRM on a develop — hasSelectedTilesForDevelop's iron affordability. */
+const explainDevelopConfirm = (context: GameState): string | null => {
+  const count = context.selectedTilesForDevelop.length
+  if (count === 0) return 'No tiles selected to develop.'
+  const player = getCurrentPlayer(context)
+  const { ironCost } = consumeIronFromSources(context, count)
+  if (player.money < ironCost) {
+    return `Not enough money: you have ${money(player.money)}, the iron to develop ${count === 1 ? 'this tile' : `these ${count} tiles`} costs ${money(ironCost)}.`
+  }
+  return null
+}
+
+/** CHOOSE_DOUBLE_LINK_BUILD — canBuildSecondLink's era + beer-supply check. */
+const explainSecondLinkOffer = (context: GameState): string | null => {
+  if (context.era !== 'rail') {
+    return 'Two links at once is a Rail Era action.'
+  }
+  if (!context.selectedLink) return 'Select the first link first.'
+  const hasAnyBeer = context.players.some((p) =>
+    p.industries.some(
+      (i) => i.type === 'brewery' && !i.flipped && i.beerBarrelsOnTile > 0,
+    ),
+  )
+  if (!hasAnyBeer) {
+    return 'Two rails needs 1 beer — no brewery on the board has any.'
+  }
+  return null
+}
+
+/**
+ * EXECUTE_DOUBLE_NETWORK_ACTION — canCompleteDoubleLink: beer, then coal for
+ * both links, then £15. Probed in the guard's own order.
+ */
+const explainDoubleLink = (context: GameState): string | null => {
+  const first = context.selectedLink
+  const second = context.selectedSecondLink
+  if (context.era !== 'rail') return 'Two links at once is a Rail Era action.'
+  if (!first || !second) return 'Select both links first.'
+
+  const beer = consumeBeerFromSources(context, second.to as CityId, 1)
+  if (!beer.success) {
+    return (
+      beer.errorMessage ??
+      'Two rails needs 1 beer — none is reachable from your network.'
+    )
+  }
+  const coal = consumeCoalFromSources(context, first.from as CityId, 1)
+  if (!coal.success) {
+    return `No coal reachable from ${first.from} — each rail link needs 1 coal.`
+  }
+  const player = getCurrentPlayer(context)
+  const cost = GAME_CONSTANTS.RAIL_DOUBLE_LINK_COST
+  if (player.money < cost) {
+    return `Not enough money: you have ${money(player.money)}, two rails cost ${money(cost)} plus coal.`
+  }
+  return null
+}
+
 /**
  * Explain a refused event. Returns null when the cause cannot be pinned —
  * callers should fall back to a generic message rather than guess.
+ *
+ * Takes the SNAPSHOT (not just context) because a CONFIRM means something
+ * different at each confirm step, and only the state tells them apart.
  */
 export function explainRefusal(
-  context: GameState,
+  snapshot: GameStoreSnapshot,
   event: GameEvent,
-  /** true when the machine is parked on a link confirm step */
-  atLinkConfirm = false,
 ): string | null {
+  const context = snapshot.context
+  const at = (path: unknown) => snapshot.matches(path as never)
+
   switch (event.type) {
     case 'SELECT_LINK':
     case 'SELECT_SECOND_LINK':
@@ -141,6 +230,12 @@ export function explainRefusal(
       // validateSale already produces the exact reason (missing beer, no
       // merchant, not connected) — the guard just throws it away.
       return validateSale(context, event).error ?? null
+
+    case 'CHOOSE_DOUBLE_LINK_BUILD':
+      return explainSecondLinkOffer(context)
+
+    case 'EXECUTE_DOUBLE_NETWORK_ACTION':
+      return explainDoubleLink(context)
 
     case 'TAKE_LOAN': {
       if (context.selectedCard === null) return 'No card selected for the loan.'
@@ -177,7 +272,16 @@ export function explainRefusal(
     }
 
     case 'CONFIRM':
-      return atLinkConfirm ? explainSelectedLink(context) : null
+      if (at({ playing: { action: { networking: 'confirmingLink' } } })) {
+        return explainSelectedLink(context)
+      }
+      if (at({ playing: { action: { building: 'confirmingBuild' } } })) {
+        return explainBuildConfirm(context)
+      }
+      if (at({ playing: { action: { developing: 'confirmingDevelop' } } })) {
+        return explainDevelopConfirm(context)
+      }
+      return null
 
     default:
       return null

--- a/src/store/refusal.ts
+++ b/src/store/refusal.ts
@@ -1,0 +1,185 @@
+// Why did the engine refuse this event?
+//
+// The machine's guards are booleans: `can(event) === false` tells a caller a
+// move is illegal but never WHAT is missing. Every can()-gated caller (the
+// multiplayer server, the AI driver, the UI) then has to invent a message,
+// and they all landed on the same useless one — "that action is not legal
+// right now". The captain's requirement (2026-07-16) is that a refusal says
+// exactly what is missing.
+//
+// This module re-derives the reason by calling the SAME validators and probes
+// the guards themselves call (validateSale, consumeCoalFromSources,
+// linkConnectedLocations, GAME_CONSTANTS costs) — it never re-implements a
+// rule. If a guard changes, the explainer changes with it, because both read
+// the same helper. Where an explainer cannot pin the cause it returns null and
+// the caller falls back to a generic string; a wrong reason is worse than a
+// vague one.
+//
+// CONTRACT: only call this when `can(event)` is already false. It answers "why
+// would this be refused", not "is this legal" — the machine owns legality.
+import { type CityId, connections, linkConnectedLocations } from '../data/board'
+import { GAME_CONSTANTS } from './constants'
+import { type GameEvent, type GameState, validateSale } from './gameStore'
+import { consumeCoalFromSources } from './market/marketActions'
+import { getCurrentPlayer } from './shared/gameUtils'
+
+/** £ amounts read better without a trailing `.00`. */
+const money = (amount: number) => `£${amount}`
+
+const linkCostFor = (context: GameState) =>
+  context.era === 'canal'
+    ? GAME_CONSTANTS.CANAL_LINK_COST
+    : GAME_CONSTANTS.RAIL_LINK_COST
+
+/** The set of locations the player's network reaches (mirrors canBuildLink). */
+const networkLocations = (context: GameState) => {
+  const player = getCurrentPlayer(context)
+  const locations = new Set<string>()
+  player.industries.forEach((industry) => locations.add(industry.location))
+  player.links.forEach((link) => {
+    for (const loc of linkConnectedLocations(link.from, link.to)) {
+      locations.add(loc)
+    }
+  })
+  return locations
+}
+
+/**
+ * SELECT_LINK / SELECT_SECOND_LINK. Mirrors canBuildLink's rejection order so
+ * the reason names the FIRST thing that actually blocks the player.
+ */
+const explainLink = (
+  context: GameState,
+  event: Extract<GameEvent, { type: 'SELECT_LINK' | 'SELECT_SECOND_LINK' }>,
+): string | null => {
+  const player = getCurrentPlayer(context)
+  const era = context.era === 'canal' ? 'canal' : 'rail'
+
+  const exists = connections.some(
+    (c) =>
+      (c.from === event.from && c.to === event.to) ||
+      (c.from === event.to && c.to === event.from),
+  )
+  if (!exists) return `There is no route between ${event.from} and ${event.to}.`
+
+  const taken = context.players.some((p) =>
+    p.links.some(
+      (link) =>
+        (link.from === event.from && link.to === event.to) ||
+        (link.from === event.to && link.to === event.from),
+    ),
+  )
+  if (taken) {
+    return `A link already connects ${event.from} and ${event.to}.`
+  }
+
+  const cost = linkCostFor(context)
+  if (player.money < cost) {
+    return `Not enough money: you have ${money(player.money)}, a ${era} link costs ${money(cost)}.`
+  }
+
+  // Virgin board: a player with nothing on the board may build anywhere.
+  if (player.industries.length === 0 && player.links.length === 0) return null
+
+  if (event.type === 'SELECT_SECOND_LINK' && !context.selectedLink) {
+    return 'Select the first link before the second.'
+  }
+
+  const reachable = networkLocations(context)
+  if (!reachable.has(event.from) && !reachable.has(event.to)) {
+    return `No ${era} connection to ${event.to}: neither ${event.from} nor ${event.to} is in your network.`
+  }
+
+  return null
+}
+
+/**
+ * CONFIRM on a selected link — the seam canBuildLink cannot see, because coal
+ * cost is only known once the link is picked (hasSelectedLink's check).
+ */
+const explainSelectedLink = (context: GameState): string | null => {
+  const link = context.selectedLink
+  if (!link) return 'No link selected.'
+  const player = getCurrentPlayer(context)
+  const cost = linkCostFor(context)
+
+  if (context.era === 'rail') {
+    // Probe coal exactly as hasSelectedLink does — a rail link burns 1 coal.
+    const coal = consumeCoalFromSources(context, link.from as CityId, 1)
+    if (!coal.success) {
+      return `No coal reachable from ${link.from} — a rail link needs 1 coal.`
+    }
+    const total = cost + coal.coalCost
+    if (player.money < total) {
+      return `Not enough money: you have ${money(player.money)}, this rail link costs ${money(total)} (${money(cost)} + ${money(coal.coalCost)} coal).`
+    }
+    return null
+  }
+
+  if (player.money < cost) {
+    return `Not enough money: you have ${money(player.money)}, a canal link costs ${money(cost)}.`
+  }
+  return null
+}
+
+/**
+ * Explain a refused event. Returns null when the cause cannot be pinned —
+ * callers should fall back to a generic message rather than guess.
+ */
+export function explainRefusal(
+  context: GameState,
+  event: GameEvent,
+  /** true when the machine is parked on a link confirm step */
+  atLinkConfirm = false,
+): string | null {
+  switch (event.type) {
+    case 'SELECT_LINK':
+    case 'SELECT_SECOND_LINK':
+      return explainLink(context, event)
+
+    case 'SELECT_SALE':
+      // validateSale already produces the exact reason (missing beer, no
+      // merchant, not connected) — the guard just throws it away.
+      return validateSale(context, event).error ?? null
+
+    case 'TAKE_LOAN': {
+      if (context.selectedCard === null) return 'No card selected for the loan.'
+      const player = getCurrentPlayer(context)
+      const after = player.income - GAME_CONSTANTS.LOAN_INCOME_PENALTY
+      if (after < GAME_CONSTANTS.MIN_INCOME) {
+        return `A loan drops your income ${GAME_CONSTANTS.LOAN_INCOME_PENALTY} levels to ${after}, below the minimum of ${GAME_CONSTANTS.MIN_INCOME}.`
+      }
+      return null
+    }
+
+    case 'SCOUT': {
+      const player = getCurrentPlayer(context)
+      if (
+        player.hand.some(
+          (c) => c.type === 'wild_location' || c.type === 'wild_industry',
+        )
+      ) {
+        return 'You cannot Scout while holding a wild card.'
+      }
+      if (
+        context.wildLocationPile.length === 0 ||
+        context.wildIndustryPile.length === 0
+      ) {
+        return 'No wild cards are left to Scout for.'
+      }
+      if (
+        context.selectedCardsForScout.length !==
+        GAME_CONSTANTS.SCOUT_CARDS_REQUIRED
+      ) {
+        return `Scout needs exactly ${GAME_CONSTANTS.SCOUT_CARDS_REQUIRED} cards discarded.`
+      }
+      return null
+    }
+
+    case 'CONFIRM':
+      return atLinkConfirm ? explainSelectedLink(context) : null
+
+    default:
+      return null
+  }
+}


### PR DESCRIPTION
When the server refused a move, it said one of two things: **"That action is not legal right now"** or **"Not your turn"**. A player refused for want of £1, a barrel of beer, or a rail connection was told only that *something* went wrong.

![Refusal toast in a live multiplayer game](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-19-images/pr-refusal-toast.png)

*A real `/g/<token>` game against a live DB. Ada holds the worcester–gloucester link (see the journal) and clicks walsall–wolverhampton: "No canal connection to wolverhampton: neither walsall nor wolverhampton is in your network."*

## The reasons already existed — we were throwing them away

`validateSale` returns `"Cannot sell: worcester is not connected to gloucester"` and the exact beer shortfall. The `canExecuteSale` guard reduces all of it to `.isValid`. And since e10d6e8 moved affordability **into** the guards, money-short refusals now fail at `can()` — a boolean — so the amounts never survived.

So this is mostly plumbing what the engine already knows, not inventing new text.

## What changed

- **`src/store/refusal.ts` (`explainRefusal`)** — explains a guard refusal by calling the **same validators and probes the guards call** (`validateSale`, `consumeCoalFromSources`, `consumeBeerFromSources`, `consumeIronFromSources`). It returns `null` when it can't pin the cause and the caller falls back to the generic string: **a wrong reason is worse than a vague one.** It takes the snapshot, since a `CONFIRM` means something different at each confirm step.
- **`src/server/mp/intent.ts` (`applyIntent`)** — the decision split out of `actInGame` (which keeps the I/O). This also closed a **second bug**: execution failures set `lastError`, but the server persisted that snapshot and returned `ok`, leaving the client to round-trip a `CLEAR_ERROR` to find out why. A refusal now discards the snapshot and reports the reason verbatim.
- **Client** — `mp-game.tsx` gates board clicks against its local actor, so an illegal route never reached the server and the player got the client's *own* generic string. Route-click refusals now use the same explainer (all the state it needs is public), so there is still exactly one place that knows why a link is refused.

### Only the acting player sees it

A refusal is **never persisted**, so the reason lives only in the actor's own POST response and cannot ride out in a bystander's frame. `filterSnapshotForSeat` also nulls `lastError` for foreign seats as defence in depth, since a pre-fix record may already carry one.

## Before / after

| | before | after |
|---|---|---|
| money | That action is not legal right now | `Not enough money: you have £2, a canal link costs £3.` |
| beer | *(silently ok, error round-tripped)* | `Needs 1 beer — no connected brewery has beer.` |
| connection | That action is not legal right now | `No canal connection to wolverhampton: neither walsall nor wolverhampton is in your network.` |
| turn | Not your turn | `Not your turn — waiting on Ada.` |

## Review follow-ups (all folded in)

Review came back approve-with-nits; every finding is addressed in `e939b22`:

1. **Contract gaps** — the seam now also explains develop's iron affordability, build's coal reachability, and both double-rail guards.
2. **Stale reason** — only a *newly set* `lastError` may refuse a move. A pre-fix record already carrying one would otherwise have its next legal loan/scout rejected with a stale, wrong reason.
3. **Path 2 untested** — a location-card build that clears the guard and fails in execution now pins the verbatim reason and the no-consume guarantee, plus the stale-lastError regression and the develop-iron case.
4. **Nits** — the beer shortfall's partial branch no longer says "breweries" (merchant beer counts toward it). The link explainers do restate `canBuildLink`'s cascade (it has no shared helper to borrow); the header now says so and says to update both together, rather than the PR claiming no duplication exists.

## Tests

The seam is DB-free **on purpose**: the mp suites need Neon, so the refusal contract is pinned offline. **312 passed, 4 skipped**; lint and typecheck clean. The 3 failures in my worktree (`mp-ai`, `egress`, `gameStore.multiplayer`) are all `No database connection string` — CI runs them against its Neon branch and **CI's `test` job is green**.

`pnpm test` did not glob `src/server/mp/`, so those suites — the new one **and the existing `egress` pins** — never ran in CI. They do now.

> `claude-review` fails repo-wide ("Claude Code GitHub App not installed") — unrelated to this PR; that workflow was deleted on main and will vanish on rebase.

## Related

The double-rail branches (`explainSecondLinkOffer`, `explainDoubleLink`) are exactly what **brass-double-rail-ux** needs to explain a disabled "Build two rails" button instead of hiding it — they live in `src/store/refusal.ts` so that work can call them rather than re-implement the rules. Not wired to the button here, as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
