### PR TITLE
fix(engine): rail era must Develop past canal-only L1 tiles, not skip them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,10 +188,18 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   builder already has a tile there, the build MUST replace it (own
   overbuild) even when another slot is free; enforced in
   `canPlaceOrOverbuildIndustry` + `buildIndustryTile`, pinned by
-  `gameStore.canalrule.test.ts`. Known adjacent gap: in the Rail Era the
-  guard auto-SKIPS unbuildable canal-only L1 mat tiles to the next level,
-  but rules p.7 say those tiles must be removed via Develop first (and the
-  era-ignorant `selectIndustryType` action can disagree with the guard).
+  `gameStore.canalrule.test.ts`.
+  ONLY THE MAT'S LOWEST TILE IS EVER BUILDABLE (era rule, fixed 2026-07-16):
+  rules p.4 step 2 takes the lowest tile, p.7 bars tiles showing the era's
+  half-circle — so a barred tile BLOCKS its industry until Develop removes
+  it; never fall through to the next level (that is a free Develop). Ask
+  `getBuildableTileInEra` (`src/data/industryTiles.ts`) rather than
+  filtering a mat by era and taking the lowest of the remainder — that
+  inversion was the bug, in `selectCard` + `canSelectIndustryType` + the
+  mat UI's "next tile" highlight alike. Which tiles are barred is tile
+  data (`canBuildInCanalEra`/`canBuildInRailEra`, incl. the L1-Pottery
+  rail exception), never a level check. Pinned by
+  `gameStore.railera.test.ts`.
   Wild cards route through the full build flow: wild location picks
   industry then ANY city; wild industry picks industry then a network
   city. Regression tests: `gameStore.bugfixes.test.ts`, `e2e/bugfixes.spec.ts`.

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -166,13 +166,11 @@ export function PlayerLedger({
               const rows = [...(player.industryTilesOnMat[t] ?? [])].sort(
                 (a, b) => a.tile.level - b.tile.level,
               )
-              const nextIdx = rows.findIndex(
-                (r) =>
-                  r.quantityAvailable > 0 &&
-                  (era === 'canal'
-                    ? r.tile.canBuildInCanalEra
-                    : r.tile.canBuildInRailEra),
-              )
+              // The mat's next tile is simply the lowest one left — never the
+              // next era-legal one. A barred tile blocks the industry until
+              // Develop removes it, so highlighting past it would promise a
+              // build the engine refuses (rules p.4 step 2 / p.7).
+              const nextIdx = rows.findIndex((r) => r.quantityAvailable > 0)
               return (
                 <div key={t} className="flex flex-col gap-1.5">
                   <span
@@ -189,11 +187,15 @@ export function PlayerLedger({
                           ? r.tile.canBuildInCanalEra
                           : r.tile.canBuildInRailEra
                       const depleted = r.quantityAvailable === 0
-                      const isNext = i === nextIdx
+                      // Only the lowest remaining tile is ever in play, and
+                      // only if this era allows it — otherwise it is what the
+                      // player must Develop away.
+                      const isNext = i === nextIdx && eraOk
+                      const isBlocking = i === nextIdx && !eraOk
                       return (
                         <div
                           key={r.tile.id}
-                          className="flex items-center gap-2 rounded border px-2 py-1.5 text-[13px]"
+                          className="flex flex-wrap items-center gap-2 rounded border px-2 py-1.5 text-[13px]"
                           style={{
                             borderColor: isNext
                               ? 'var(--bb-brass-bright)'
@@ -322,6 +324,17 @@ export function PlayerLedger({
                           >
                             ×{r.quantityAvailable}
                           </span>
+                          {isBlocking && (
+                            <span
+                              data-testid={`mat-blocked-${r.tile.id}`}
+                              className="w-full text-[11px] italic"
+                              style={{ color: 'rgba(231,215,177,.5)' }}
+                            >
+                              {era === 'rail'
+                                ? 'canal-era tile — Develop to skip'
+                                : 'rail-era tile — not yet buildable'}
+                            </span>
+                          )}
                         </div>
                       )
                     })}

--- a/src/data/industryTiles.ts
+++ b/src/data/industryTiles.ts
@@ -726,6 +726,26 @@ export function canBuildTileInEra(
   return era === 'canal' ? tile.canBuildInCanalEra : tile.canBuildInRailEra
 }
 
+/**
+ * The one tile an industry can currently build, or null if it can build none.
+ *
+ * Rules p.4 step 2 takes the LOWEST level tile on the mat, and p.7 forbids
+ * building a tile whose slot shows the current era's half-circle. So the
+ * lowest tile is the only candidate: when it is barred, the industry is
+ * unbuildable this era until a Develop action removes the tile — the engine
+ * must NOT quietly fall through to the next level (that would hand out a free
+ * Develop). Level 1 Pottery carries no blue half-circle and is the rulebook's
+ * explicit Rail Era exception; that lives in the tile data, not here.
+ */
+export function getBuildableTileInEra(
+  tilesWithQuantity: IndustryTileWithQuantity[],
+  era: 'canal' | 'rail',
+): IndustryTile | null {
+  const lowest = getLowestAvailableTile(tilesWithQuantity)
+  if (!lowest) return null
+  return canBuildTileInEra(lowest, era) ? lowest : null
+}
+
 export function canDevelopTile(tile: IndustryTile): boolean {
   return !tile.hasLightbulbIcon
 }

--- a/src/store/build/buildActions.ts
+++ b/src/store/build/buildActions.ts
@@ -1,7 +1,10 @@
 import type { GameState, Player } from '../gameStore'
 import type { Card, IndustryCard, LocationCard } from '../../data/cards'
 import type { IndustryTile } from '../../data/industryTiles'
-import { decrementTileQuantity } from '../../data/industryTiles'
+import {
+  canBuildTileInEra,
+  decrementTileQuantity,
+} from '../../data/industryTiles'
 import type { CityId } from '../../data/board'
 import {
   advanceIncomeSpaces,
@@ -196,12 +199,24 @@ export function validateCardIndustryMatching(card: Card, selectedIndustryTile: I
   }
 }
 
-export function validateTileEraCompatibility(context: GameState, tile: IndustryTile): void {
-  if (context.era === 'canal' && !tile.canBuildInCanalEra) {
-    throw new Error(`Cannot build ${tile.type} Level ${tile.level} in Canal Era`)
+/**
+ * Why a tile's slot is barred this era, phrased so the player knows the way
+ * out: a canal-only tile (blue half-circle) is removed with Develop, not
+ * skipped (rules p.7).
+ */
+export function eraRestrictionMessage(
+  tile: IndustryTile,
+  era: GameState['era'],
+): string {
+  if (era === 'rail') {
+    return `Cannot build ${tile.type} Level ${tile.level} in the Rail Era — it is a canal-era tile; Develop to remove it first`
   }
-  if (context.era === 'rail' && !tile.canBuildInRailEra) {
-    throw new Error(`Cannot build ${tile.type} Level ${tile.level} in Rail Era`)
+  return `Cannot build ${tile.type} Level ${tile.level} in the Canal Era — it is a rail-era tile`
+}
+
+export function validateTileEraCompatibility(context: GameState, tile: IndustryTile): void {
+  if (!canBuildTileInEra(tile, context.era)) {
+    throw new Error(eraRestrictionMessage(tile, context.era))
   }
 }
 

--- a/src/store/gameStore.cardSelection.test.ts
+++ b/src/store/gameStore.cardSelection.test.ts
@@ -157,13 +157,11 @@ describe('Game Store - Card Selection Auto-behavior', () => {
 
     snapshot = actor.getSnapshot()
 
-    // In rail era, level 1 coal mines can't be built (canBuildInRailEra: false)
-    // So it should select the next available tile (level 2) or be null if none available
-    const selectedTile = snapshot.context.selectedIndustryTile
-    if (selectedTile) {
-      expect(selectedTile.canBuildInRailEra).toBe(true)
-    }
-    // Note: The exact behavior depends on what tiles are available in rail era
+    // The mat's lowest coal tile is the canal-only L1, so in the Rail Era
+    // NOTHING is selected — the player must Develop it away first. Selecting
+    // the L2 instead would be a free Develop (rules p.4 step 2 / p.7); see
+    // gameStore.railera.test.ts.
+    expect(snapshot.context.selectedIndustryTile).toBeNull()
   })
 
   test('wild industry card auto-selects first available industry type', () => {

--- a/src/store/gameStore.railera.test.ts
+++ b/src/store/gameStore.railera.test.ts
@@ -1,0 +1,291 @@
+// Rail-era canal-only tile rule (crew-flagged gap, fixed 2026-07-16).
+// RULES (ai-docs/brass-birmingham-rules.mdc):
+//   p.4 step 2 — "Take the LOWEST level tile of the chosen industry from
+//     your Player Mat and place it..."
+//   p.7 "Rail Era Building" — "Industry tiles with a blue half-circle to the
+//     left of their slot on your Player Mat may not be built. To remove these
+//     tiles (and access the higher level tiles) you must perform the develop
+//     action."
+//   p.9 — "Unlike the other level 1 Industry tiles, the level 1 Pottery tile
+//     may be built during the Rail Era."
+// Together: the ONLY candidate tile is the lowest remaining on the mat. If it
+// is canal-only (blue half-circle), that industry is unbuildable this era
+// until Develop removes it. The engine used to filter era-illegal tiles OUT
+// and then take the lowest of the remainder — silently auto-skipping the
+// canal-only L1 and letting the player build L2 for free.
+import { describe, expect, it } from 'vitest'
+import { createActor } from 'xstate'
+import {
+  getBuildableTileInEra,
+  industryTileDefinitions,
+} from '../data/industryTiles'
+import { eraRestrictionMessage } from './build/buildActions'
+import { gameStore } from './gameStore'
+
+const PLAYERS = [
+  { id: '1', name: 'P1', color: 'red', character: 'A' },
+  { id: '2', name: 'P2', color: 'blue', character: 'B' },
+].map((p) => ({
+  ...p,
+  money: 17,
+  victoryPoints: 0,
+  income: 0,
+  industryTilesOnMat: {},
+}))
+
+type Snap = {
+  can: (e: unknown) => boolean
+  context: {
+    era: string
+    lastError: string | null
+    currentPlayerIndex: number
+    selectedIndustryTile: { level: number; type: string } | null
+    players: Array<{
+      industries: Array<{ type: string; location: string; level: number }>
+      industryTilesOnMat: Record<
+        string,
+        Array<{ tile: { level: number }; quantityAvailable: number }>
+      >
+    }>
+  }
+}
+
+type AnyActor = ReturnType<typeof createActor>
+const snap = (a: AnyActor) => a.getSnapshot() as unknown as Snap
+
+const tilesAt = (a: AnyActor, loc: string) =>
+  snap(a)
+    .context.players[0]!.industries.filter((i) => i.location === loc)
+    .map((i) => `${i.type}L${i.level}`)
+    .sort()
+
+/** Levels still on P1's mat for an industry, lowest first. */
+const matLevels = (a: AnyActor, type: string) =>
+  (snap(a).context.players[0]!.industryTilesOnMat[type] ?? [])
+    .filter((r) => r.quantityAvailable > 0)
+    .map((r) => r.tile.level)
+    .sort((x, y) => x - y)
+
+/** Burn other players' turns until P1 is on the clock. */
+const untilP1 = (a: AnyActor) => {
+  for (let i = 0; i < 12 && snap(a).context.currentPlayerIndex !== 0; i++) {
+    a.send({ type: 'PASS' } as never)
+  }
+  expect(snap(a).context.currentPlayerIndex).toBe(0)
+}
+
+const start = (era: 'canal' | 'rail') => {
+  const a = createActor(gameStore)
+  a.start()
+  a.send({ type: 'START_GAME', players: PLAYERS } as never)
+  a.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 0, money: 300 } as never)
+  a.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 1, money: 300 } as never)
+  if (era === 'rail') a.send({ type: 'TEST_SET_ERA', era: 'rail' } as never)
+  return a
+}
+
+const giveLocationCard = (a: AnyActor, id: string, location: string) =>
+  a.send({
+    type: 'TEST_SET_PLAYER_HAND',
+    playerId: 0,
+    hand: [{ id, type: 'location', location, color: 'other' }],
+  } as never)
+
+const giveIndustryCard = (a: AnyActor, id: string, industries: string[]) =>
+  a.send({
+    type: 'TEST_SET_PLAYER_HAND',
+    playerId: 0,
+    hand: [{ id, type: 'industry', industries }],
+  } as never)
+
+const unwind = (a: AnyActor) => {
+  a.send({ type: 'CLEAR_ERROR' } as never)
+  for (let i = 0; i < 5; i++) a.send({ type: 'CANCEL' } as never)
+}
+
+/** Full build attempt; returns lastError (null on success). */
+const buildAs = (a: AnyActor, cardId: string, industryType: string) => {
+  a.send({ type: 'BUILD' } as never)
+  a.send({ type: 'SELECT_CARD', cardId } as never)
+  a.send({ type: 'SELECT_INDUSTRY_TYPE', industryType } as never)
+  a.send({ type: 'CONFIRM' } as never)
+  const err = snap(a).context.lastError
+  unwind(a)
+  return err
+}
+
+describe('rail era: canal-only L1 tiles are NOT buildable (Develop first)', () => {
+  it('the guard refuses the industry step while the canal-only coal L1 is on the mat', () => {
+    const a = start('rail')
+    untilP1(a)
+    giveLocationCard(a, 'du1', 'dudley')
+
+    // The mat's lowest coal tile is L1 (canal-only, blue half-circle).
+    expect(matLevels(a, 'coal')[0]).toBe(1)
+
+    a.send({ type: 'BUILD' } as never)
+    a.send({ type: 'SELECT_CARD', cardId: 'du1' } as never)
+    expect(
+      snap(a).can({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'coal' }),
+    ).toBe(false)
+    unwind(a)
+    a.stop()
+  })
+
+  it('forcing the build through anyway places NOTHING and does not skip to L2', () => {
+    const a = start('rail')
+    untilP1(a)
+    giveLocationCard(a, 'du1', 'dudley')
+
+    buildAs(a, 'du1', 'coal')
+
+    expect(tilesAt(a, 'dudley')).toStrictEqual([])
+    // The L1 is still on the mat — only Develop removes it.
+    expect(matLevels(a, 'coal')[0]).toBe(1)
+    a.stop()
+  })
+
+  it('the action agrees with the guard: a forced select errors instead of picking L2', () => {
+    const a = start('rail')
+    untilP1(a)
+    giveLocationCard(a, 'du1', 'dudley')
+
+    a.send({ type: 'BUILD' } as never)
+    a.send({ type: 'SELECT_CARD', cardId: 'du1' } as never)
+    // The guard already refuses this event; selectIndustryType used to be
+    // era-ignorant and disagree with it, leaving a dead-end where the tile
+    // was selected but the build could never execute.
+    a.send({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'coal' } as never)
+    expect(snap(a).context.selectedIndustryTile).toBeNull()
+    unwind(a)
+    a.stop()
+  })
+
+  it('an INDUSTRY card does not auto-select past the canal-only L1 either', () => {
+    const a = start('rail')
+    untilP1(a)
+    giveIndustryCard(a, 'coalcard', ['coal'])
+
+    a.send({ type: 'BUILD' } as never)
+    a.send({ type: 'SELECT_CARD', cardId: 'coalcard' } as never)
+
+    // Before the fix this auto-selected coal L2, handing the player a free
+    // level skip that the rules charge a Develop action for.
+    expect(snap(a).context.selectedIndustryTile).toBeNull()
+    unwind(a)
+    a.stop()
+  })
+
+  it('Develop removes the L1, and THEN the L2 builds', () => {
+    const a = start('rail')
+    untilP1(a)
+    expect(matLevels(a, 'coal')[0]).toBe(1)
+
+    // Develop away the canal-only coal L1.
+    giveLocationCard(a, 'dev1', 'dudley')
+    a.send({ type: 'DEVELOP' } as never)
+    a.send({ type: 'SELECT_CARD', cardId: 'dev1' } as never)
+    a.send({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['coal'],
+    } as never)
+    a.send({ type: 'CONFIRM' } as never)
+    a.send({ type: 'CONFIRM' } as never)
+    expect(snap(a).context.lastError).toBeNull()
+
+    // The L1 is gone; L2 is now the lowest and IS rail-legal.
+    expect(matLevels(a, 'coal')[0]).toBe(2)
+
+    untilP1(a)
+    giveLocationCard(a, 'du2', 'dudley')
+    expect(buildAs(a, 'du2', 'coal')).toBeNull()
+    expect(tilesAt(a, 'dudley')).toStrictEqual(['coalL2'])
+    a.stop()
+  })
+
+  it('level 1 POTTERY is the rulebook exception — still buildable in the Rail Era', () => {
+    const a = start('rail')
+    untilP1(a)
+    // Pottery L1 has no blue half-circle (rules p.9).
+    expect(matLevels(a, 'pottery')[0]).toBe(1)
+    giveLocationCard(a, 'st1', 'stoke')
+    expect(buildAs(a, 'st1', 'pottery')).toBeNull()
+    expect(tilesAt(a, 'stoke')).toStrictEqual(['potteryL1'])
+    a.stop()
+  })
+})
+
+describe('getBuildableTileInEra: lowest tile, or nothing', () => {
+  /** Whole-mat rows for an industry, as the player starts the game. */
+  const mat = (type: string) =>
+    (industryTileDefinitions[type] ?? []).map((tile) => ({
+      tile,
+      quantityAvailable: tile.quantity,
+    }))
+
+  /** Mat rows with every tile below `from` already developed away. */
+  const matFrom = (type: string, from: number) =>
+    mat(type).map((r) =>
+      r.tile.level < from ? { ...r, quantityAvailable: 0 } : r,
+    )
+
+  it('returns null in rail era while a canal-only L1 blocks the industry', () => {
+    for (const type of ['coal', 'iron', 'cotton', 'manufacturer', 'brewery']) {
+      expect(getBuildableTileInEra(mat(type), 'rail')).toBeNull()
+      expect(getBuildableTileInEra(mat(type), 'canal')?.level).toBe(1)
+    }
+  })
+
+  it('returns the L2 once the blocking L1 is gone', () => {
+    expect(getBuildableTileInEra(matFrom('coal', 2), 'rail')?.level).toBe(2)
+  })
+
+  it('pottery L1 is buildable in BOTH eras (rulebook exception)', () => {
+    expect(getBuildableTileInEra(mat('pottery'), 'rail')?.level).toBe(1)
+    expect(getBuildableTileInEra(mat('pottery'), 'canal')?.level).toBe(1)
+  })
+
+  it('rail-only top tiles are refused in the canal era, not skipped down', () => {
+    // pottery V and brewery IV carry the black half-circle instead.
+    expect(getBuildableTileInEra(matFrom('pottery', 5), 'canal')).toBeNull()
+    expect(getBuildableTileInEra(matFrom('pottery', 5), 'rail')?.level).toBe(5)
+    expect(getBuildableTileInEra(matFrom('brewery', 4), 'canal')).toBeNull()
+  })
+
+  it('an empty mat yields nothing', () => {
+    expect(getBuildableTileInEra([], 'rail')).toBeNull()
+    expect(getBuildableTileInEra(matFrom('coal', 99), 'rail')).toBeNull()
+  })
+})
+
+describe('eraRestrictionMessage points the player at Develop', () => {
+  it('names the canal-era tile and the Develop way out', () => {
+    const coal1 = industryTileDefinitions.coal![0]!
+    const msg = eraRestrictionMessage(coal1, 'rail')
+    expect(msg).toMatch(/canal/i)
+    expect(msg).toMatch(/develop/i)
+  })
+})
+
+describe('canal era is unaffected', () => {
+  it('the canal-only coal L1 builds normally in the Canal Era', () => {
+    const a = start('canal')
+    untilP1(a)
+    giveLocationCard(a, 'du1', 'dudley')
+    expect(buildAs(a, 'du1', 'coal')).toBeNull()
+    expect(tilesAt(a, 'dudley')).toStrictEqual(['coalL1'])
+    a.stop()
+  })
+
+  it('an industry card still auto-selects the lowest (L1) tile in the Canal Era', () => {
+    const a = start('canal')
+    untilP1(a)
+    giveIndustryCard(a, 'coalcard', ['coal'])
+    a.send({ type: 'BUILD' } as never)
+    a.send({ type: 'SELECT_CARD', cardId: 'coalcard' } as never)
+    expect(snap(a).context.selectedIndustryTile?.level).toBe(1)
+    expect(snap(a).context.selectedIndustryTile?.type).toBe('coal')
+    unwind(a)
+    a.stop()
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -22,7 +22,9 @@ import {
 import {
   type IndustryTile,
   type IndustryTileWithQuantity,
+  canBuildTileInEra,
   decrementTileQuantity,
+  getBuildableTileInEra,
   getInitialPlayerIndustryTiles,
   getInitialPlayerIndustryTilesWithQuantities,
   getLowestAvailableTile,
@@ -31,6 +33,7 @@ import {
 import {
   type ValidationResult,
   buildIndustryTile,
+  eraRestrictionMessage,
   validateBuildActionSelections,
   // Non-throwing validation functions
   validateBuildActionSelectionsResult,
@@ -645,21 +648,14 @@ export const gameStore = setup({
         for (const industryType of industryCard.industries) {
           const tilesWithQuantity =
             player.industryTilesOnMat[industryType] || []
-          const availableTiles = tilesWithQuantity
-            .filter((t) => t.quantityAvailable > 0)
-            .map((t) => t.tile)
-            .filter((tile) => {
-              if (context.era === 'canal') return tile.canBuildInCanalEra
-              if (context.era === 'rail') return tile.canBuildInRailEra
-              return false
-            })
+          const buildableTile = getBuildableTileInEra(
+            tilesWithQuantity,
+            context.era,
+          )
 
-          if (availableTiles.length > 0) {
-            const lowestTile = getLowestLevelTile(availableTiles)
-            if (lowestTile) {
-              result.selectedIndustryTile = lowestTile
-              break
-            }
+          if (buildableTile) {
+            result.selectedIndustryTile = buildableTile
+            break
           }
         }
       }
@@ -2046,6 +2042,16 @@ export const gameStore = setup({
         }
       }
 
+      // Stay era-aware so this agrees with canSelectIndustryType: the lowest
+      // tile is the only candidate, and a canal-only one must be Developed
+      // away rather than skipped (rules p.7).
+      if (!canBuildTileInEra(lowestTile, context.era)) {
+        return {
+          lastError: eraRestrictionMessage(lowestTile, context.era),
+          errorContext: 'build' as const,
+        }
+      }
+
       const result: Partial<GameState> = {
         selectedIndustryTile: lowestTile,
       }
@@ -2616,20 +2622,18 @@ export const gameStore = setup({
       if (event.type !== 'SELECT_INDUSTRY_TYPE') return false
       if (!context.selectedCard) return false
 
-      // Check if player has tiles of this industry type available
+      // The mat's lowest tile is the only candidate, and it must be legal in
+      // the current era - a canal-only tile is not skipped, it blocks the
+      // industry until Develop removes it (rules p.4 step 2 / p.7).
       const player = getCurrentPlayer(context)
       const tilesWithQuantity =
         player.industryTilesOnMat[event.industryType] || []
-      const availableTiles = tilesWithQuantity
-        .filter((t) => t.quantityAvailable > 0)
-        .map((t) => t.tile)
-        .filter((tile) => {
-          if (context.era === 'canal') return tile.canBuildInCanalEra
-          if (context.era === 'rail') return tile.canBuildInRailEra
-          return false
-        })
+      const buildableTile = getBuildableTileInEra(
+        tilesWithQuantity,
+        context.era,
+      )
 
-      if (availableTiles.length === 0) {
+      if (!buildableTile) {
         return false
       }
 
@@ -2637,12 +2641,11 @@ export const gameStore = setup({
       // industry type - either in a free slot or as a legal overbuild
       if (context.selectedCard.type === 'location') {
         const locationCard = context.selectedCard as LocationCard
-        const lowestTile = getLowestLevelTile(availableTiles)
         return canPlaceOrOverbuildIndustry(
           context,
           locationCard.location as CityId,
           event.industryType,
-          lowestTile?.level ?? 1,
+          buildableTile.level,
         )
       }
 


### PR DESCRIPTION
## The rule

Two rules compose (`ai-docs/brass-birmingham-rules.mdc`):

- **p.4, Build step 2** — "Take the **lowest level tile** of the chosen industry from your Player Mat..."
- **p.7, Rail Era Building** — "Industry tiles with a blue half-circle to the left of their slot on your Player Mat may not be built. **To remove these tiles (and access the higher level tiles) you must perform the develop action.**"

So the mat's lowest tile is the *only* build candidate. When it's barred, that industry is unbuildable for the era until Develop removes it — you never fall through to the next level.

## The bug

The engine had the composition **inverted**: it filtered era-illegal tiles *out*, then took the lowest of what remained. In the Rail Era that silently skipped the canal-only L1 and handed the player the L2 — a free Develop action, plus the iron it costs.

The inversion sat in three places, all now asking one helper (`getBuildableTileInEra`):

| | Before | After |
|---|---|---|
| `selectCard` | industry card auto-selected coal **L2** while coal L1 sat on the mat | selects nothing |
| `canSelectIndustryType` | guard reported the industry legal on the strength of a tile the build would never use | refuses |
| mat UI | highlighted the next era-legal tile as "next out of the mat" | highlights nothing; greys the blocker |

The guard defect had a second edge: `selectIndustryType` was era-*ignorant*, so it picked the real (barred) lowest tile while the guard had approved on the L2. Guard and action disagreed and the flow dead-ended in an error the UI could never surface. They now agree.

## Data gap: none

`canBuildInCanalEra` / `canBuildInRailEra` were already correct and complete — including the L1-Pottery Rail Era exception (p.9) and the rail-only Pottery V / Brewery IV. The markers just weren't being *applied* correctly. Barred-ness stays tile data, never a level check.

## Scope

Fixed in the `canPlaceOrOverbuildIndustry` guard family, so the UI affordances, the mp server and the AI's legal-move enumeration all inherit it — each derives legality from the machine's `can()`.

**Canal era is unaffected** by construction: its only barred tiles (Pottery V, Brewery IV) are the top of their tracks, so there was never a lower tile to skip to. Pinned by tests anyway.

## UI (disable-not-hide)

The blocker is greyed with `canal-era tile — Develop to skip`, and no longer highlights the tile behind it. Note Cotton I (×3, blocked) — Cotton II is no longer brass-ringed as "next", which was exactly the free skip. Coal/Pottery/Brewery correctly ring their lowest *available* tile, and Pottery I is not blocked. The existing legend ("Lowest level builds first… Greyed tiles cannot be built in the rail era") now tells the truth.

![Rail-era player mat: canal-only L1 tiles greyed with "Develop to skip"; the L2 behind them is no longer highlighted](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-22-images/rail-era-mat-blocked-tiles.png)

## Tests

`gameStore.railera.test.ts` (14 new) pins: rail-era refusal at guard and action, Develop-then-build-L2, the Pottery L1 exception, rail-only tiles not skipped *down* in the canal era, and canal era unaffected.

`gameStore.cardSelection.test.ts` had an `if (selectedTile)` that made the old auto-skip pass vacuously — tightened to assert the rule.

## Verification

- Offline suite **322 passed** (+14), e2e **17 passed**, typecheck + lint clean.
- Two pre-existing conditions, identical on the untouched baseline commit and **not** introduced here:
  - `buildValidation.test.ts > allows building when some compatible slots are available` fails on baseline too (slot availability, unrelated to era) — left alone rather than widen scope.
  - `gameStore.multiplayer.test.ts` / `mp-ai.test.ts` can't run in this worktree (no `DATABASE_URL`; the only local credential points at the `dev` branch, which AGENTS.md says tests must never hit). CI provisions its own Neon branch and will cover them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
