### PR TITLE
Round-end curtain: announce the round, the spends, and the turn-order switch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -400,6 +400,19 @@ When updating this file, preserve this bar for all agents and keep entries conci
   passesToGameOver in generate-demo.test.ts) so a freeze condition is
   asserted by the machine's own guards, never re-implemented.
 
+- ROUND CURTAIN (2026-07-16): `nextPlayer` records a `RoundSummary` in context
+  (`context.roundSummary`) when a round completes — the round that ended, its
+  spends, the previous + installed turn orders, the income settlement as a real
+  money delta, and `eraEnded`. It exists because `nextPlayer` overwrites
+  `playerSpending`/`turnOrder` in the SAME assign that reorders, so nothing
+  downstream could otherwise see what a round did; never recompute the order
+  switch in the UI, render from the summary. `RoundCurtain` (`overlays.tsx`) is
+  shared by both surfaces: hotseat (`game.tsx`, z-60, sits ABOVE the pass gate —
+  any e2e loop that passes turns must dismiss it, see `coverage.spec.ts`) and
+  multiplayer (`mp-game.tsx`, `MP_CURTAIN_MS` auto-lift, since nobody hands the
+  device on). Both seed "already seen" from the booted snapshot so a resume/join
+  never replays an old round. The summary is PUBLIC (spends and turn order are
+  visible at any table) and passes `filterSnapshotForSeat` unfiltered.
 - UNDO (2026-07-15) is HOTSEAT-ONLY and shell-level: `game.tsx` snapshots the
   machine at turn start (`turnAnchor`) and remounts from it; one action
   undoable while the same player still has an action left. Multiplayer undo

