### PR TITLE
chore: add .worktreeinclude for pooled worktrees

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,9 @@
+# Files to copy from the main checkout into freshly prepared worktrees.
+# Only gitignored files are eligible — tracked files are already shared.
+# Format: gitignore-compatible globs.
+
+# ─── Environment & secrets ────────────────────────────────────────────
+# Dev needs DATABASE_URL (Neon "dev" branch connection string) to boot the
+# app; see the CI/local-db notes in CLAUDE.md. Without this, `pnpm dev`
+# fails env validation unless SKIP_ENV_VALIDATION=1 is set.
+.env


### PR DESCRIPTION
## Summary
- Adds `.worktreeinclude` so treehouse copies the gitignored `.env` (dev Neon DATABASE_URL) into freshly prepared pooled worktrees — crews currently start without it and hit env-validation failures on `pnpm dev`.
- Modeled on saidot's `.worktreeinclude` format (gitignore-compatible globs, comment header).
- Only `.env` is included — verified it holds nothing but a dev-branch Neon connection string, no production secret. No other gitignored file is needed to boot the dev server (caches/build output/node_modules excluded per the task brief).

## Test plan
- [x] Inspected `.env` contents — dev Neon connection string only
- [x] Confirmed `.gitignore` covers `.env`
- [x] No README dev-setup section exists to amend (boilerplate create-t3-app README)