### PR TITLE
feat(engine): card-first action flow — play a card, then pick its action

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,18 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   Wild cards route through the full build flow: wild location picks
   industry then ANY city; wild industry picks industry then a network
   city. Regression tests: `gameStore.bugfixes.test.ts`, `e2e/bugfixes.spec.ts`.
+- CARD-FIRST entry (2026-07-16): `playing.action.cardSelected` — SELECT_CARD
+  from idle holds a hand card and offers its actions; each action event then
+  jumps PAST that action's own selectingCard step (BUILD routes by the HELD
+  card's type exactly like the action-first SELECT_CARD split; SCOUT seeds
+  `selectedCardsForScout` via `seedScoutFromSelectedCard`). Re-click/CANCEL
+  returns to idle; PASS stays idle-only. Machine-owned — the UI only renders
+  the state (`getHandSelection` + the dock's cardSelected branch). The AI's
+  `legal-moves.ts` deliberately does NOT offer the entry (redundant surface;
+  the deterministic fallback would loop through it). Pinned by
+  `gameStore.cardfirst.test.ts` + `e2e/card-first.spec.ts`. GOTCHA: a stray
+  SELECT_CARD in idle is no longer a silent no-op — scripted tests must not
+  send one unless they mean it (two old suites did, after PASS; fixed).
 - ENGINE-TEST GOTCHA: never call TEST_SET_PLAYER_HAND repeatedly in a
   scripted scenario — every end-of-turn refill then draws a full hand from
   the draw pile, burning the deck in ~3 rounds and ending the era mid-test

--- a/e2e/card-first.spec.ts
+++ b/e2e/card-first.spec.ts
@@ -1,0 +1,107 @@
+import { type Page, expect, test } from '@playwright/test'
+
+/**
+ * Card-first flow: playing a hand card BEFORE choosing an action holds the
+ * card (machine state playing.action.cardSelected) and offers the actions it
+ * can start; the chosen action then continues with the card carried in.
+ * Fixture: ?demo — canal round 8, Eliza to act with £19, LAST action of her
+ * turn (see coverage.spec.ts for the fixture map).
+ */
+
+function treasuryOf(page: Page, name: string) {
+  return page
+    .locator('[data-testid^="mat-"]')
+    .filter({ hasText: name })
+    .getByTestId('treasury')
+}
+
+/** Click a map route ON its stroke (curved paths — see coverage.spec.ts). */
+async function clickRoute(page: Page, conn: string) {
+  const path = page.locator(`path[data-conn="${conn}"]`)
+  const pt = await path.evaluate((el) => {
+    const p = el as unknown as SVGPathElement
+    const mid = p.getPointAtLength(p.getTotalLength() / 2)
+    const sp = new DOMPoint(mid.x, mid.y).matrixTransform(p.getScreenCTM()!)
+    return { x: sp.x, y: sp.y }
+  })
+  await page.mouse.click(pt.x, pt.y)
+}
+
+test('card-first: play a card, pick Network, confirm — card never re-asked', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
+
+  // The hand is live while idling — play a card first.
+  await page.getByTestId('card-brewery_2').click()
+  await expect(page.getByText('Play this card')).toBeVisible()
+  await expect(page.getByText('Holding')).toBeVisible()
+
+  // The held card's actions are offered; Network goes STRAIGHT to the
+  // route step — no second card ask.
+  const network = page.getByTestId('action-network')
+  await expect(network).toBeEnabled()
+  await network.click()
+  await expect(
+    page.getByText(/Choose a canal route — \d+ available/),
+  ).toBeVisible()
+
+  const legalRoute = page.locator('path[data-conn][data-legal="true"]')
+  expect(await legalRoute.count()).toBeGreaterThan(0)
+  const firstConn = (await legalRoute.first().getAttribute('data-conn'))!
+  await clickRoute(page, firstConn)
+
+  const confirm = page.getByTestId('confirm-action')
+  await expect(confirm).toBeEnabled()
+  await confirm.click()
+
+  // The link was laid with the held card and consumed the action (£19 − £3;
+  // this was Eliza's LAST action, so the device passes on).
+  await expect(
+    page.getByText(/Eliza built a canal link between/).first(),
+  ).toBeVisible()
+  await expect(treasuryOf(page, 'Eliza')).toHaveText('£16')
+  await expect(page.getByTestId('pass-curtain')).toBeVisible()
+})
+
+test('card-first: build with the held card resumes at the industry step', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+
+  // brewery_2 is an industry card — card-first Build skips the card step.
+  await page.getByTestId('card-brewery_2').click()
+  await page.getByTestId('action-build').click()
+  await expect(page.getByText(/Choose a site for your brewery/)).toBeVisible()
+
+  // Cancel unwinds the flow without having consumed anything.
+  await page.getByTestId('cancel-action').click()
+  await page.getByTestId('cancel-action').click()
+  await expect(page.getByText('Choose an action')).toBeVisible()
+  await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
+})
+
+test('card-first: the held card can be put back (re-tap and Put back)', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  const chooseAnAction = page.getByText('Choose an action')
+  const card = page.getByTestId('card-brewery_2')
+
+  // Re-tapping the held card puts it back.
+  await card.click()
+  await expect(page.getByText('Play this card')).toBeVisible()
+  await expect(card).toHaveAttribute('data-selected', 'true')
+  await card.click()
+  await expect(chooseAnAction).toBeVisible()
+
+  // The Put back button does the same.
+  await card.click()
+  await expect(page.getByText('Play this card')).toBeVisible()
+  await page.getByTestId('cancel-action').click()
+  await expect(chooseAnAction).toBeVisible()
+
+  // Nothing was spent along the way.
+  await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
+})

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -86,6 +86,19 @@ export function getHandSelection(
   snapshot: GameStoreSnapshot,
 ): HandSelection | null {
   const is = (path: string) => snapshot.matches(path as never)
+  // Card-first: the hand is live while idling — playing a card opens the
+  // actions it can start (the machine's cardSelected state). Wording gotcha:
+  // neither hint may contain "choose an action" (the idle dock title, pinned
+  // by e2e getByText, which substring-matches case-insensitively).
+  if (is('playing.action.selectingAction'))
+    return { hint: 'Pick an action — or play a card first', selectedIds: [] }
+  if (is('playing.action.cardSelected')) {
+    const held = snapshot.context.selectedCard
+    return {
+      hint: 'Pick an action for this card — tap it again to put it back',
+      selectedIds: held ? [held.id] : [],
+    }
+  }
   if (is('playing.action.building.selectingCard'))
     return { hint: 'Build — play a card from your hand', selectedIds: [] }
   if (is('playing.action.networking.selectingCard'))
@@ -459,55 +472,59 @@ export function ActionDock({
   const cancel = () => send({ type: 'CANCEL' })
   const c = snapshot.context
 
+  // The six card-consuming actions — shared by the idle chooser and the
+  // card-first chooser (same labels, testids and gating in both).
+  const actionPlaques = (): Array<{
+    label: string
+    event: GameEvent
+    hint: string
+    icon: React.ReactNode
+    blocked?: boolean
+  }> => [
+    {
+      label: 'Build',
+      event: { type: 'BUILD' },
+      hint: 'Place an industry tile',
+      icon: <BuildIcon size={15} />,
+    },
+    {
+      label: 'Network',
+      event: { type: 'NETWORK' },
+      hint: c.era === 'canal' ? 'Canal £3' : 'Rail £5 + coal',
+      icon: <NetworkIcon size={15} />,
+    },
+    {
+      label: 'Develop',
+      event: { type: 'DEVELOP' },
+      hint: 'Remove tiles · 1 iron each',
+      icon: <DevelopIcon size={15} />,
+    },
+    {
+      label: 'Sell',
+      event: { type: 'SELL' },
+      hint: canSellAnything
+        ? 'Flip goods at merchants'
+        : 'No goods you can sell right now',
+      icon: <SellIcon size={15} />,
+      blocked: !canSellAnything,
+    },
+    {
+      label: 'Loan',
+      event: { type: 'TAKE_LOAN' },
+      hint: '+£30 · −3 income',
+      icon: <LoanIcon size={15} />,
+    },
+    {
+      label: 'Scout',
+      event: { type: 'SCOUT' },
+      hint: '3 cards → 2 wilds',
+      icon: <ScoutIcon size={15} />,
+    },
+  ]
+
   /* ---------- choose an action ---------- */
   if (is('playing.action.selectingAction')) {
-    const actions: Array<{
-      label: string
-      event: GameEvent
-      hint: string
-      icon: React.ReactNode
-      blocked?: boolean
-    }> = [
-      {
-        label: 'Build',
-        event: { type: 'BUILD' },
-        hint: 'Place an industry tile',
-        icon: <BuildIcon size={15} />,
-      },
-      {
-        label: 'Network',
-        event: { type: 'NETWORK' },
-        hint: c.era === 'canal' ? 'Canal £3' : 'Rail £5 + coal',
-        icon: <NetworkIcon size={15} />,
-      },
-      {
-        label: 'Develop',
-        event: { type: 'DEVELOP' },
-        hint: 'Remove tiles · 1 iron each',
-        icon: <DevelopIcon size={15} />,
-      },
-      {
-        label: 'Sell',
-        event: { type: 'SELL' },
-        hint: canSellAnything
-          ? 'Flip goods at merchants'
-          : 'No goods you can sell right now',
-        icon: <SellIcon size={15} />,
-        blocked: !canSellAnything,
-      },
-      {
-        label: 'Loan',
-        event: { type: 'TAKE_LOAN' },
-        hint: '+£30 · −3 income',
-        icon: <LoanIcon size={15} />,
-      },
-      {
-        label: 'Scout',
-        event: { type: 'SCOUT' },
-        hint: '3 cards → 2 wilds',
-        icon: <ScoutIcon size={15} />,
-      },
-    ]
+    const actions = actionPlaques()
     return (
       <div className="flex flex-col gap-3">
         <div className="flex items-baseline justify-between gap-2">
@@ -556,6 +573,64 @@ export function ActionDock({
           >
             ↩ Undo first action
           </button>
+        )}
+      </div>
+    )
+  }
+
+  /* ---------- card-first: a card is held, choose its action ---------- */
+  if (is('playing.action.cardSelected')) {
+    const actions = actionPlaques()
+    const anyBlocked = actions.some((a) => !can(a.event) || a.blocked)
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-col gap-1.5">
+            <span className="bb2-panel-title">Play this card</span>
+            {c.selectedCard && (
+              <div
+                className="flex items-center gap-2 text-[12px]"
+                style={{ color: 'rgba(231,215,177,.6)' }}
+              >
+                Holding <CardChip card={c.selectedCard} />
+              </div>
+            )}
+          </div>
+          <button
+            type="button"
+            className="bb2-ghost-btn"
+            data-testid="cancel-action"
+            onClick={cancel}
+          >
+            Put back
+          </button>
+        </div>
+        <hr className="bb2-rule" />
+        <div className="grid grid-cols-2 gap-2">
+          {actions.map((a) => (
+            <button
+              key={a.label}
+              type="button"
+              className="bb2-plaque"
+              data-testid={`action-${a.label.toLowerCase()}`}
+              disabled={!can(a.event) || a.blocked}
+              onClick={() => send(a.event)}
+            >
+              <span className="bb2-plaque-name">
+                {a.icon}
+                {a.label}
+              </span>
+              <span className="bb2-plaque-hint">{a.hint}</span>
+            </button>
+          ))}
+        </div>
+        {anyBlocked && (
+          <p
+            className="text-[12px] leading-snug"
+            style={{ color: 'rgba(231,215,177,.5)' }}
+          >
+            Greyed actions can't start with this card right now.
+          </p>
         )}
       </div>
     )

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -544,7 +544,17 @@ function GameInner({
   // and ask the machine's own guards (audit: Sell used to demand a discard
   // before revealing there was nothing to sell).
   const canSellAnything = useMemo(() => {
-    if (!is('playing.action.selectingAction') || !currentPlayer) return true
+    // Gates the Sell plaque in both choosers: idle and card-first (from
+    // cardSelected the probe's SELL skips the card step; the stray
+    // SELECT_CARD below is simply ignored there).
+    if (
+      !(
+        is('playing.action.selectingAction') ||
+        is('playing.action.cardSelected')
+      ) ||
+      !currentPlayer
+    )
+      return true
     const sellable = currentPlayer.industries.filter(
       (i) => !i.flipped && SELLABLE.includes(i.type),
     )

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -968,7 +968,14 @@ function MpTable({
   // Exact sale probe on my own filtered snapshot (my hand is real in it).
   const canSellAnything = useMemo(() => {
     if (!myTurn || !state || !me || !ctx) return true
-    if (!is('playing.action.selectingAction')) return true
+    // Both choosers show the Sell plaque: idle and card-first (from
+    // cardSelected the probe's SELL skips the card step; the stray
+    // SELECT_CARD below is simply ignored there).
+    if (
+      !is('playing.action.selectingAction') &&
+      !is('playing.action.cardSelected')
+    )
+      return true
     const sellable = me.industries.filter(
       (i) => !i.flipped && SELLABLE.includes(i.type),
     )

--- a/src/server/ai/legal-moves.ts
+++ b/src/server/ai/legal-moves.ts
@@ -78,11 +78,22 @@ export function enumerateLegalMoves(snapshot: GameStoreSnapshot): LegalMove[] {
 
   for (const c of TOP_LEVEL) push(c.event, c.label)
 
-  for (const card of me.hand) {
-    push(
-      { type: 'SELECT_CARD', cardId: card.id },
-      `Play card: ${describeCard(card)}`,
-    )
+  // The card-first entry (SELECT_CARD from idle → cardSelected) is a human
+  // ergonomics flow: every move it reaches is also reachable action-first,
+  // so offering it to the model would only widen the decision surface with
+  // a redundant path — and the deterministic fallback (which ranks
+  // SELECT_CARD high for the mid-flow discard steps) would loop through it
+  // instead of taking a turn-consuming action.
+  const atActionChoice = snapshot.matches({
+    playing: { action: 'selectingAction' },
+  } as never)
+  if (!atActionChoice) {
+    for (const card of me.hand) {
+      push(
+        { type: 'SELECT_CARD', cardId: card.id },
+        `Play card: ${describeCard(card)}`,
+      )
+    }
   }
 
   for (const industryType of INDUSTRY_TYPES) {

--- a/src/store/gameStore.build.test.ts
+++ b/src/store/gameStore.build.test.ts
@@ -296,15 +296,11 @@ describe('Game Store - Build Actions', () => {
     actor.send({ type: 'SELECT_LINK', from: 'coalbrookdale', to: 'shrewsbury' })
     actor.send({ type: 'CONFIRM' })
 
-    // After network action in round 1, it's now player 1's turn
-    // Player 1 passes
-    snapshot = actor.getSnapshot()
+    // After network action in round 1, it's now player 1's turn.
+    // Player 1 passes — PASS discards hand[0] and completes by itself (the
+    // old trailing SELECT_CARD + CONFIRM were no-ops before the card-first
+    // entry made SELECT_CARD meaningful in idle).
     actor.send({ type: 'PASS' })
-    snapshot = actor.getSnapshot()
-    const p1Card =
-      snapshot.context.players[snapshot.context.currentPlayerIndex]!.hand[0]!
-    actor.send({ type: 'SELECT_CARD', cardId: p1Card.id })
-    actor.send({ type: 'CONFIRM' })
 
     // Now it's round 2, player 0's turn (2 actions available)
     snapshot = actor.getSnapshot()

--- a/src/store/gameStore.cardfirst.test.ts
+++ b/src/store/gameStore.cardfirst.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import { type Card } from '../data/cards'
+import { getInitialPlayerIndustryTilesWithQuantities } from '../data/industryTiles'
+import { gameStore } from './gameStore'
+
+// Card-first flow: pick a hand card BEFORE choosing an action, then the
+// machine offers the actions that card can start and carries the card into
+// the normal per-action states (captain request 2026-07-16). The action-first
+// order stays untouched — these tests pin both directions.
+
+const locationCard: Card = {
+  id: 'cf_loc_stoke',
+  type: 'location',
+  location: 'stoke',
+  color: 'blue',
+} as Card
+const coalCard: Card = {
+  id: 'cf_ind_coal',
+  type: 'industry',
+  industries: ['coal'],
+} as Card
+const ironCard: Card = {
+  id: 'cf_ind_iron',
+  type: 'industry',
+  industries: ['iron'],
+} as Card
+const wildLocationCard: Card = {
+  id: 'cf_wild_loc',
+  type: 'wild_location',
+} as Card
+const wildIndustryCard: Card = {
+  id: 'cf_wild_ind',
+  type: 'wild_industry',
+} as Card
+
+const setupGame = (hand: Card[]) => {
+  const actor = createActor(gameStore)
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: [
+      {
+        id: '1',
+        name: 'Test Player 1',
+        money: 30,
+        victoryPoints: 0,
+        income: 10,
+        color: 'red' as const,
+        character: 'Richard Arkwright' as const,
+        industryTilesOnMat: getInitialPlayerIndustryTilesWithQuantities(),
+      },
+      {
+        id: '2',
+        name: 'Test Player 2',
+        money: 30,
+        victoryPoints: 0,
+        income: 10,
+        color: 'green' as const,
+        character: 'Eliza Tinsley' as const,
+        industryTilesOnMat: getInitialPlayerIndustryTilesWithQuantities(),
+      },
+    ],
+  })
+  const playerId = actor.getSnapshot().context.currentPlayerIndex
+  actor.send({ type: 'TEST_SET_PLAYER_HAND', playerId, hand })
+  return { actor, playerId }
+}
+
+const isCardSelected = (actor: ReturnType<typeof createActor>) =>
+  actor.getSnapshot().matches({ playing: { action: 'cardSelected' } })
+
+describe('card-first flow — entering and leaving cardSelected', () => {
+  test('selecting a card from idle enters cardSelected with the card held', () => {
+    const { actor } = setupGame([coalCard, locationCard])
+    expect(
+      actor.getSnapshot().matches({ playing: { action: 'selectingAction' } }),
+    ).toBe(true)
+    expect(
+      actor.getSnapshot().can({ type: 'SELECT_CARD', cardId: coalCard.id }),
+    ).toBe(true)
+
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.matches({ playing: { action: 'cardSelected' } })).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+    // The shared selectCard action auto-picks the buildable tile for
+    // industry cards — same context shape as the action-first order.
+    expect(snapshot.context.selectedIndustryTile?.type).toBe('coal')
+  })
+
+  test('a card id not in the hand cannot start the card-first flow', () => {
+    const { actor } = setupGame([coalCard])
+    expect(
+      actor.getSnapshot().can({ type: 'SELECT_CARD', cardId: 'not_in_hand' }),
+    ).toBe(false)
+
+    actor.send({ type: 'SELECT_CARD', cardId: 'not_in_hand' })
+    expect(
+      actor.getSnapshot().matches({ playing: { action: 'selectingAction' } }),
+    ).toBe(true)
+    expect(actor.getSnapshot().context.selectedCard).toBeNull()
+  })
+
+  test('clicking the held card again deselects it and returns to idle', () => {
+    const { actor } = setupGame([coalCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    expect(isCardSelected(actor)).toBe(true)
+
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.matches({ playing: { action: 'selectingAction' } })).toBe(
+      true,
+    )
+    expect(snapshot.context.selectedCard).toBeNull()
+    expect(snapshot.context.selectedIndustryTile).toBeNull()
+  })
+
+  test('selecting a different card switches the held card in place', () => {
+    const { actor } = setupGame([coalCard, ironCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    expect(actor.getSnapshot().context.selectedIndustryTile?.type).toBe('coal')
+
+    actor.send({ type: 'SELECT_CARD', cardId: ironCard.id })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.matches({ playing: { action: 'cardSelected' } })).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(ironCard.id)
+    expect(snapshot.context.selectedIndustryTile?.type).toBe('iron')
+  })
+
+  test('a bogus card id while holding a card is ignored', () => {
+    const { actor } = setupGame([coalCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+
+    actor.send({ type: 'SELECT_CARD', cardId: 'not_in_hand' })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.matches({ playing: { action: 'cardSelected' } })).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+  })
+
+  test('CANCEL from cardSelected returns to idle and clears the selection', () => {
+    const { actor } = setupGame([coalCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+
+    actor.send({ type: 'CANCEL' })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.matches({ playing: { action: 'selectingAction' } })).toBe(
+      true,
+    )
+    expect(snapshot.context.selectedCard).toBeNull()
+    expect(snapshot.context.selectedIndustryTile).toBeNull()
+  })
+
+  test('every card-consuming action is offered while a card is held; PASS is not', () => {
+    const { actor } = setupGame([coalCard, ironCard, locationCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.can({ type: 'BUILD' })).toBe(true)
+    expect(snapshot.can({ type: 'NETWORK' })).toBe(true)
+    expect(snapshot.can({ type: 'DEVELOP' })).toBe(true)
+    expect(snapshot.can({ type: 'SELL' })).toBe(true)
+    expect(snapshot.can({ type: 'TAKE_LOAN' })).toBe(true)
+    expect(snapshot.can({ type: 'SCOUT' })).toBe(true)
+    // Pass plays no card — it stays an idle-only choice.
+    expect(snapshot.can({ type: 'PASS' })).toBe(false)
+  })
+})
+
+describe('card-first BUILD — routing matches the card type', () => {
+  test('location card goes straight to the industry choice and completes', () => {
+    const { actor, playerId } = setupGame([locationCard, coalCard])
+    actor.send({ type: 'SELECT_CARD', cardId: locationCard.id })
+    actor.send({ type: 'BUILD' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { building: 'selectingIndustryType' } },
+      }),
+    ).toBe(true)
+    // The card is carried in — never re-asked.
+    expect(snapshot.context.selectedCard?.id).toBe(locationCard.id)
+
+    // Real location card: site is fixed, so industry choice confirms.
+    actor.send({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'cotton' })
+    snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { building: 'confirmingBuild' } },
+      }),
+    ).toBe(true)
+
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
+    const player = snapshot.context.players[playerId]!
+    expect(
+      player.industries.some(
+        (i) => i.location === 'stoke' && i.type === 'cotton',
+      ),
+    ).toBe(true)
+    expect(player.hand.some((c) => c.id === locationCard.id)).toBe(false)
+  })
+
+  test('industry card goes straight to the site choice and completes', () => {
+    const { actor, playerId } = setupGame([coalCard, locationCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'BUILD' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { building: 'selectingLocation' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+    expect(snapshot.context.selectedIndustryTile?.type).toBe('coal')
+
+    actor.send({ type: 'SELECT_LOCATION', cityId: 'coalbrookdale' })
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
+    const player = snapshot.context.players[playerId]!
+    expect(
+      player.industries.some(
+        (i) => i.location === 'coalbrookdale' && i.type === 'coal',
+      ),
+    ).toBe(true)
+  })
+
+  test('wild location card routes through the industry choice like action-first', () => {
+    const { actor } = setupGame([wildLocationCard, coalCard])
+    actor.send({ type: 'SELECT_CARD', cardId: wildLocationCard.id })
+    actor.send({ type: 'BUILD' })
+
+    const snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { building: 'selectingIndustryType' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(wildLocationCard.id)
+  })
+
+  test('wild industry card routes through the industry choice like action-first', () => {
+    const { actor } = setupGame([wildIndustryCard, coalCard])
+    actor.send({ type: 'SELECT_CARD', cardId: wildIndustryCard.id })
+    actor.send({ type: 'BUILD' })
+
+    const snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { building: 'selectingIndustryType' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(wildIndustryCard.id)
+  })
+})
+
+describe('card-first — remaining actions continue past the card step', () => {
+  test('NETWORK goes straight to the link choice and completes', () => {
+    const { actor, playerId } = setupGame([coalCard, ironCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'NETWORK' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { networking: 'selectingLink' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+
+    actor.send({ type: 'SELECT_LINK', from: 'coalbrookdale', to: 'shrewsbury' })
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
+    const player = snapshot.context.players[playerId]!
+    expect(player.links.length).toBe(1)
+    expect(player.hand.some((c) => c.id === coalCard.id)).toBe(false)
+  })
+
+  test('DEVELOP goes straight to the tile choice and completes', () => {
+    const { actor, playerId } = setupGame([coalCard, ironCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'DEVELOP' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { developing: 'selectingTiles' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+
+    actor.send({ type: 'SELECT_TILES_FOR_DEVELOP', industryTypes: ['coal'] })
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
+    expect(
+      snapshot.context.players[playerId]!.hand.some(
+        (c) => c.id === coalCard.id,
+      ),
+    ).toBe(false)
+  })
+
+  test('SELL goes straight to the sale choice with the card carried', () => {
+    const { actor } = setupGame([coalCard, ironCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'SELL' })
+
+    const snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({ playing: { action: { selling: 'selectingSale' } } }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+
+    // Nothing on the board to sell — cancel unwinds without a discard.
+    actor.send({ type: 'CANCEL' })
+    expect(
+      actor
+        .getSnapshot()
+        .matches({ playing: { action: { selling: 'selectingCard' } } }),
+    ).toBe(true)
+  })
+
+  test('TAKE_LOAN goes straight to the confirm and discards the held card', () => {
+    const { actor, playerId } = setupGame([coalCard, ironCard])
+    const moneyBefore = actor.getSnapshot().context.players[playerId]!.money
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'TAKE_LOAN' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { takingLoan: 'confirmingLoan' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
+    const player = snapshot.context.players[playerId]!
+    expect(player.money).toBe(moneyBefore + 30)
+    expect(player.hand.some((c) => c.id === coalCard.id)).toBe(false)
+  })
+
+  test('SCOUT seeds the discard pick with the held card', () => {
+    const { actor, playerId } = setupGame([coalCard, ironCard, locationCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'SCOUT' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { scouting: 'selectingCards' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCardsForScout.map((c) => c.id)).toEqual([
+      coalCard.id,
+    ])
+    // The card moved into the scout pick — it is no longer "held".
+    expect(snapshot.context.selectedCard).toBeNull()
+
+    actor.send({ type: 'SELECT_CARD', cardId: ironCard.id })
+    actor.send({ type: 'SELECT_CARD', cardId: locationCard.id })
+    actor.send({ type: 'CONFIRM' })
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
+    const player = snapshot.context.players[playerId]!
+    expect(player.hand.some((c) => c.type === 'wild_location')).toBe(true)
+    expect(player.hand.some((c) => c.type === 'wild_industry')).toBe(true)
+    expect(player.hand.some((c) => c.id === coalCard.id)).toBe(false)
+  })
+
+  test('SCOUT cancel returns the whole selection to idle', () => {
+    const { actor } = setupGame([coalCard, ironCard, locationCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'SCOUT' })
+    actor.send({ type: 'CANCEL' })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.matches({ playing: { action: 'selectingAction' } })).toBe(
+      true,
+    )
+    expect(snapshot.context.selectedCardsForScout).toEqual([])
+    expect(snapshot.context.selectedCard).toBeNull()
+  })
+})
+
+describe('action-first flow — unchanged by the card-first entry', () => {
+  test('BUILD from idle still asks for the card first', () => {
+    const { actor } = setupGame([coalCard, locationCard])
+    actor.send({ type: 'BUILD' })
+
+    const snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({ playing: { action: { building: 'selectingCard' } } }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard).toBeNull()
+  })
+
+  test('action-first loan still works end to end', () => {
+    const { actor, playerId } = setupGame([coalCard, ironCard])
+    const moneyBefore = actor.getSnapshot().context.players[playerId]!.money
+    actor.send({ type: 'TAKE_LOAN' })
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'CONFIRM' })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.context.lastError).toBeNull()
+    expect(snapshot.context.players[playerId]!.money).toBe(moneyBefore + 30)
+  })
+})

--- a/src/store/gameStore.income.test.ts
+++ b/src/store/gameStore.income.test.ts
@@ -60,13 +60,10 @@ const advanceRound = (actor: ReturnType<typeof createActor>) => {
       const currentPlayer =
         snapshot.context.players[snapshot.context.currentPlayerIndex]!
       if (currentPlayer.hand.length > 0) {
+        // PASS discards hand[0] and completes by itself. (This helper used
+        // to also send SELECT_CARD + CONFIRM — harmless no-ops before the
+        // card-first entry made SELECT_CARD meaningful in idle.)
         actor.send({ type: 'PASS' })
-        snapshot = actor.getSnapshot()
-        const cardId =
-          snapshot.context.players[snapshot.context.currentPlayerIndex]!
-            .hand[0]!.id
-        actor.send({ type: 'SELECT_CARD', cardId })
-        actor.send({ type: 'CONFIRM' })
       }
     }
   }

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -714,6 +714,18 @@ export const gameStore = setup({
       return {}
     }),
 
+    // Card-first Scout entry: the card held in cardSelected becomes the
+    // first of the three discards (selectCard may also have auto-picked an
+    // industry tile — clear it, scout never uses one).
+    seedScoutFromSelectedCard: assign(({ context }) => {
+      if (!context.selectedCard) return {}
+      return {
+        selectedCardsForScout: [context.selectedCard],
+        selectedCard: null,
+        selectedIndustryTile: null,
+      }
+    }),
+
     selectLink: assign(({ context, event }) => {
       if (event.type !== 'SELECT_LINK') return {}
       debugLog('selectLink', context, event)
@@ -1606,9 +1618,7 @@ export const gameStore = setup({
               const tileToRemove = tilesWithQuantity
                 .filter((t) => t.quantityAvailable > 0)
                 .map((t) => t.tile)
-                .find(
-                  (t) => t.level === lowestLevel && isDevelopable(t),
-                )
+                .find((t) => t.level === lowestLevel && isDevelopable(t))
 
               if (tileToRemove) {
                 updatedPlayer.industryTilesOnMat = {
@@ -2457,6 +2467,25 @@ export const gameStore = setup({
       const card = findCardInHand(player, event.cardId)
       return card?.type === 'location' || card?.type === 'wild_location'
     },
+    isCardInHand: ({ context, event }) => {
+      if (event.type !== 'SELECT_CARD') return false
+      const player = getCurrentPlayer(context)
+      return findCardInHand(player, event.cardId) !== null
+    },
+    isSelectedCardReclick: ({ context, event }) => {
+      if (event.type !== 'SELECT_CARD') return false
+      return (
+        context.selectedCard !== null &&
+        context.selectedCard.id === event.cardId
+      )
+    },
+    // Card-first BUILD routing — the same split isLocationCard/isIndustryCard
+    // make on the SELECT_CARD event, but read from the already-held card.
+    isSelectedCardLocationKind: ({ context }) =>
+      context.selectedCard?.type === 'location' ||
+      context.selectedCard?.type === 'wild_location',
+    isSelectedCardIndustry: ({ context }) =>
+      context.selectedCard?.type === 'industry',
     canCompleteBuild: ({ context }) => {
       // For REAL location cards, just need card and location (wild location
       // cards fall through to the full tile + location + resources check).
@@ -2985,6 +3014,72 @@ export const gameStore = setup({
                 TAKE_LOAN: 'takingLoan',
                 NETWORK: 'networking',
                 PASS: 'passing',
+                // Card-first entry: picking a hand card before an action
+                // holds it and offers the actions it can start.
+                SELECT_CARD: {
+                  target: 'cardSelected',
+                  actions: 'selectCard',
+                  guard: 'isCardInHand',
+                },
+              },
+            },
+            // A hand card is held but no action chosen yet. Each action
+            // event continues into that action's normal flow PAST its
+            // card step — the held card is carried, never re-asked.
+            cardSelected: {
+              on: {
+                SELECT_CARD: [
+                  {
+                    // Clicking the held card again puts it back.
+                    target: 'selectingAction',
+                    actions: 'clearSelections',
+                    guard: 'isSelectedCardReclick',
+                  },
+                  {
+                    // Clicking another card switches the held card.
+                    actions: 'selectCard',
+                    guard: 'isCardInHand',
+                  },
+                ],
+                BUILD: [
+                  {
+                    // Same routing as the action-first SELECT_CARD split:
+                    // location & wild cards pick the industry next; a real
+                    // industry card (tile auto-picked) goes to the site.
+                    target:
+                      '#brassGame.playing.action.building.selectingIndustryType',
+                    guard: 'isSelectedCardLocationKind',
+                  },
+                  {
+                    target:
+                      '#brassGame.playing.action.building.selectingLocation',
+                    guard: 'isSelectedCardIndustry',
+                  },
+                  {
+                    target:
+                      '#brassGame.playing.action.building.selectingIndustryType',
+                  },
+                ],
+                NETWORK: {
+                  target: '#brassGame.playing.action.networking.selectingLink',
+                },
+                DEVELOP: {
+                  target: '#brassGame.playing.action.developing.selectingTiles',
+                },
+                SELL: {
+                  target: '#brassGame.playing.action.selling.selectingSale',
+                },
+                TAKE_LOAN: {
+                  target: '#brassGame.playing.action.takingLoan.confirmingLoan',
+                },
+                SCOUT: {
+                  target: '#brassGame.playing.action.scouting.selectingCards',
+                  actions: 'seedScoutFromSelectedCard',
+                },
+                CANCEL: {
+                  target: 'selectingAction',
+                  actions: 'clearSelections',
+                },
               },
             },
             building: {


### PR DESCRIPTION
## What

Captain (2026-07-16): *"it sometimes happens that I click on the card first and then I want to select the action."* Both orders now work — the existing action-first flow is untouched, and a new **card-first** flow lets you play a hand card while no action is in progress, then pick the action for it.

## How (engine owns the flow — no UI pseudo-state)

- New first-class state `playing.action.cardSelected` in the machine (`src/store/gameStore.ts`): `SELECT_CARD` from `selectingAction` (guarded by `isCardInHand`) holds the card via the SAME shared `selectCard` action the per-action flows use (industry cards auto-pick their buildable tile, unchanged).
- Each action event from `cardSelected` jumps **past** that action's own `selectingCard` step, so the held card is carried in and never re-asked:
  - `BUILD` routes by the held card's type with new context guards (`isSelectedCardLocationKind` / `isSelectedCardIndustry`) — the exact same split the action-first `SELECT_CARD` event guards make (location & wild → industry choice; industry → site choice).
  - `SCOUT` seeds the three-discard pick with the held card (`seedScoutFromSelectedCard`).
  - `NETWORK`/`DEVELOP`/`SELL`/`TAKE_LOAN` resume at their post-card step.
- Re-clicking the held card, clicking another card, or `CANCEL`: deselect / switch / back to idle. `PASS` stays idle-only (it plays no card).
- UI on both surfaces just renders the state: `getHandSelection` makes the hand live in idle and marks the held card; a `cardSelected` dock branch shows the same six action plaques gated by `can()` + the existing sell probe (extended to cover `cardSelected` in both `game.tsx` and `mp-game.tsx`). Multiplayer needs no wire changes — `SELECT_CARD` and the action events were already whitelisted.
- The AI's `legal-moves.ts` deliberately does **not** offer the card-first entry: every move it reaches is reachable action-first, and the deterministic fallback (which ranks `SELECT_CARD` high for mid-flow discard steps) would loop through it in idle.

## Tests

- New `src/store/gameStore.cardfirst.test.ts` (19 tests): entry/deselect/switch/cancel, per-card-type BUILD routing incl. wilds, full completions (location-card build, industry-card build, network, develop, loan, scout with seeded discard), `can()` legality from `cardSelected`, and action-first regression pins.
- New `e2e/card-first.spec.ts` (3 journeys): card-first network completes with real money movement; card-first build resumes at the right step and cancels clean; re-tap and "Put back" both deselect.
- Two scripted suites (`gameStore.income.test.ts` helper, one `gameStore.build.test.ts` test) sent a stray `SELECT_CARD`+`CONFIRM` after `PASS` — no-ops before this change (PASS discards by itself). Dropped the stray sends; the tests' intent is unchanged.
- Browser-verified live on `?demo`: idle hint pill, hold/deselect, card-first Build greys exactly the same industries as action-first with the same card (probe parity).

## Pre-existing failures (not this PR)

Verified identical on clean `origin/main` in a throwaway worktree: `gameUtils.industrySlots.test.ts` (9) + `buildValidation.test.ts` (1) fail offline, and the DB-backed suites/e2e (`gameStore.multiplayer.test.ts`, multiplayer e2e chat-badge step) fail in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