--- a/e2e/coverage.spec.ts
+++ b/e2e/coverage.spec.ts
@@ -263,6 +263,9 @@ test('capstone: play the final turns through the UI to the winner', async ({
   const finished = page.getByText('The books are closed')
   for (let i = 0; i < 45; i++) {
     if (await finished.isVisible().catch(() => false)) break
+    // A round closing raises the round curtain over the pass gate; lift it.
+    const curtain = page.getByTestId('round-curtain-dismiss')
+    if (await curtain.isVisible().catch(() => false)) await curtain.click()
     await revealIfGated(page)
     const pass = page.getByTestId('action-pass')
     if (await pass.isVisible().catch(() => false)) {

--- a/e2e/round-curtain.spec.ts
+++ b/e2e/round-curtain.spec.ts
@@ -1,0 +1,112 @@
+import { type Page, expect, test } from '@playwright/test'
+
+/**
+ * The round-end curtain: a round closing announces itself with what each
+ * player spent and the spend-driven turn-order switch.
+ *
+ * ?fresh=1 with 2 players is fully deterministic — canal round 1, one action
+ * each — so a link build (£3) against a pass (£0) makes the reorder exact.
+ */
+
+/**
+ * Pass a whole turn. Pass is two-tap and the arm lapses after 4s, so wait for
+ * the armed label before the confirming tap — otherwise a loaded machine can
+ * let the arm expire between clicks and the turn silently never passes.
+ */
+async function passTurn(page: Page) {
+  const pass = page.getByTestId('action-pass')
+  await pass.click()
+  await expect(pass).toContainText('Really pass?')
+  await pass.click()
+}
+
+/** Click a map route ON its stroke — routes are curved, so bbox-centre misses. */
+async function clickRoute(page: Page, conn: string) {
+  const path = page.locator(`path[data-conn="${conn}"]`)
+  const pt = await path.evaluate((el) => {
+    const p = el as unknown as SVGPathElement
+    const mid = p.getPointAtLength(p.getTotalLength() / 2)
+    const sp = new DOMPoint(mid.x, mid.y).matrixTransform(p.getScreenCTM()!)
+    return { x: sp.x, y: sp.y }
+  })
+  await page.mouse.click(pt.x, pt.y)
+}
+
+test('round end: curtain reports spends and switches the turn order', async ({
+  page,
+}) => {
+  await page.goto('/?fresh=1')
+  await page.getByRole('button', { name: '2', exact: true }).click()
+  await page.getByPlaceholder('Eliza').fill('Ada')
+  await page.getByRole('button', { name: 'Open the ledger' }).click()
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 1')
+
+  // Ada claims a canal route — £3 spent.
+  await page.getByTestId('action-network').click()
+  await page.locator('button.bb2-card:not([disabled])').first().click()
+  const legal = page.locator('path[data-conn][data-legal="true"]').first()
+  await clickRoute(page, (await legal.getAttribute('data-conn'))!)
+  await page.getByTestId('confirm-action').click()
+
+  // No curtain yet — the round is only half played.
+  await expect(page.getByTestId('round-curtain')).toBeHidden()
+
+  // Player two passes — £0 spent, and the round closes. Pass is two-tap:
+  // the first click arms it, the second confirms.
+  await page.getByTestId('reveal-hand').click()
+  await passTurn(page)
+
+  const curtain = page.getByTestId('round-curtain')
+  await expect(curtain).toBeVisible()
+  await expect(curtain.getByText('Round 1 complete')).toBeVisible()
+
+  // The spends that drove the switch, per player.
+  await expect(page.getByTestId('curtain-spend-1')).toContainText('£3')
+  await expect(page.getByTestId('curtain-spend-2')).toContainText('£0')
+
+  // The £0 spender now leads: rank 1 belongs to player 2, not Ada.
+  await expect(page.getByTestId('curtain-order-2')).toHaveAttribute(
+    'data-rank',
+    '1',
+  )
+  await expect(page.getByTestId('curtain-order-1')).toHaveAttribute(
+    'data-rank',
+    '2',
+  )
+
+  // Dismissing hands the board back, in the new round.
+  await page.getByTestId('round-curtain-dismiss').click()
+  await expect(curtain).toBeHidden()
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 2')
+})
+
+test('round curtain: any key dismisses it and it does not return', async ({
+  page,
+}) => {
+  await page.goto('/?fresh=1')
+  await page.getByRole('button', { name: '2', exact: true }).click()
+  await page.getByRole('button', { name: 'Open the ledger' }).click()
+
+  // Both players pass out the round — equal £0 spends, order preserved.
+  for (let i = 0; i < 2; i++) {
+    const reveal = page.getByTestId('reveal-hand')
+    if (await reveal.isVisible().catch(() => false)) await reveal.click()
+    await passTurn(page)
+  }
+
+  const curtain = page.getByTestId('round-curtain')
+  await expect(curtain).toBeVisible()
+  await expect(page.getByTestId('curtain-order-1')).toHaveAttribute(
+    'data-rank',
+    '1',
+  )
+
+  await page.keyboard.press('Escape')
+  await expect(curtain).toBeHidden()
+
+  // The next player's turn proceeds with the curtain gone for good.
+  const reveal = page.getByTestId('reveal-hand')
+  if (await reveal.isVisible().catch(() => false)) await reveal.click()
+  await expect(page.getByTestId('action-pass')).toBeVisible()
+  await expect(curtain).toBeHidden()
+})

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -43,7 +43,7 @@ import { demoSnapshotSell } from './demo/demo-snapshot-sell'
 import { demoSnapshotWilds } from './demo/demo-snapshot-wilds'
 import { HandTray } from './hand-tray'
 import { computeHoverCities } from './hover-highlight'
-import { GameOverScreen, PassGate } from './overlays'
+import { GameOverScreen, PassGate, RoundCurtain } from './overlays'
 import { OpenMatButton, PlayerLedger } from './player-ledger'
 import { PlayerRail } from './player-rail'
 import { SetupScreen } from './setup-screen'
@@ -151,6 +151,18 @@ const snapshotCurrentPlayerId = (snapshot: unknown): string | null => {
     snapshot as { context: { players: Player[]; currentPlayerIndex: number } }
   ).context
   return ctx.players[ctx.currentPlayerIndex]?.id ?? null
+}
+
+/**
+ * The round a booted snapshot's summary already describes — treated as
+ * already-seen, so resuming a save does not replay a curtain for a round the
+ * player finished before the refresh.
+ */
+const snapshotRoundSummaryRound = (snapshot: unknown): number | null => {
+  if (!snapshot) return null
+  const ctx = (snapshot as { context?: { roundSummary?: { round: number } } })
+    .context
+  return ctx?.roundSummary?.round ?? null
 }
 
 interface Boot {
@@ -358,6 +370,12 @@ function GameInner({
   )
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
+  // The round the player has already seen the curtain for. Seeded from the
+  // booted snapshot so resuming a save mid-game never replays an old round's
+  // curtain; a round ending in play bumps roundSummary.round past it.
+  const [curtainSeen, setCurtainSeen] = useState<number | null>(() =>
+    snapshotRoundSummaryRound(boot.snapshot),
+  )
 
   const ctx = state.context
   const currentPlayer: Player | undefined = ctx.players[ctx.currentPlayerIndex]
@@ -932,6 +950,16 @@ function GameInner({
           era={ctx.era}
           isCurrent={ledgerPlayer.id === currentPlayer.id}
           onClose={() => setLedgerFor(null)}
+        />
+      )}
+
+      {/* Round end announces itself above the pass gate: what everyone spent
+          and how the turn order moved because of it. */}
+      {ctx.roundSummary && ctx.roundSummary.round !== curtainSeen && (
+        <RoundCurtain
+          summary={ctx.roundSummary}
+          players={ctx.players}
+          onDismiss={() => setCurtainSeen(ctx.roundSummary!.round)}
         />
       )}
 

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -24,7 +24,7 @@ import { linkKey } from '../board/board-data'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
 import { HandTray } from '../hand-tray'
 import { computeHoverCities } from '../hover-highlight'
-import { GameOverScreen } from '../overlays'
+import { GameOverScreen, RoundCurtain } from '../overlays'
 import { OpenMatButton, PlayerLedger } from '../player-ledger'
 import { PlayerRail } from '../player-rail'
 import { CollapsiblePanel, JournalPanel, MarketsPanel } from '../side-panels'
@@ -101,6 +101,12 @@ const credsKey = (token: string) => `bb-mp-${token}`
 /** Keep the client's chat memory bounded; the recent tail on a full frame is
  *  smaller than this, so a reconnect never loses already-seen lines. */
 const CLIENT_CHAT_CAP = 200
+
+/**
+ * How long the round-end curtain hangs before lifting itself. Nobody hands
+ * this device on, so the curtain must never be the reason a live turn stalls.
+ */
+const MP_CURTAIN_MS = 6000
 
 /**
  * Merge chat lines by `id` (== per-game seq): idempotent union, sorted, capped.
@@ -865,6 +871,16 @@ function MpTable({
     }
   }, [myTurn, view.phase])
 
+  // Round-end curtain. Seeded from the first view we see, so joining or
+  // refreshing mid-game never replays the curtain for an already-finished
+  // round — only a round ending live bumps roundSummary.round past the seed.
+  const [curtainSeen, setCurtainSeen] = useState<number | null>(null)
+  const curtainSeed = useRef<number | null | undefined>(undefined)
+  if (curtainSeed.current === undefined && ctx) {
+    curtainSeed.current = ctx.roundSummary?.round ?? null
+  }
+  const seenRound = curtainSeen ?? curtainSeed.current ?? null
+
   // Era turnover announcement.
   const prevEra = useRef(ctx?.era)
   useEffect(() => {
@@ -1304,6 +1320,17 @@ function MpTable({
           era={ctx.era}
           isCurrent={ledgerPlayer.id === currentPlayer.id}
           onClose={() => setLedgerFor(null)}
+        />
+      )}
+
+      {/* Round end: spends + the order switch. Auto-lifts so it can never
+          stall the next player's turn on a shared, live board. */}
+      {ctx.roundSummary && ctx.roundSummary.round !== seenRound && (
+        <RoundCurtain
+          summary={ctx.roundSummary}
+          players={ctx.players}
+          autoDismissMs={MP_CURTAIN_MS}
+          onDismiss={() => setCurtainSeen(ctx.roundSummary!.round)}
         />
       )}
 

--- a/src/components/overlays.tsx
+++ b/src/components/overlays.tsx
@@ -1,8 +1,13 @@
 'use client'
 
-// Full-screen moments: the pass-the-device curtain and the final scoring.
-import { useMemo, useState } from 'react'
-import { type Merchant, type Player } from '~/store/gameStore'
+// Full-screen moments: the round-end curtain, the pass-the-device curtain and
+// the final scoring.
+import { useEffect, useMemo, useState } from 'react'
+import {
+  type Merchant,
+  type Player,
+  type RoundSummary,
+} from '~/store/gameStore'
 import { BoardMap, PLAYER_FILL } from './board/board-map'
 import { CardBack } from './cards'
 import { IncomeIcon, LaurelIcon, PoundIcon } from './icons'
@@ -11,6 +16,255 @@ import {
   annotationsFor,
   buildBreakdown,
 } from './vp-breakdown'
+
+/** Height of one turn-order row, in px — the animation translates by it. */
+const ORDER_ROW = 46
+
+/**
+ * The round-end interstitial: announces the round that closed, what each
+ * player spent, and animates the spend-driven reordering of the turn order.
+ *
+ * Everything rendered here comes from the engine's own RoundSummary — the
+ * order switch is the one the machine installed, not a recomputed guess.
+ */
+export function RoundCurtain({
+  summary,
+  players,
+  onDismiss,
+  autoDismissMs,
+}: {
+  summary: RoundSummary
+  players: Player[]
+  onDismiss: () => void
+  /** When set, the curtain lifts itself after this long (multiplayer). */
+  autoDismissMs?: number
+}) {
+  // The reorder animates from the old ranking to the new one shortly after
+  // mount, so the switch is legible as a movement rather than a jump cut.
+  const [settled, setSettled] = useState(false)
+  useEffect(() => {
+    const t = setTimeout(() => setSettled(true), 850)
+    return () => clearTimeout(t)
+  }, [])
+
+  useEffect(() => {
+    if (!autoDismissMs) return
+    const t = setTimeout(onDismiss, autoDismissMs)
+    return () => clearTimeout(t)
+  }, [autoDismissMs, onDismiss])
+
+  // Any key lifts the curtain — it is an announcement, never a prompt.
+  useEffect(() => {
+    const onKey = () => onDismiss()
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onDismiss])
+
+  const byId = useMemo(() => new Map(players.map((p) => [p.id, p])), [players])
+  const spendRows = summary.previousOrder
+    .map((id) => byId.get(id))
+    .filter((p): p is Player => Boolean(p))
+  const topSpend = Math.max(
+    1,
+    ...Object.values(summary.spending).map((v) => Math.abs(v)),
+  )
+
+  return (
+    <div
+      className="bb2-curtain fixed inset-0 z-[60] flex flex-col items-center justify-center gap-7 overflow-y-auto p-6"
+      data-testid="round-curtain"
+      style={{
+        background:
+          'radial-gradient(900px 600px at 50% 25%, rgba(214,168,84,.07), transparent 60%), linear-gradient(180deg, rgba(16,13,10,.98), rgba(12,10,8,.99))',
+      }}
+      // A stray click anywhere dismisses; the button below is the signposted way.
+      onClick={onDismiss}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Round ${summary.round} complete`}
+    >
+      <div className="bb2-seal-pop flex flex-col items-center gap-2 text-center">
+        <span
+          className="text-[11px] font-semibold uppercase tracking-[0.34em]"
+          style={{ color: 'rgba(231,215,177,.5)' }}
+        >
+          {summary.era} era
+        </span>
+        <span
+          className="bb2-display text-5xl font-black"
+          style={{ color: 'var(--bb-parchment-bright)' }}
+        >
+          Round {summary.round} complete
+        </span>
+        {summary.eraEnded && (
+          <span
+            className="bb2-chip mt-1"
+            style={{ color: 'var(--bb-brass-bright)' }}
+            data-testid="curtain-era-note"
+          >
+            deck spent — the {summary.era} era closes
+          </span>
+        )}
+      </div>
+
+      <div className="flex w-full max-w-4xl flex-col gap-6 lg:flex-row lg:items-start lg:justify-center">
+        {/* ---------- what everyone spent ---------- */}
+        <section className="flex-1">
+          <h3
+            className="mb-3 text-[11px] font-semibold uppercase tracking-[0.28em]"
+            style={{ color: 'rgba(231,215,177,.5)' }}
+          >
+            Spent this round
+          </h3>
+          <ul className="flex flex-col gap-2">
+            {spendRows.map((p) => {
+              const spent = summary.spending[p.id] ?? 0
+              const income = summary.income[p.id]
+              return (
+                <li
+                  key={p.id}
+                  className="flex items-center gap-3"
+                  data-testid={`curtain-spend-${p.id}`}
+                >
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ background: PLAYER_FILL[p.color] }}
+                  />
+                  <span
+                    className="w-24 shrink-0 truncate text-[13px]"
+                    style={{ color: 'var(--bb-parchment)' }}
+                  >
+                    {p.name}
+                  </span>
+                  {/* Spend bar — relative weight is the thing that decides order. */}
+                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-[rgba(231,215,177,.08)]">
+                    <span
+                      className="bb2-spend-bar block h-full rounded-full"
+                      style={{
+                        width: `${(spent / topSpend) * 100}%`,
+                        background: PLAYER_FILL[p.color],
+                      }}
+                    />
+                  </span>
+                  <span
+                    className="w-12 shrink-0 text-right text-[13px] font-bold tabular-nums"
+                    style={{ color: 'var(--bb-parchment-bright)' }}
+                  >
+                    £{spent}
+                  </span>
+                  {income !== undefined && (
+                    <span
+                      className="w-14 shrink-0 text-right text-[11px] tabular-nums"
+                      style={{
+                        color:
+                          income >= 0 ? 'rgba(150,200,150,.75)' : '#e0968b',
+                      }}
+                      title="income collected at round end"
+                    >
+                      {income >= 0 ? '+' : '−'}£{Math.abs(income)}
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+
+        {/* ---------- the order switch ---------- */}
+        <section className="flex-1">
+          <h3
+            className="mb-3 text-[11px] font-semibold uppercase tracking-[0.28em]"
+            style={{ color: 'rgba(231,215,177,.5)' }}
+          >
+            Turn order — round {summary.round + 1}
+          </h3>
+          <div
+            className="relative"
+            style={{ height: summary.newOrder.length * ORDER_ROW }}
+            data-testid="curtain-order"
+          >
+            {summary.newOrder.map((id) => {
+              const p = byId.get(id)
+              if (!p) return null
+              const from = summary.previousOrder.indexOf(id)
+              const to = summary.newOrder.indexOf(id)
+              const rank = settled ? to : from
+              const moved = to - from
+              return (
+                <div
+                  key={id}
+                  className="bb2-order-row absolute inset-x-0 flex items-center gap-3 rounded border px-3 py-2"
+                  data-testid={`curtain-order-${id}`}
+                  data-rank={to + 1}
+                  style={{
+                    transform: `translateY(${rank * ORDER_ROW}px)`,
+                    borderColor:
+                      settled && to === 0
+                        ? 'var(--bb-brass)'
+                        : 'var(--bb-brass-hairline)',
+                    background: 'rgba(20,16,11,.7)',
+                  }}
+                >
+                  <span
+                    className="bb2-display w-5 shrink-0 text-center text-[15px] font-black tabular-nums"
+                    style={{ color: 'var(--bb-brass-bright)' }}
+                  >
+                    {rank + 1}
+                  </span>
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ background: PLAYER_FILL[p.color] }}
+                  />
+                  <span
+                    className="flex-1 truncate text-[13px]"
+                    style={{ color: 'var(--bb-parchment-bright)' }}
+                  >
+                    {p.name}
+                  </span>
+                  {moved !== 0 && (
+                    <span
+                      className="text-[11px] font-bold tabular-nums transition-opacity duration-300"
+                      style={{
+                        opacity: settled ? 1 : 0,
+                        color: moved < 0 ? 'rgba(150,200,150,.85)' : '#e0968b',
+                      }}
+                    >
+                      {moved < 0 ? '▲' : '▼'} {Math.abs(moved)}
+                    </span>
+                  )}
+                  {settled && to === 0 && (
+                    <span
+                      className="text-[10px] uppercase tracking-[0.2em]"
+                      style={{ color: 'var(--bb-brass)' }}
+                    >
+                      leads
+                    </span>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+          <p
+            className="mt-3 text-[11px] italic"
+            style={{ color: 'rgba(231,215,177,.45)' }}
+          >
+            The lightest spender leads the next round; equal spenders keep their
+            order.
+          </p>
+        </section>
+      </div>
+
+      <button
+        type="button"
+        className="bb2-confirm max-w-xs"
+        data-testid="round-curtain-dismiss"
+        onClick={onDismiss}
+      >
+        Begin round {summary.round + 1}
+      </button>
+    </div>
+  )
+}
 
 export function PassGate({
   player,

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -569,6 +569,35 @@ button.bb2-card {
   animation: bb2-curtain 0.35s ease both;
 }
 
+/* Round curtain: a turn-order row slides from its old rank to its new one. */
+.bb2-order-row {
+  transition: transform 0.7s cubic-bezier(0.34, 1.2, 0.5, 1), border-color 0.4s
+    ease;
+}
+
+.bb2-spend-bar {
+  transform-origin: left center;
+  animation: bb2-spend-grow 0.6s 0.15s ease both;
+}
+
+@keyframes bb2-spend-grow {
+  from {
+    transform: scaleX(0);
+  }
+  to {
+    transform: scaleX(1);
+  }
+}
+
+/* The reorder is decorative; motion-sensitive players get the end state. */
+@media (prefers-reduced-motion: reduce) {
+  .bb2-order-row,
+  .bb2-spend-bar {
+    transition: none;
+    animation: none;
+  }
+}
+
 @keyframes bb2-seal-pop {
   0% {
     transform: scale(0.6) rotate(-8deg);

--- a/src/store/build/buildValidation.test.ts
+++ b/src/store/build/buildValidation.test.ts
@@ -46,6 +46,7 @@ const createTestContext = (overrides: Partial<GameState> = {}): GameState => {
     spentMoney: 0,
     playerSpending: {},
     turnOrder: [],
+    roundSummary: null,
     isFinalRound: false,
     selectedLink: null,
     selectedSecondLink: null,

--- a/src/store/gameStore.roundsummary.test.ts
+++ b/src/store/gameStore.roundsummary.test.ts
@@ -1,0 +1,210 @@
+// Round summary tests — the engine-produced record of a completed round that
+// drives the UI's round-end curtain (spends, order switch, income).
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import { gameStore } from './gameStore'
+
+let activeActors: ReturnType<typeof createActor>[] = []
+
+afterEach(() => {
+  activeActors.forEach((actor) => {
+    try {
+      actor.stop()
+    } catch {}
+  })
+  activeActors = []
+})
+
+const player = (id: string, extra: Record<string, unknown> = {}) => ({
+  id,
+  name: `P${id}`,
+  color: (['red', 'blue', 'green', 'purple'] as const)[Number(id) - 1]!,
+  character: (
+    [
+      'Richard Arkwright',
+      'Eliza Tinsley',
+      'Isambard Kingdom Brunel',
+      'George Stephenson',
+    ] as const
+  )[Number(id) - 1]!,
+  money: 30,
+  victoryPoints: 0,
+  income: 10,
+  industryTilesOnMat: {} as any,
+  ...extra,
+})
+
+const setup = (count = 2, extra: Record<string, unknown> = {}) => {
+  const actor = createActor(gameStore)
+  activeActors.push(actor)
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: Array.from({ length: count }, (_, i) =>
+      player(String(i + 1), extra),
+    ),
+  })
+  return { actor }
+}
+
+/** Current player passes once — consumes one action, spending £0. */
+const pass = (actor: ReturnType<typeof createActor>) => {
+  const s: any = actor.getSnapshot()
+  const p = s.context.players[s.context.currentPlayerIndex]!
+  actor.send({ type: 'PASS' })
+  actor.send({ type: 'SELECT_CARD', cardId: p.hand[0]!.id })
+  actor.send({ type: 'CONFIRM' })
+}
+
+/**
+ * Pass away the current player's WHOLE turn — round 1 grants one action but
+ * every later round grants two, so a single pass would not end the turn.
+ */
+const passTurn = (actor: ReturnType<typeof createActor>) => {
+  const seat = (actor.getSnapshot() as any).context.currentPlayerIndex
+  while ((actor.getSnapshot() as any).context.currentPlayerIndex === seat) {
+    const before = actor.getSnapshot()
+    pass(actor)
+    if (actor.getSnapshot() === before) break // guard against a stuck loop
+  }
+}
+
+/** Current player builds a canal link — spends £3. */
+const buildLink = (
+  actor: ReturnType<typeof createActor>,
+  from: string,
+  to: string,
+) => {
+  const s: any = actor.getSnapshot()
+  const p = s.context.players[s.context.currentPlayerIndex]!
+  actor.send({ type: 'NETWORK' })
+  actor.send({ type: 'SELECT_CARD', cardId: p.hand[0]!.id })
+  actor.send({ type: 'SELECT_LINK', from, to })
+  actor.send({ type: 'CONFIRM' })
+}
+
+describe('Game Store - round summary', () => {
+  test('is null at setup and stays null mid-round', () => {
+    const { actor } = setup()
+    expect(actor.getSnapshot().context.roundSummary).toBeNull()
+
+    pass(actor) // player 1 of 2 — round not complete yet
+    expect(actor.getSnapshot().context.currentPlayerIndex).toBe(1)
+    expect(actor.getSnapshot().context.roundSummary).toBeNull()
+  })
+
+  test('records the completed round, its spends and the resulting order', () => {
+    const { actor } = setup()
+
+    buildLink(actor, 'worcester', 'gloucester') // P1 spends £3
+    pass(actor) // P2 spends £0
+
+    const summary = actor.getSnapshot().context.roundSummary!
+    expect(summary).not.toBeNull()
+    // The round that just ENDED, not the new one.
+    expect(summary.round).toBe(1)
+    expect(actor.getSnapshot().context.round).toBe(2)
+    expect(summary.era).toBe('canal')
+    expect(summary.previousOrder).toEqual(['1', '2'])
+    expect(summary.spending).toEqual({ '1': 3, '2': 0 })
+    // Least spender leads the next round — and the summary agrees with the
+    // order the engine actually installed.
+    expect(summary.newOrder).toEqual(['2', '1'])
+    expect(actor.getSnapshot().context.turnOrder).toEqual(['2', '1'])
+    expect(summary.eraEnded).toBe(false)
+  })
+
+  test('spends survive the reset that clears playerSpending', () => {
+    const { actor } = setup()
+    buildLink(actor, 'worcester', 'gloucester')
+    pass(actor)
+
+    // The live tracker is reset for the new round; the summary keeps the
+    // record the curtain renders from.
+    expect(actor.getSnapshot().context.playerSpending).toEqual({})
+    expect(actor.getSnapshot().context.roundSummary!.spending).toEqual({
+      '1': 3,
+      '2': 0,
+    })
+  })
+
+  test('records income settlement as the real money delta', () => {
+    const { actor } = setup()
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 0, income: 5 })
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 1, income: -2 })
+
+    const before = actor.getSnapshot().context.players.map((p) => p.money)
+    pass(actor)
+    pass(actor)
+
+    const s = actor.getSnapshot()
+    const summary = s.context.roundSummary!
+    expect(summary.income).toEqual({ '1': 5, '2': -2 })
+    // The recorded delta reconciles against the players' actual money.
+    s.context.players.forEach((p, i) => {
+      expect(p.money - before[i]!).toBe(summary.income[p.id])
+    })
+  })
+
+  test('equal spends keep relative order and are still reported', () => {
+    const { actor } = setup(3)
+    pass(actor)
+    pass(actor)
+    pass(actor)
+
+    const summary = actor.getSnapshot().context.roundSummary!
+    expect(summary.spending).toEqual({ '1': 0, '2': 0, '3': 0 })
+    expect(summary.previousOrder).toEqual(['1', '2', '3'])
+    expect(summary.newOrder).toEqual(['1', '2', '3'])
+  })
+
+  test('4-player game reports every seat', () => {
+    const { actor } = setup(4)
+    buildLink(actor, 'worcester', 'gloucester') // P1 £3
+    pass(actor) // P2 £0
+    buildLink(actor, 'birmingham', 'dudley') // P3 £3
+    pass(actor) // P4 £0
+
+    const summary = actor.getSnapshot().context.roundSummary!
+    expect(summary.spending).toEqual({ '1': 3, '2': 0, '3': 3, '4': 0 })
+    // £0 spenders first (stable by previous position), then the £3 spenders.
+    expect(summary.newOrder).toEqual(['2', '4', '1', '3'])
+    expect(actor.getSnapshot().context.turnOrder).toEqual(['2', '4', '1', '3'])
+  })
+
+  test('a later round overwrites the previous summary', () => {
+    const { actor } = setup()
+    passTurn(actor)
+    passTurn(actor)
+    expect(actor.getSnapshot().context.roundSummary!.round).toBe(1)
+
+    passTurn(actor)
+    passTurn(actor)
+    const summary = actor.getSnapshot().context.roundSummary!
+    expect(summary.round).toBe(2)
+    expect(actor.getSnapshot().context.round).toBe(3)
+  })
+
+  test('flags the round whose end exhausts the deck as the era end', () => {
+    const { actor } = setup()
+    // Empty the draw pile and leave each player exactly one card, so the
+    // round that plays them out is the era's last.
+    actor.send({ type: 'TEST_SET_DRAW_PILE', drawPile: [] } as any)
+    const s: any = actor.getSnapshot()
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: 0,
+      hand: [s.context.players[0]!.hand[0]!],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: 1,
+      hand: [s.context.players[1]!.hand[0]!],
+    })
+
+    pass(actor)
+    pass(actor)
+
+    expect(actor.getSnapshot().context.roundSummary!.eraEnded).toBe(true)
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -168,6 +168,26 @@ export interface Player {
   }[]
 }
 
+/** What happened in the round that just ended, as the engine recorded it. */
+export interface RoundSummary {
+  /** The round that ENDED (context.round has already advanced past it). */
+  round: number
+  era: 'canal' | 'rail'
+  /** Turn order used during the round that ended. */
+  previousOrder: string[]
+  /** Turn order installed for the next round (least spender first). */
+  newOrder: string[]
+  /** Money spent per player id during the round that ended. */
+  spending: Record<string, number>
+  /**
+   * Net money change per player id from the end-of-round income settlement.
+   * Empty on the game's final round, where no income is collected.
+   */
+  income: Record<string, number>
+  /** The round's end also exhausted the deck, so the era ends. */
+  eraEnded: boolean
+}
+
 export interface GameState {
   players: Player[]
   currentPlayerIndex: number
@@ -194,6 +214,11 @@ export interface GameState {
   // Round management state
   playerSpending: Record<string, number> // Track spending per player per round
   turnOrder: string[] // Player IDs in turn order (updated each round based on spending)
+  // Record of the most recently completed round. playerSpending/turnOrder are
+  // overwritten the instant a round ends, so this is the only place the UI can
+  // read what actually happened (it drives the round-end curtain). Public
+  // information — every value in it is already visible at the table.
+  roundSummary: RoundSummary | null
   isFinalRound: boolean
   // Network-related state
   selectedLink: {
@@ -616,6 +641,7 @@ export const gameStore = setup({
         spentMoney: 0,
         playerSpending: {},
         turnOrder: players.map((p) => p.id), // Initial turn order
+        roundSummary: null,
         isFinalRound: false,
         selectedLink: null,
         selectedSecondLink: null,
@@ -1806,6 +1832,7 @@ export const gameStore = setup({
       let newTurnOrder = context.turnOrder
       let finalPlayerIndex = context.currentPlayerIndex
       let eraEndPending = false
+      let roundSummary = context.roundSummary
       const logs = [...context.logs]
 
       if (!isRoundComplete) {
@@ -1849,6 +1876,13 @@ export const gameStore = setup({
         eraEndPending = isEraOver
         const isFinalGameRound =
           context.isFinalRound || (context.era === 'rail' && isEraOver)
+
+        // Money before settlement, so the summary can report the income
+        // delta the players actually experienced (a shortfall pays only
+        // what it can) rather than the nominal income figure.
+        const moneyBefore = new Map(
+          updatedPlayers.map((player) => [player.id, player.money]),
+        )
 
         // 2. Collect income (if not final round of the game)
         if (!isFinalGameRound) {
@@ -1965,6 +1999,27 @@ export const gameStore = setup({
           })
         }
 
+        const income: Record<string, number> = {}
+        updatedPlayers.forEach((player) => {
+          const delta = player.money - (moneyBefore.get(player.id) ?? 0)
+          if (delta !== 0) income[player.id] = delta
+        })
+
+        roundSummary = {
+          round: context.round,
+          era: context.era,
+          previousOrder: context.turnOrder,
+          newOrder: newTurnOrder,
+          spending: Object.fromEntries(
+            context.turnOrder.map((playerId) => [
+              playerId,
+              context.playerSpending[playerId] || 0,
+            ]),
+          ),
+          income,
+          eraEnded: isEraOver,
+        }
+
         logs.push(createLogEntry(`Round ${context.round} completed`, 'system'))
 
         if (isEraOver) {
@@ -1985,6 +2040,7 @@ export const gameStore = setup({
         players: updatedPlayers,
         playerSpending: updatedPlayerSpending,
         turnOrder: newTurnOrder,
+        roundSummary,
         eraEndPending,
         selectedCard: null,
         selectedCardsForScout: [],
@@ -2849,6 +2905,7 @@ export const gameStore = setup({
     spentMoney: 0,
     playerSpending: {},
     turnOrder: [],
+    roundSummary: null,
     isFinalRound: false,
     selectedLink: null,
     selectedSecondLink: null,

--- a/src/store/shared/gameUtils.industrySlots.test.ts
+++ b/src/store/shared/gameUtils.industrySlots.test.ts
@@ -88,6 +88,7 @@ const createTestGameState = (
     spentMoney: 0,
     playerSpending: {},
     turnOrder: [],
+    roundSummary: null,
     isFinalRound: false,
     selectedLink: null,
     selectedSecondLink: null,


### PR DESCRIPTION
Closes the captain's ask (2026-07-16): *"round turn is invisible, we could show a courtain screen announcing round end, how much who spended and, maybe even recap and simple animation on the order switch"*.

## The problem

Spend-driven reordering is core Brass, and it happened **silently**. Worse, the UI *couldn't* have shown it: `nextPlayer` overwrites `playerSpending` and `turnOrder` in the same `assign` that reorders, so by the time any component renders, the evidence is gone.

## The approach

Record it in the engine rather than recompute it in the UI. `nextPlayer` now emits a `RoundSummary` — the round that ended, its spends, the previous and installed orders, the income settlement, and whether the deck ran out. The curtain renders straight from it, so **the order it animates is the one the machine installed**, not a guess that could drift from the rules.

Two details worth calling out:

- **Income is recorded as the real money delta**, not the nominal income figure — a player who can't cover negative income pays only what they have. A test pins the delta against the players' actual money.
- **`RoundSummary` is public information** (spends and turn order are visible at any table), so it passes `filterSnapshotForSeat` unfiltered — that filter is a passthrough clone, deliberately verified rather than assumed.

## Behaviour

| | Hotseat | Multiplayer |
|---|---|---|
| Dismiss | click, button, or any key | same, **plus** a 6s auto-lift |
| Sits above | the pass gate (z-60) | the dock |

Multiplayer auto-lifts because nobody hands the device on there, so the curtain must never be why a live turn stalls. Both surfaces seed "already seen" from the booted snapshot, so resuming a save or joining mid-game never replays an old round's curtain. The reorder animation honours `prefers-reduced-motion`.

## Screenshots

Round 8 closing in a live canal game. George spent £12, Isambard £0 — rows first show the order that *was*:

![before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-round-curtain-images/curtain-before-switch.png)

…then slide into the order the engine installed: Isambard rises 3rd→1st (▲2, "leads"), George drops to 3rd (▼2):

![after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-round-curtain-images/curtain-after-switch.png)

Multiplayer, against a live AI rival — same component, auto-lifting:

![multiplayer](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-round-curtain-images/curtain-multiplayer.png)

## Verification

- **8 new engine tests** (TDD, red first) covering 2/3/4 players, tie-stability, the income delta reconciliation, the `playerSpending` reset, overwrite across rounds, and era-end flagging.
- **2 new e2e specs**: a fresh 2-player game where a £3 link build against a £0 pass makes the reorder exact, plus keyboard dismissal.
- **Full suite green**: 306 unit tests pass; 19/21 e2e pass. The two e2e failures (`multiplayer.spec.ts`, `ai-opponent.spec.ts`) are DB-backed — `multiplayer.spec.ts` **fails identically on the base commit** (verified) and `ai-opponent.spec.ts` passes in isolation (load-flaky). The two vitest files that fail locally only need a DB connection string; CI provisions its own Neon branch and will run them.

### One real regression found and fixed

The curtain covers the pass gate, which broke `coverage.spec`'s capstone loop — it passes turns until the books close and could no longer reach `reveal-hand`. The loop now lifts the curtain first: the journey genuinely changed, so the test changed with it rather than being worked around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)