### PR TITLE
feat(ui): signpost the player mat with a button under the actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,20 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   action's built-in default `claude-sonnet-4-20250514` 404s (id no longer
   served). Bump this when the model id changes.
 
+## NEVER `git stash` here (2026-07-16)
+
+This repo is worked by CONCURRENT agent worktrees sharing ONE `.git`, and
+the stash stack is shared with it — `git stash` is global, not per-worktree.
+A `stash`/`stash pop` pair that looks atomic in your worktree will silently
+hand your work to another lane and pop THEIRS into your tree (observed: a
+lane popped a foreign `action-dock.tsx` and lost its own 5 files).
+To compare against a clean tree, use a throwaway worktree
+(`git worktree add`), `git diff > /tmp/x.patch` + `git checkout --`, or
+`git stash create` (writes a dangling commit WITHOUT touching the shared
+stack). Recovery if it happens: your work is a dangling commit — find the
+`WIP on <your-branch>` one via `git fsck --unreachable | grep commit`, then
+`git checkout <sha> -- <your files>`.
+
 ## Maintaining this file
 
 Keep this file for knowledge useful to almost every future agent session in this project.

--- a/e2e/coverage.spec.ts
+++ b/e2e/coverage.spec.ts
@@ -221,9 +221,7 @@ test('Develop: scrap the lowest tile, consuming iron', async ({ page }) => {
   ).toBeVisible()
   await page.getByTestId('confirm-action').click()
 
-  await expect(
-    page.getByText(/Eliza developed \(removed 1 tile/),
-  ).toBeVisible()
+  await expect(page.getByText(/Eliza developed \(removed 1 tile/)).toBeVisible()
   // Her turn ends but the round continues with the next player.
   await expect(page.getByTestId('round-chip')).toHaveText('Round 8')
 })
@@ -292,7 +290,7 @@ test('capstone: play the final turns through the UI to the winner', async ({
   // number the scoreboard shows — a mismatch is a scoring bug, not a
   // rendering detail.
   await expect(page.getByTestId('vp-ledger')).toContainText(
-    "George\u2019s ledger",
+    'George\u2019s ledger',
   )
   await expect(page.getByTestId('ledger-total')).toHaveText('38 VP')
   await expect(page.getByTestId('ledger-mismatch')).toHaveCount(0)
@@ -307,7 +305,7 @@ test('capstone: play the final turns through the UI to the winner', async ({
   // on industry tiles too, so cities pick up roundels.
   await page.getByTestId('score-row-2').click()
   await expect(page.getByTestId('vp-ledger')).toContainText(
-    "Isambard\u2019s ledger",
+    'Isambard\u2019s ledger',
   )
   await expect(page.getByTestId('ledger-total')).toHaveText('23 VP')
   await expect(page.locator('svg [data-vp-city]').first()).toBeVisible()
@@ -344,4 +342,29 @@ test('Undo: the first action of a turn can be taken back in full', async ({
   await expect(page.getByText(/George completed Sell action/)).toHaveCount(0)
   await expect(treasuryOf(page, 'George')).toHaveText('£9')
   await expect(page.getByTestId('undo-action')).toHaveCount(0)
+})
+
+test('the dock signposts your own player mat without a name-click', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  const open = page.getByTestId('open-player-mat')
+  await expect(open).toBeVisible()
+
+  // Opens the ACTING player's mat, exactly as tapping their rail card does.
+  await open.click()
+  const ledger = page.getByRole('dialog')
+  await expect(ledger).toHaveAttribute('aria-label', "Eliza's ledger")
+
+  // The rail card remains a way in — the button is an addition, not a swap.
+  await ledger.getByRole('button', { name: 'Close' }).click()
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  await page
+    .locator('[data-testid^="mat-"]')
+    .filter({ hasText: 'Eliza' })
+    .click()
+  await expect(page.getByRole('dialog')).toHaveAttribute(
+    'aria-label',
+    "Eliza's ledger",
+  )
 })

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -44,7 +44,7 @@ import { demoSnapshotWilds } from './demo/demo-snapshot-wilds'
 import { HandTray } from './hand-tray'
 import { computeHoverCities } from './hover-highlight'
 import { GameOverScreen, PassGate } from './overlays'
-import { PlayerLedger } from './player-ledger'
+import { OpenMatButton, PlayerLedger } from './player-ledger'
 import { PlayerRail } from './player-rail'
 import { SetupScreen } from './setup-screen'
 import { JournalPanel, MarketsPanel } from './side-panels'
@@ -880,7 +880,7 @@ function GameInner({
         </div>
 
         <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
-          <div className="bb2-panel p-4">
+          <div className="bb2-panel flex flex-col gap-3 p-4">
             {!needsReveal && (
               <ActionDock
                 snapshot={state as GameStoreSnapshot}
@@ -896,6 +896,9 @@ function GameInner({
                 legalSiteCount={pickingSite ? (legalCities?.size ?? 0) : null}
                 onUndo={canUndo ? onUndo : null}
               />
+            )}
+            {!needsReveal && (
+              <OpenMatButton onClick={() => setLedgerFor(currentPlayer.id)} />
             )}
           </div>
           <MarketsPanel

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -240,6 +240,17 @@ export function LaurelIcon(p: IconProps) {
   )
 }
 
+// The player mat: a tile board of unflipped industry slots.
+export function MatIcon(p: IconProps) {
+  return base(
+    p,
+    <>
+      <rect x="3" y="5" width="18" height="14" rx="1.5" />
+      <path d="M3 12h18M9 5v14M15 5v14" />
+    </>,
+  )
+}
+
 export function CardsIcon(p: IconProps) {
   return base(
     p,

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -25,7 +25,7 @@ import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
 import { HandTray } from '../hand-tray'
 import { computeHoverCities } from '../hover-highlight'
 import { GameOverScreen } from '../overlays'
-import { PlayerLedger } from '../player-ledger'
+import { OpenMatButton, PlayerLedger } from '../player-ledger'
 import { PlayerRail } from '../player-rail'
 import { CollapsiblePanel, JournalPanel, MarketsPanel } from '../side-panels'
 import { didBecomeMyTurn, playTurnChime, titleForTurn } from './turnNotify'
@@ -1175,7 +1175,7 @@ function MpTable({
 
         <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
           <div
-            className={`bb2-panel p-4 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
+            className={`bb2-panel flex flex-col gap-3 p-4 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
             aria-busy={myTurn && inFlight}
           >
             {myTurn ? (
@@ -1242,6 +1242,8 @@ function MpTable({
                 </p>
               </div>
             )}
+            {/* Always yours, never the seat that happens to be acting. */}
+            {me && <OpenMatButton onClick={() => setLedgerFor(me.id)} />}
           </div>
           {view.ai && <AiMindPanel ai={view.ai} seats={view.seats} />}
           <MarketsPanel

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 // The player ledger — the digital equivalent of the physical player mat.
-// Opened from a player's rail card: remaining industry tiles by type and
+// Opened from a player's rail card or the dock's OpenMatButton: remaining
+// industry tiles by type and
 // level (cost, VP, resource needs, next-buildable highlight), plus the
 // works and routes already on the board.
 import { useEffect } from 'react'
@@ -14,6 +15,7 @@ import {
   IncomeIcon,
   IndustryGlyph,
   LaurelIcon,
+  MatIcon,
   RailIcon,
 } from './icons'
 
@@ -408,5 +410,22 @@ export function PlayerLedger({
         </div>
       </div>
     </div>
+  )
+}
+
+// The mat is also reachable by tapping your own rail card, which is not
+// discoverable — this is the signposted way in, sat under the dock.
+export function OpenMatButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="bb2-ghost-btn flex items-center justify-center gap-2"
+      data-testid="open-player-mat"
+      onClick={onClick}
+      title="Your remaining industry tiles, works and routes"
+    >
+      <MatIcon size={14} />
+      Your player mat
+    </button>
   )
 }


### PR DESCRIPTION
## Summary

Opening your player mat required knowing you could click your own name in the player rail — nothing advertised it. This adds a labelled **Your player mat** button directly under the actions in the dock, on both the hotseat and multiplayer surfaces.

Clicking your rail card still works; the button is an addition, not a replacement.

## Notes

- **Multiplayer opens YOUR mat**, not the acting seat's — so it stays useful while you wait on an opponent. The hotseat opens the acting player's mat, which is the same thing there.
- Works at every player count (nothing is seat-count dependent) and is hidden behind the pass-the-device curtain, like the rest of the dock.
- Styled with the existing `bb2-ghost-btn`, matching the Undo button beside it, plus a small mat glyph in the established stroke-icon set.
- Deliberately localized: `action-dock.tsx` is **untouched**, to avoid fighting the concurrent beer/iron picker work.

## Screenshots

### The button in the dock, under "Pass the turn"
![Dock button](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-21-images/dock-button.png)

### It opens the mat — same overlay the name-click gives you
![Mat opened](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-21-images/mat-opened.png)

### Multiplayer: opens YOUR mat while waiting on the opponent
Verified against a real server-backed game — the Host is acting, I am Player 2, and the button opens *Player 2's* ledger.

![Multiplayer your mat](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-21-images/mp-your-mat.png)

## Testing

- New e2e case pins both routes in (button *and* rail card) and that the button opens the acting player's mat.
- `pnpm test`: 298 passed. The 2 failing DB-backed *files* fail identically on an untouched tree — this worktree has no DB credentials.
- `pnpm exec playwright test`: 19 passed. `multiplayer.spec.ts` is flaky against the shared network DB here — I confirmed it fails on the untouched tree too (pre-existing, unrelated).
- `pnpm typecheck` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
