### PR TITLE
test(db): survive the parallel CREATE-TABLE race on ephemeral Neon branches

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -7,3 +7,10 @@
 # app; see the CI/local-db notes in CLAUDE.md. Without this, `pnpm dev`
 # fails env validation unless SKIP_ENV_VALIDATION=1 is set.
 .env
+
+# Carries NEON_API_KEY, which is what buys a test run its OWN ephemeral Neon
+# branch (src/test/global-db-branch.ts). Without it a worktree silently falls
+# back to .env's DATABASE_URL — the shared `dev` branch — so concurrent runs in
+# pooled worktrees clobber each other's rows. That is the exact interference the
+# per-run branch exists to prevent, so this file has to travel with .env.
+.env.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -522,7 +522,12 @@ When updating this file, preserve this bar for all agents and keep entries conci
   fail). This mirrors the CI workflow (`.github/workflows/ci.yml`, per-run
   branch off `ci`). Credential `NEON_API_KEY` (brass-project-scoped Neon key):
   LOCAL — put it in `.env.local` (gitignored via `.env*.local`; never committed
-  / printed); CI — the `NEON_API_KEY` repo secret (a plain env var, which also
+  / printed), which `.worktreeinclude` copies into pooled worktrees ALONGSIDE
+  `.env` (without it a worktree silently degrades to `.env`'s shared `dev`
+  branch — the exact interference this whole mechanism prevents; mint a
+  project-scoped key via `neonctl api /organizations/<org>/api_keys -X POST -d
+  '{"key_name":...,"project_id":"muddy-night-85782525"}'`); CI — the
+  `NEON_API_KEY` repo secret (a plain env var, which also
   overrides `.env.local` in disposable worktrees). `NEON_PROJECT_ID` is likewise
   overridable but defaults to the brass project. FALLBACK PRECEDENCE (offline
   never hard-fails, and tests must NEVER hit `dev`): (1) `NEON_API_KEY` present
@@ -535,7 +540,17 @@ When updating this file, preserve this bar for all agents and keep entries conci
   (beforeAll, `src/test/db-schema.ts`) migrates it idempotently — so a stale
   `test` branch is brought current by the same harness step the ephemeral path
   uses. Keep `TEST_DATABASE_URL` (not the plain `DATABASE_URL`) pointed at the
-  `test` branch for the no-key / `TEST_DB_BRANCH=0` path.
+  `test` branch for the no-key / `TEST_DB_BRANCH=0` path. That idempotent apply
+  must swallow BOTH "already exists" (re-run over a populated branch) AND the
+  parallel-CREATE race: two DB suites run in separate vitest workers against ONE
+  branch, so when a table is absent (a fresh migration not yet on the `ci`
+  parent) both issue the same `CREATE TABLE` at once and the loser gets a
+  `23505` on `pg_catalog` (NOT a polite `42P07`). `isBenignSchemaRace`
+  (`src/test/db-schema.ts`, unit-tested in `db-schema.test.ts`) accepts exactly
+  those; a `23505` on an application table still throws. Re-migrate the `ci`
+  parent after adding a table (`neonctl connection-string ci --project-id
+  muddy-night-85782525` → `pnpm db:migrate`) so ephemeral branches inherit it —
+  but the race handler is the safety net for the window before that.
 - DEPLOY (Vercel, wired 2026-07-15): ship is direct-PR → Vercel Git
   integration (project `brass-birmingham`, prod branch = `main`, PR previews
   on). The Neon<->Vercel native integration (store "brass") manages the

