### PR TITLE
fix(ai): hide Versus AI opponent option in production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,6 +316,14 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   without ANTHROPIC_API_KEY (or without a gateway for openai-wire tiers)
   refuses with a clear error. Rationales + cost are PUBLIC in
   `GameView.ai`; the AI's hand stays as hidden as any other seat's.
+- Versus AI is hidden in production (2026-07-16, not ready for prod yet):
+  `aiOpponentsEnabled(vercelEnv)` in `src/lib/features.ts` is the single
+  flag — `false` when `VERCEL_ENV`/`NEXT_PUBLIC_VERCEL_ENV === 'production'`,
+  `true` everywhere else (dev, preview, unset). Gated in two places: the
+  setup screen hides the "Versus AI" charter option, and
+  `POST /api/mp/create` refuses (403) any request for AI opponent seats —
+  the server check exists so a client bypassing the hidden UI still can't
+  create AI seats in prod. Flip the one function to re-enable.
 
 ## CI (GitHub Actions, Neon-per-run added 2026-07-15)
 

--- a/src/app/api/mp/create/route.ts
+++ b/src/app/api/mp/create/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { aiOpponentsEnabled } from '~/lib/features'
 import { isAiTierId } from '~/server/ai/types'
 import { createGame } from '~/server/mp/game'
 
@@ -15,6 +16,15 @@ export async function POST(req: Request) {
     const opponents = (body.opponents ?? []).map((o) =>
       isAiTierId(o) ? o : ('human' as const),
     )
+    if (
+      opponents.some((o) => o !== 'human') &&
+      !aiOpponentsEnabled(process.env.VERCEL_ENV)
+    ) {
+      return NextResponse.json(
+        { error: 'AI opponents are not available in production yet' },
+        { status: 403 },
+      )
+    }
     const result = await createGame(
       String(body.name ?? ''),
       Number(body.playerCount ?? 0),

--- a/src/components/setup-screen.tsx
+++ b/src/components/setup-screen.tsx
@@ -5,9 +5,12 @@
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { toast } from 'sonner'
+import { aiOpponentsEnabled } from '~/lib/features'
 import { AI_TIERS, type AiTierId } from '~/server/ai/types'
 import { type Player } from '~/store/gameStore'
 import { PLAYER_FILL } from './board/board-map'
+
+const AI_ENABLED = aiOpponentsEnabled(process.env.NEXT_PUBLIC_VERCEL_ENV)
 
 const COLORS: Player['color'][] = ['red', 'blue', 'green', 'yellow']
 const CHARACTERS: Player['character'][] = [
@@ -123,7 +126,11 @@ export function SetupScreen({
       >
         <span className="bb2-panel-title">Company charter</span>
 
-        <div className="grid grid-cols-3 gap-2">
+        <div
+          className={
+            AI_ENABLED ? 'grid grid-cols-3 gap-2' : 'grid grid-cols-2 gap-2'
+          }
+        >
           <button
             type="button"
             className="bb2-option justify-center py-2"
@@ -146,17 +153,19 @@ export function SetupScreen({
               Play online
             </span>
           </button>
-          <button
-            type="button"
-            className="bb2-option justify-center py-2"
-            data-selected={mode === 'ai'}
-            data-testid="mode-ai"
-            onClick={() => setMode('ai')}
-          >
-            <span className="text-[11.5px] font-bold uppercase tracking-[0.14em]">
-              Versus AI
-            </span>
-          </button>
+          {AI_ENABLED && (
+            <button
+              type="button"
+              className="bb2-option justify-center py-2"
+              data-selected={mode === 'ai'}
+              data-testid="mode-ai"
+              onClick={() => setMode('ai')}
+            >
+              <span className="text-[11.5px] font-bold uppercase tracking-[0.14em]">
+                Versus AI
+              </span>
+            </button>
+          )}
         </div>
 
         <div className="flex flex-col gap-2">

--- a/src/lib/features.test.ts
+++ b/src/lib/features.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { aiOpponentsEnabled } from './features'
+
+describe('aiOpponentsEnabled', () => {
+  it('is disabled in production', () => {
+    expect(aiOpponentsEnabled('production')).toBe(false)
+  })
+
+  it('is enabled in preview', () => {
+    expect(aiOpponentsEnabled('preview')).toBe(true)
+  })
+
+  it('is enabled in development', () => {
+    expect(aiOpponentsEnabled('development')).toBe(true)
+  })
+
+  it('is enabled when unset (local dev, CI)', () => {
+    expect(aiOpponentsEnabled(undefined)).toBe(true)
+  })
+})

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -1,0 +1,7 @@
+// AI opponents are server-driven and not ready for prod yet (captain's call,
+// 2026-07-16) — gated off production, on everywhere else (dev, preview, CI).
+// Vercel sets VERCEL_ENV server-side and mirrors it to NEXT_PUBLIC_VERCEL_ENV
+// for the client automatically; pass whichever is in scope.
+export function aiOpponentsEnabled(vercelEnv: string | undefined): boolean {
+  return vercelEnv !== 'production'
+}


### PR DESCRIPTION
## Summary
- The captain says server-driven AI opponents aren't ready for prod. Adds `aiOpponentsEnabled(vercelEnv)` in `src/lib/features.ts` — a single, tiny, obviously-reversible check.
- Setup screen (`src/components/setup-screen.tsx`): hides the "Versus AI" charter option and its tier picker when `NEXT_PUBLIC_VERCEL_ENV === 'production'`.
- Server (`src/app/api/mp/create/route.ts`): belt-and-braces — refuses (403, clear error) any `POST /api/mp/create` that requests AI opponent seats when `VERCEL_ENV === 'production'`, even if a client bypasses the hidden UI.
- Development and preview deployments are unaffected (both env values, and unset, keep it enabled).

## Test plan
- [x] `pnpm exec vitest run src/lib/features.test.ts` — both env values covered (production → disabled, preview/development/unset → enabled)
- [x] `pnpm typecheck`
- [x] `pnpm exec biome check` on touched files
- [x] Manually booted `NEXT_PUBLIC_VERCEL_ENV=production pnpm dev` and confirmed the "Versus AI" button is absent from the setup screen:

![Production setup screen — Versus AI option absent](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-20-images/prod-setup-no-ai.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)