### PR TITLE
fix(ui): explain the double-rail option instead of hiding it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,13 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   for REAL pointers while synthetic `dispatchEvent` clicks still pass (so
   automated tests won't catch it). Capture only after drag movement starts.
   When browser-verifying board clicks, use trusted input (axi `click @ref`),
-  not `dispatchEvent`.
+  not `dispatchEvent`. For ROUTES specifically, axi `click @ref` also misses:
+  it aims at the a11y node's bbox centre, which on a bowed path lies off the
+  hit-stroke (same root cause as the Playwright `clickRoute` helper). Routes
+  are keyboard-activatable when legal, so focus + Enter is the reliable
+  manual path:
+  `axi eval 'document.querySelector("[data-conn=\"belper|leek\"]").focus()'`
+  then `axi press Enter`.
 - The engine's `canBuildLink` guard does NOT check era or the board graph
   (documented rules gap) — the UI enforces era in `legalLinks`/`onLinkClick`
   (`game.tsx`), so keep that filter if the guard ever changes.

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -14,6 +14,10 @@ import {
 import { isDevelopable } from '~/store/shared/gameUtils'
 import { CardChip } from './cards'
 import {
+  doubleLinkDisabledReason,
+  showsDoubleLinkOption,
+} from './double-link-availability'
+import {
   BuildIcon,
   CanalIcon,
   DevelopIcon,
@@ -338,6 +342,50 @@ function Confirm({
       </button>
       {(disabled || refused) && reason && (
         <p className="text-[12.5px] leading-snug" style={{ color: '#d68d80' }}>
+          {reason}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The Rail-Era "two rails for one action" option. It renders DISABLED rather
+ * than vanishing when the machine refuses it: a player with no beer in reach
+ * otherwise saw a plain single-rail confirm and had no way to learn double
+ * rail exists at all.
+ */
+function DoubleLinkOption({
+  enabled,
+  reason,
+  onClick,
+}: {
+  enabled: boolean
+  /** Why it is refused — only read when `enabled` is false. */
+  reason: string
+  onClick: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <button
+        type="button"
+        className="bb2-option justify-center"
+        data-testid="choose-double-link"
+        disabled={!enabled}
+        title={enabled ? undefined : reason}
+        onClick={onClick}
+      >
+        <RailIcon size={14} />
+        <span className="text-[12px] font-semibold">
+          Build two rails — £15 + 2 coal + 1 beer
+        </span>
+      </button>
+      {!enabled && (
+        <p
+          className="text-[12.5px] leading-snug"
+          data-testid="double-link-reason"
+          style={{ color: '#d68d80' }}
+        >
           {reason}
         </p>
       )}
@@ -703,18 +751,12 @@ export function ActionDock({
         >
           Lay the {c.era === 'canal' ? 'canal' : 'track'}
         </Confirm>
-        {can({ type: 'CHOOSE_DOUBLE_LINK_BUILD' }) && (
-          <button
-            type="button"
-            className="bb2-option justify-center"
-            data-testid="choose-double-link"
+        {showsDoubleLinkOption(c) && (
+          <DoubleLinkOption
+            enabled={can({ type: 'CHOOSE_DOUBLE_LINK_BUILD' })}
+            reason={doubleLinkDisabledReason(c)}
             onClick={() => send({ type: 'CHOOSE_DOUBLE_LINK_BUILD' })}
-          >
-            <RailIcon size={14} />
-            <span className="text-[12px] font-semibold">
-              Build two rails — £15 + 2 coal + 1 beer
-            </span>
-          </button>
+          />
         )}
       </Flow>
     )

--- a/src/components/double-link-availability.test.ts
+++ b/src/components/double-link-availability.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import type { GameState } from '~/store/gameStore'
+import {
+  DOUBLE_LINK_GENERIC_REASON,
+  doubleLinkDisabledReason,
+  explainDoubleLinkUnavailable,
+  showsDoubleLinkOption,
+} from './double-link-availability'
+
+const brewery = (beerBarrelsOnTile: number, flipped = false) => ({
+  type: 'brewery',
+  flipped,
+  beerBarrelsOnTile,
+})
+
+const state = (over: Record<string, unknown>): GameState =>
+  ({
+    era: 'rail',
+    selectedLink: { from: 'birmingham', to: 'coventry' },
+    players: [{ id: 'p1', industries: [brewery(1)] }],
+    ...over,
+  }) as unknown as GameState
+
+describe('showsDoubleLinkOption', () => {
+  it('shows the option in the rail era', () => {
+    expect(showsDoubleLinkOption(state({}))).toBe(true)
+  })
+
+  it('hides it in the canal era, where double rail does not exist', () => {
+    expect(showsDoubleLinkOption(state({ era: 'canal' }))).toBe(false)
+  })
+})
+
+describe('explainDoubleLinkUnavailable', () => {
+  it('has nothing to explain when a brewery with beer stands on the board', () => {
+    expect(explainDoubleLinkUnavailable(state({}))).toBeNull()
+  })
+
+  it('accepts an opponent brewery as the beer source, like the engine guard', () => {
+    const reason = explainDoubleLinkUnavailable(
+      state({
+        players: [
+          { id: 'p1', industries: [] },
+          { id: 'p2', industries: [brewery(2)] },
+        ],
+      }),
+    )
+    expect(reason).toBeNull()
+  })
+
+  it('names beer as the missing requirement when no brewery has a barrel', () => {
+    const reason = explainDoubleLinkUnavailable(
+      state({ players: [{ id: 'p1', industries: [brewery(0)] }] }),
+    )
+    expect(reason).toContain('1 beer')
+  })
+
+  it('ignores flipped breweries, which hold no beer', () => {
+    const reason = explainDoubleLinkUnavailable(
+      state({ players: [{ id: 'p1', industries: [brewery(1, true)] }] }),
+    )
+    expect(reason).toContain('1 beer')
+  })
+
+  it('explains the era when asked outside the rail era', () => {
+    expect(explainDoubleLinkUnavailable(state({ era: 'canal' }))).toContain(
+      'Rail Era',
+    )
+  })
+
+  it('explains the missing first route', () => {
+    expect(
+      explainDoubleLinkUnavailable(state({ selectedLink: null })),
+    ).toContain('first route')
+  })
+})
+
+describe('doubleLinkDisabledReason', () => {
+  it('names the missing requirement when it knows one', () => {
+    expect(
+      doubleLinkDisabledReason(
+        state({ players: [{ id: 'p1', industries: [brewery(0)] }] }),
+      ),
+    ).toContain('1 beer')
+  })
+
+  it('falls back to the full price rather than guessing a cause', () => {
+    // Beer is on the board, so this module knows of nothing missing — the
+    // machine refused for a reason it cannot see (money, coal, reach).
+    expect(doubleLinkDisabledReason(state({}))).toBe(DOUBLE_LINK_GENERIC_REASON)
+  })
+
+  it('always yields a sentence to print under the disabled button', () => {
+    for (const s of [
+      state({}),
+      state({ era: 'canal' }),
+      state({ selectedLink: null }),
+      state({ players: [{ id: 'p1', industries: [brewery(0)] }] }),
+    ]) {
+      expect(doubleLinkDisabledReason(s).length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/src/components/double-link-availability.ts
+++ b/src/components/double-link-availability.ts
@@ -1,0 +1,61 @@
+// Why the "Build two rails" affordance is unavailable, in words.
+//
+// The dock used to render that button only when the machine's
+// `CHOOSE_DOUBLE_LINK_BUILD` guard passed, so a player with no reachable
+// beer never saw it at all and double rail looked like it didn't exist.
+// The dock now renders it DISABLED instead, and asks this module what to
+// say. Legality itself still comes from the machine (`snapshot.can`) — this
+// only EXPLAINS a refusal the machine has already made, mirroring the
+// `canBuildSecondLink` guard's checks in the same order.
+import type { GameState } from '~/store/gameStore'
+
+/**
+ * Whether the double-rail option belongs on screen at all. Double rail is a
+ * Rail Era rule — in the Canal Era it doesn't exist, so it is hidden rather
+ * than disabled (an option that can never apply is noise, not information).
+ */
+export function showsDoubleLinkOption(context: GameState): boolean {
+  return context.era === 'rail'
+}
+
+/**
+ * The reason `CHOOSE_DOUBLE_LINK_BUILD` is refused, phrased for a player.
+ * Returns `null` when nothing this module knows about is missing — the
+ * caller should fall back to a generic message rather than claim a cause.
+ */
+export function explainDoubleLinkUnavailable(
+  context: GameState,
+): string | null {
+  if (context.era !== 'rail') {
+    return 'Two rails can only be laid in the Rail Era.'
+  }
+  if (!context.selectedLink) {
+    return 'Choose your first route before adding a second.'
+  }
+
+  const hasBeer = context.players.some((player) =>
+    player.industries.some(
+      (industry) =>
+        industry.type === 'brewery' &&
+        !industry.flipped &&
+        industry.beerBarrelsOnTile > 0,
+    ),
+  )
+  if (!hasBeer) {
+    return 'Needs 1 beer — no brewery with a barrel left stands on the board.'
+  }
+
+  return null
+}
+
+/**
+ * Said when the machine refuses the option for a reason this module cannot
+ * name — it lists the full price rather than guessing which part is missing.
+ */
+export const DOUBLE_LINK_GENERIC_REASON =
+  'Two rails need £15, 2 coal and 1 beer within reach.'
+
+/** The line to print under a disabled "Build two rails" — always a sentence. */
+export function doubleLinkDisabledReason(context: GameState): string {
+  return explainDoubleLinkUnavailable(context) ?? DOUBLE_LINK_GENERIC_REASON
+}


### PR DESCRIPTION
## The bug

In the Network flow, the **"Build two rails — £15 + 2 coal + 1 beer"** button rendered only when the machine's `CHOOSE_DOUBLE_LINK_BUILD` guard passed:

```tsx
{can({ type: 'CHOOSE_DOUBLE_LINK_BUILD' }) && ( <button …> )}
```

When no beer was reachable, the button silently **vanished** — no disabled state, no tooltip. A player in that position saw an ordinary single-rail confirm screen and had no way to learn that double rail exists at all. The costs themselves match the official rules exactly (Rail era: 1 link = £5 + 1 coal; 2 links = £15 + 2 coal + 1 beer), so this was purely a discoverability bug.

## The fix

Render the button **disabled instead of hidden**, naming the missing requirement both as a `title` tooltip and as a visible line beneath it — the same treatment `Confirm` already gives its refusals.

**Rail era only.** Double rail is a Rail Era rule, so the Canal Era still hides it entirely: an option that can never apply there is noise, not information.

**Legality still comes from the engine.** `enabled` remains driven by `snapshot.can({ type: 'CHOOSE_DOUBLE_LINK_BUILD' })`. The new `double-link-availability.ts` only puts into words a refusal the machine has *already* made — it never re-derives legality (per the "legality comes from the engine, not the UI" rule in CLAUDE.md). When it cannot see the cause, it declines to guess and falls back to quoting the full price rather than naming a requirement that may not be the real blocker.

### Enabled (beer available)

![Enabled](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-24-images/double-rail-enabled.png)

### Disabled (no beer on the board)

![Disabled](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-24-images/double-rail-disabled.png)

## Tests

11 unit tests in `double-link-availability.test.ts` cover the disabled-state logic: era visibility, own vs. opponent breweries as beer sources, flipped breweries holding no beer, and the generic fallback. The existing `e2e/coverage.spec.ts` double-link journey still passes (the button is enabled in the rail fixture, so the click-through is unchanged).

## Other vanish-instead-of-disable affordances in this flow

I checked, as asked. **The dock is already clean** — this was the only true vanish case:

- The **Build → industry** grid (`action-dock.tsx:530`) already does the right thing: `disabled={!isViable(t)}` plus a `title` and a note explaining greyed entries. It's the precedent this fix mirrors.
- The **Sell** action button already renders disabled with the reason "No goods you can sell right now".

Nothing trivial left to fix. One adjacent observation, **not** changed here: `canBuildSecondLink` checks only that beer *exists* somewhere, not that it is network-reachable or affordable — so the button can be enabled and still fail at the final confirm, which `canCompleteDoubleLink` then explains. That is pre-existing engine-guard behaviour, unchanged by this PR, and it overlaps the `brass-refusal-reasons` work rather than this client-side display task.

## Verification notes

- `pnpm lint`, `pnpm typecheck` clean; `pnpm test` → 310 passed.
- The two DB-backed suites (`gameStore.multiplayer`, `mp-ai`) could not run locally — this disposable worktree has no `DATABASE_URL`/`NEON_API_KEY`. They are unrelated to this client-side change and CI provisions a Neon branch for them.
- Pre-existing on `main`, untouched here: `src/store/shared/gameUtils.industrySlots.test.ts` has 9 failing tests. It is outside `pnpm test`'s scope (which is what CI runs) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