--- a/src/test/db-schema.test.ts
+++ b/src/test/db-schema.test.ts
@@ -1,0 +1,87 @@
+// Offline unit tests for the schema-application error predicate.
+//
+// These pin WHICH Postgres failures ensureTestSchema() is allowed to swallow.
+// Getting this wrong is expensive in both directions: too narrow and parallel
+// DB suites flake (see the pg_type race below); too wide and a genuine broken
+// migration passes silently.
+import { describe, expect, it } from 'vitest'
+import { isBenignSchemaRace } from './db-schema'
+
+/** Shape of the driver error drizzle wraps (fields we actually branch on). */
+function pgError(fields: Record<string, unknown>): Error {
+  return Object.assign(new Error(String(fields.message ?? 'pg error')), fields)
+}
+
+describe('isBenignSchemaRace', () => {
+  it('accepts duplicate_table (42P07) — the object already exists', () => {
+    expect(isBenignSchemaRace(pgError({ code: '42P07' }))).toBe(true)
+  })
+
+  it('accepts an "already exists" message when no code is surfaced', () => {
+    expect(
+      isBenignSchemaRace(
+        pgError({ message: 'relation "games" already exists' }),
+      ),
+    ).toBe(true)
+  })
+
+  it('accepts duplicate_object (42710) — a constraint/index lost the race', () => {
+    expect(isBenignSchemaRace(pgError({ code: '42710' }))).toBe(true)
+  })
+
+  // The regression this file exists for. Two DB suites run in parallel workers
+  // against ONE fresh ephemeral branch; both find `chat_messages` absent and
+  // issue CREATE TABLE at the same instant. The loser does NOT get a polite
+  // 42P07 — Postgres surfaces the catalog's own unique-index violation.
+  it('accepts a concurrent CREATE losing on the pg_catalog unique index', () => {
+    expect(
+      isBenignSchemaRace(
+        pgError({
+          code: '23505',
+          schema: 'pg_catalog',
+          table: 'pg_type',
+          constraint: 'pg_type_typname_nsp_index',
+          message:
+            'duplicate key value violates unique constraint "pg_type_typname_nsp_index"',
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('unwraps the cause chain drizzle wraps the driver error in', () => {
+    const wrapped = Object.assign(new Error('Failed query: CREATE TABLE ...'), {
+      cause: pgError({ code: '42P07' }),
+    })
+    expect(isBenignSchemaRace(wrapped)).toBe(true)
+  })
+
+  // Guard the other direction: 23505 is only benign against the CATALOG. A
+  // unique violation on an application table is a real bug and must surface.
+  it('rejects a 23505 on an application table', () => {
+    expect(
+      isBenignSchemaRace(
+        pgError({
+          code: '23505',
+          schema: 'public',
+          table: 'games',
+          constraint: 'games_pkey',
+          message:
+            'duplicate key value violates unique constraint "games_pkey"',
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects a genuinely broken migration', () => {
+    expect(
+      isBenignSchemaRace(
+        pgError({ code: '42601', message: 'syntax error at or near "CRAETE"' }),
+      ),
+    ).toBe(false)
+  })
+
+  it('rejects non-Error throws rather than guessing', () => {
+    expect(isBenignSchemaRace('boom')).toBe(false)
+    expect(isBenignSchemaRace(null)).toBe(false)
+  })
+})

--- a/src/test/db-schema.ts
+++ b/src/test/db-schema.ts
@@ -1,20 +1,50 @@
 // Apply the shipped Drizzle migrations to the connected DB for tests.
 //
-// The multiplayer suites run against a real (Neon/Postgres) database — set
-// DATABASE_URL to a dev branch. Rather than depend on a driver-specific
-// runtime migrator, we execute the generated migration SQL directly, which is
-// robust across drivers and exercises the exact SQL that ships. Re-running is
-// safe: an "already exists" error on the CREATE TABLE is ignored so tests can
-// share a persistent dev branch across runs.
+// The multiplayer suites run against a real (Neon/Postgres) database, normally
+// the per-run ephemeral branch from src/test/global-db-branch.ts. Rather than
+// depend on a driver-specific runtime migrator, we execute the generated
+// migration SQL directly, which is robust across drivers and exercises the exact
+// SQL that ships. Applying is safe both when the objects already exist and when
+// parallel workers create them at the same instant — see isBenignSchemaRace.
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
 import { sql } from 'drizzle-orm'
 import { db } from '~/server/db'
 
-function isAlreadyExists(err: unknown): boolean {
+/**
+ * Is this failure just "the object is already there"?
+ *
+ * Two shapes, both benign:
+ *
+ *  - The object EXISTS ALREADY (42P07 duplicate_table / 42710 duplicate_object,
+ *    or an "already exists" message when no code surfaces). Re-running the
+ *    shipped migrations over a populated branch.
+ *
+ *  - The object was created CONCURRENTLY, a hair before us. vitest runs the DB
+ *    suites in parallel workers against ONE database; when the branch is missing
+ *    a table (an ephemeral branch off a `ci` parent that predates the migration)
+ *    both workers issue the same CREATE at once. The loser does NOT get 42P07 —
+ *    CREATE TABLE isn't atomic against a concurrent twin, so Postgres surfaces
+ *    its own catalog unique-index violation (23505 on pg_catalog) instead. The
+ *    winner's object is committed by then, so the loser can safely carry on.
+ *
+ * 23505 is accepted ONLY against pg_catalog: a unique violation on an
+ * application table is a real defect and must still throw. drizzle wraps the
+ * driver error, so walk the cause chain.
+ */
+export function isBenignSchemaRace(err: unknown): boolean {
   for (let e = err; e; e = (e as { cause?: unknown }).cause) {
-    const { code, message } = e as { code?: string; message?: string }
-    if (code === '42P07' || /already exists/i.test(message ?? '')) return true
+    if (typeof e !== 'object') return false
+    const { code, message, schema } = e as {
+      code?: string
+      message?: string
+      schema?: string
+    }
+    if (code === '42P07' || code === '42710') return true
+    if (code === '23505' && schema === 'pg_catalog') return true
+    // Only trust the message when no code pinned the failure — an unrelated
+    // error carrying these words shouldn't slip through.
+    if (!code && /already exists/i.test(message ?? '')) return true
   }
   return false
 }
@@ -32,10 +62,7 @@ async function apply(): Promise<void> {
       try {
         await db.execute(sql.raw(trimmed))
       } catch (err) {
-        // Idempotent: the object may already exist on a shared dev branch.
-        // drizzle wraps the driver error, so walk the cause chain looking for
-        // Postgres 42P07 (duplicate_table) / an "already exists" message.
-        if (!isAlreadyExists(err)) throw err
+        if (!isBenignSchemaRace(err)) throw err
       }
     }
   }


### PR DESCRIPTION
## Context

The task was to make **all DB-backed test runs use an ephemeral per-run Neon branch**, mirroring CI, so local/agent runs never share the long-lived `dev` branch. **That mechanism already landed on `main`** (`src/test/global-db-branch.ts` + `neon-branch.ts`, commits `496f92e`…`c39f72d`) — but it had never been exercised: no `NEON_API_KEY` was present anywhere, so every run silently fell back to the shared branch. Wiring up the key and actually running the mechanism surfaced two real gaps this PR fixes.

## What was broken

1. **Parallel `CREATE TABLE` race.** With a genuine ephemeral branch, the two DB-backed suites (`gameStore.multiplayer.test.ts`, `mp-ai.test.ts`) run in separate vitest workers against **one** fresh branch. When a table is absent (a migration newer than the `ci` parent — here `chat_messages`), both workers issue the same `CREATE TABLE` at the same instant. The loser gets Postgres **`23505` on `pg_catalog`**, not the polite `42P07` the old `isAlreadyExists` predicate handled, so `ensureTestSchema` threw and the run failed. This is the exact interference the ephemeral branch exists to prevent; it stayed hidden because 2-core CI effectively serializes the two files while a dev laptop runs them truly in parallel.

2. **`.env.local` never reached pooled worktrees.** `.worktreeinclude` copied only `.env`, but the mechanism reads `NEON_API_KEY` from `.env.local`. So every agent worktree degraded to `.env`'s shared `dev` branch — no isolation at all.

## Changes

- **`isBenignSchemaRace`** (renamed from `isAlreadyExists`, exported, unit-tested in new `src/test/db-schema.test.ts`): accepts `42P07`/`42710`, an "already exists" message when no code is pinned, and `23505` **only** against `pg_catalog`. A `23505` on an application table still throws — a real broken-migration must not pass silently.
- **`.worktreeinclude`** now copies `.env.local` alongside `.env`.
- Re-migrated the `ci` parent branch (added `chat_messages`) so future ephemeral branches inherit it; the race handler is the safety net for the window before a re-migrate.
- Documented both in `AGENTS.md`.

## Verification (all against real ephemeral branches)

- ✅ **Two concurrent `pnpm test` runs** → distinct branches (`local-test-71db7beb`, `local-test-de1f4d7b`), both green (20/20 each).
- ✅ Previously-racing suite pair now passes **3/3 in parallel**.
- ✅ Full suite: **46 files, 374 passed** on one ephemeral branch, created + deleted.
- ✅ **No orphan branches** after success, failure, and `kill -9` (2h TTL backstop confirmed on the killed run).
- ✅ CI unchanged: its test step exports only `DATABASE_URL` (GitHub doesn't expose secrets as env vars), so `resolveNeonApiKey()` finds nothing and CI keeps using its own action-created branch — no double-create.
- ✅ `pnpm lint` + `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)