### PR TITLE
feat(dev): opt-in Stately Inspector for the client game machine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,6 +233,11 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   removed then, so `/v2` no longer resolves.) The former v1 hotseat surface
   and the legacy networked flow (`gameManager`/`GameInterface`/`/game/[gameId]`)
   were deleted when this surface replaced them; `pnpm build` passes cleanly.
+- DEV-ONLY machine visualisation: `NEXT_PUBLIC_XSTATE_INSPECT=1 pnpm dev`
+  pops the Stately Inspector on the live `gameStore` actor. Hard-gated off
+  production and dynamically imported (`src/lib/xstate-inspector.ts`, fed into
+  `useMachine` in `game.tsx`); disabled default is a zero-behaviour no-op. See
+  the README "Debugging the game state machine" section.
 - The action UI is generated from the machine, not hand-coded state:
   `ActionDock` branches on `snapshot.matches('playing.action.<...>')` and
   gates every choice with `snapshot.can(event)`. Board city/link clicks are

--- a/README.md
+++ b/README.md
@@ -28,6 +28,26 @@ You can check out the [create-t3-app GitHub repository](https://github.com/t3-os
 
 Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel), [Netlify](https://create.t3.gg/en/deployment/netlify) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
 
+## Debugging the game state machine (Stately Inspector)
+
+The client-side XState machine can be visualised live with the
+[Stately Inspector](https://stately.ai/docs/inspector). It is **opt-in and
+dev-only** — hard-gated off production, and the inspector package is loaded via
+a dynamic import so it never lands in the production bundle.
+
+To turn it on, set the flag when running locally (or on a preview):
+
+```bash
+NEXT_PUBLIC_XSTATE_INSPECT=1 pnpm dev
+```
+
+Then open the app. A Stately Inspector window pops up and shows the live
+machine, its states and every event as you play. Leave the flag unset (the
+default) for normal play — the inspector adds nothing when disabled.
+
+Wiring lives in `src/lib/xstate-inspector.ts` (the flag check + dynamic import)
+and is fed into `useMachine` in `src/components/game.tsx`.
+
 ## Icon credits
 
 Industry and marker icons are from [game-icons.net](https://game-icons.net),

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@biomejs/biome": "1.9.4",
     "@neondatabase/api-client": "^2.7.3",
     "@playwright/test": "^1.61.1",
+    "@statelyai/inspect": "^0.7.2",
     "@types/eslint": "^8.56.10",
     "@types/node": "^20.14.10",
     "@types/react": "^18.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 0.10.1(typescript@5.7.3)(zod@3.24.2)
       '@vercel/functions':
         specifier: ^3.7.5
-        version: 3.7.5(ws@8.18.1)
+        version: 3.7.5(ws@8.21.1)
       '@xstate/react':
         specifier: ^5.0.2
         version: 5.0.2(@types/react@18.3.18)(react@18.3.1)(xstate@5.19.2)
@@ -63,6 +63,9 @@ importers:
       '@playwright/test':
         specifier: ^1.61.1
         version: 1.61.1
+      '@statelyai/inspect':
+        specifier: ^0.7.2
+        version: 0.7.2(xstate@5.19.2)
       '@types/eslint':
         specifier: ^8.56.10
         version: 8.56.12
@@ -1173,6 +1176,11 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@statelyai/inspect@0.7.2':
+    resolution: {integrity: sha512-axuXSEBsI8pQ89rP2DWq+kHLjABiXpe2qYDOo6+jVLJ+9NPOTjutMnmDd+XcJjn76d+RH6sfHa0XkFIYPUHDOw==}
+    peerDependencies:
+      xstate: ^5.5.1
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1596,6 +1604,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -2008,6 +2020,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  event-target-shim@6.0.2:
+    resolution: {integrity: sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==}
+    engines: {node: '>=10.13.0'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2036,6 +2052,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
@@ -2393,11 +2412,20 @@ packages:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
 
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-ws@5.0.0:
+    resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
+    peerDependencies:
+      ws: '*'
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -2724,6 +2752,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  partysocket@0.0.25:
+    resolution: {integrity: sha512-1oCGA65fydX/FgdnsiBh68buOvfxuteoZVSb3Paci2kRp/7lhF0HyA8EDb5X/O6FxId1e+usPTQNRuzFEvkJbQ==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -3038,6 +3069,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -3223,6 +3258,10 @@ packages:
     resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superjson@1.13.3:
+    resolution: {integrity: sha512-mJiVjfd2vokfDxsQPOwJ/PtanO87LhpYY88ubI5dUB1Ab58Txbyje3+jpm+/83R/fevaq/107NNhtYBLuoTrFg==}
+    engines: {node: '>=10'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -3502,6 +3541,18 @@ packages:
 
   ws@8.18.1:
     resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4327,6 +4378,19 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
+  '@statelyai/inspect@0.7.2(xstate@5.19.2)':
+    dependencies:
+      fast-safe-stringify: 2.1.1
+      isomorphic-ws: 5.0.0(ws@8.21.1)
+      partysocket: 0.0.25
+      safe-stable-stringify: 2.5.0
+      superjson: 1.13.3
+      ws: 8.21.1
+      xstate: 5.19.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -4479,11 +4543,11 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/functions@3.7.5(ws@8.18.1)':
+  '@vercel/functions@3.7.5(ws@8.21.1)':
     dependencies:
       '@vercel/oidc': 3.8.0
     optionalDependencies:
-      ws: 8.18.1
+      ws: 8.21.1
 
   '@vercel/oidc@3.8.0':
     dependencies:
@@ -4815,6 +4879,10 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  copy-anything@3.0.5:
+    dependencies:
+      is-what: 4.1.16
 
   cosmiconfig@8.3.6(typescript@5.7.3):
     dependencies:
@@ -5345,6 +5413,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  event-target-shim@6.0.2: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -5392,6 +5462,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fast-sha256@1.3.0: {}
 
@@ -5752,9 +5824,15 @@ snapshots:
       call-bound: 1.0.3
       get-intrinsic: 1.2.7
 
+  is-what@4.1.16: {}
+
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isomorphic-ws@5.0.0(ws@8.21.1):
+    dependencies:
+      ws: 8.21.1
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -6087,6 +6165,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  partysocket@0.0.25:
+    dependencies:
+      event-target-shim: 6.0.2
+
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
@@ -6353,6 +6435,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-stable-stringify@2.5.0: {}
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -6616,6 +6700,10 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
+
+  superjson@1.13.3:
+    dependencies:
+      copy-anything: 3.0.5
 
   supports-color@7.2.0:
     dependencies:
@@ -6933,6 +7021,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.18.1: {}
+
+  ws@8.21.1: {}
 
   xdg-app-paths@5.5.1:
     dependencies:

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -18,6 +18,7 @@ import { createActor } from 'xstate'
 import { Toaster } from '~/components/ui/sonner'
 import { type CityId, cities, connections } from '~/data/board'
 import { type Card, type IndustryType } from '~/data/cards'
+import { type InspectFn, useXstateInspect } from '~/lib/xstate-inspector'
 import {
   type GameEvent,
   type GameStoreSnapshot,
@@ -174,6 +175,10 @@ interface Boot {
 export function Game() {
   const [boot, setBoot] = useState<Boot | null>(null)
   const [generation, setGeneration] = useState(0)
+  // Dev-only: wait for the Stately Inspector to attach before creating the
+  // actor so its first transitions are captured. `ready` is true from the
+  // first render when the inspector is disabled (the default) — no change.
+  const { ready: inspectReady, inspect } = useXstateInspect()
 
   // Boot decision is client-only (localStorage + query params), behind a
   // mount gate so SSR and hydration always agree.
@@ -231,7 +236,7 @@ export function Game() {
     setBoot({ kind: 'fresh', resumed: false })
   }, [])
 
-  if (!boot) {
+  if (!boot || !inspectReady) {
     return (
       <div className="flex min-h-screen items-center justify-center">
         <span
@@ -299,6 +304,7 @@ export function Game() {
       <GameInner
         key={`${boot.kind}-${boot.resumed}-${generation}`}
         boot={boot}
+        inspect={inspect}
         onNewGame={newGame}
         onRestoreSnapshot={restoreSnapshot}
       />
@@ -350,17 +356,19 @@ class SaveRecoveryBoundary extends Component<
 
 function GameInner({
   boot,
+  inspect,
   onNewGame,
   onRestoreSnapshot,
 }: {
   boot: Boot
+  inspect?: InspectFn
   onNewGame: () => void
   onRestoreSnapshot: (snapshot: unknown) => void
 }) {
-  const [state, send, actorRef] = useMachine(
-    gameStore,
-    boot.snapshot ? { snapshot: boot.snapshot as never } : undefined,
-  )
+  const [state, send, actorRef] = useMachine(gameStore, {
+    ...(boot.snapshot ? { snapshot: boot.snapshot as never } : {}),
+    ...(inspect ? { inspect } : {}),
+  })
   // Demo showcases reveal immediately; resumed & fresh games always gate so
   // a refresh never exposes the incoming player's hand.
   const [revealedFor, setRevealedFor] = useState<string | null>(() =>

--- a/src/lib/xstate-inspector.ts
+++ b/src/lib/xstate-inspector.ts
@@ -1,0 +1,82 @@
+'use client'
+
+// Dev-only Stately Inspector wiring for the client-side XState machine.
+//
+// Opt-in: set NEXT_PUBLIC_XSTATE_INSPECT=1 while running locally / on a
+// preview. It is HARD-gated off production (both the Node build env and the
+// Vercel env), and the heavy @statelyai/inspect package is loaded via a
+// dynamic import so it never lands in the production bundle. When disabled
+// (the default) this module does nothing and adds no behaviour.
+
+import { useEffect, useState } from 'react'
+import type { InspectionEvent, Observer } from 'xstate'
+
+export type InspectFn = Observer<InspectionEvent>
+
+/**
+ * True only when the inspector was explicitly opted into AND we are not in a
+ * production build. Both checks read compile-time-inlined env vars so the
+ * bundler can tree-shake the dynamic import away in prod.
+ */
+export function xstateInspectEnabled(): boolean {
+  return (
+    process.env.NEXT_PUBLIC_XSTATE_INSPECT === '1' &&
+    process.env.NODE_ENV !== 'production' &&
+    process.env.NEXT_PUBLIC_VERCEL_ENV !== 'production'
+  )
+}
+
+// One inspector (one browser window) per page load, shared across remounts.
+let inspectorPromise: Promise<InspectFn | undefined> | undefined
+
+function loadInspect(): Promise<InspectFn | undefined> {
+  if (!xstateInspectEnabled() || typeof window === 'undefined') {
+    return Promise.resolve(undefined)
+  }
+  if (!inspectorPromise) {
+    inspectorPromise = import('@statelyai/inspect')
+      .then(({ createBrowserInspector }) => createBrowserInspector().inspect)
+      .catch((err) => {
+        console.error(
+          '[xstate-inspect] failed to load the Stately Inspector',
+          err,
+        )
+        return undefined
+      })
+  }
+  return inspectorPromise
+}
+
+/**
+ * Returns the inspect observer to feed into `useMachine`, plus a `ready` flag
+ * telling the caller when it is safe to create the actor.
+ *
+ * When the inspector is disabled `ready` is `true` from the first render, so
+ * the actor mounts synchronously exactly as before — zero behaviour change.
+ * When enabled, `ready` flips to `true` only after the inspector window has
+ * loaded, so the machine can be created with the observer already attached
+ * and the very first transitions are captured.
+ */
+export function useXstateInspect(): {
+  ready: boolean
+  inspect: InspectFn | undefined
+} {
+  const enabled = xstateInspectEnabled()
+  const [inspect, setInspect] = useState<InspectFn | undefined>(undefined)
+  const [ready, setReady] = useState(!enabled)
+
+  useEffect(() => {
+    if (!enabled) return
+    let alive = true
+    void loadInspect().then((fn) => {
+      if (!alive) return
+      setInspect(() => fn)
+      setReady(true)
+    })
+    return () => {
+      alive = false
+    }
+  }, [enabled])
+
+  return { ready, inspect }
+}


### PR DESCRIPTION
## What

Adds a **dev-only** [Stately Inspector](https://stately.ai/docs/inspector) integration so the client-side XState `gameStore` machine can be visualised live while playing locally or on a preview.

## How

- New `src/lib/xstate-inspector.ts`:
  - `xstateInspectEnabled()` — true only when `NEXT_PUBLIC_XSTATE_INSPECT=1` **and** not a production build (`NODE_ENV` + `NEXT_PUBLIC_VERCEL_ENV`). Both checks are compile-time-inlined so the bundler can tree-shake.
  - `useXstateInspect()` — dynamically imports `@statelyai/inspect`, creates one `createBrowserInspector()` per page load, and returns the `inspect` observer plus a `ready` flag. When disabled, `ready` is `true` from the first render, so the actor mounts synchronously exactly as before.
- `src/components/game.tsx` — minimal, additive at the actor-creation site: gate `GameInner`'s mount on `ready` (so the inspector is attached before the actor's first transitions) and pass the observer into `useMachine`'s `inspect` option.
- `@statelyai/inspect` added as a **devDependency**.
- Docs: README "Debugging the game state machine" section + a pointer in AGENTS.md/CLAUDE.md.

## Guarantees

- **Opt-in & dev-only.** The flag alone cannot enable it in production — the `NODE_ENV`/`VERCEL_ENV` checks hard-gate it off.
- **Zero prod bundle weight.** The inspector is behind `import('@statelyai/inspect')`; the prod build code-splits it into a lazy chunk that is never fetched (guard short-circuits before the import). Verified in a production build: inspector code lands in a separate chunk, not the first-load shared bundle.
- **Zero behaviour change when disabled** (the default).

## Verification

- `pnpm typecheck` ✅, `pnpm lint` ✅
- `SKIP_ENV_VALIDATION=1 pnpm build` ✅ (exit 0)
- `pnpm test` — all 346 non-DB tests pass. The 3 failing files (`egress`, `multiplayer`, `mp-ai`) fail only because this worktree has no test-DB creds (`No database connection string`); they touch none of my changes and pass in CI (Neon-per-run).
- Browser: with the flag set, opening the app loads the `@statelyai/inspect` chunk, starts a game, and runs with the inspector attached — no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)