### PR TITLE
build: upgrade to TypeScript 7 native (tsgo) — typecheck 3.84s → 1.02s

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,38 @@ when the pin changes.
 - Board connections as arrays of relationship objects
 - Immutable state updates using XState assign actions
 
+## TypeScript 7 (native `tsc`, upgraded 2026-07-16)
+
+TWO packages, and the split is deliberate — do not "fix" it back to one:
+- `@typescript/native` (= `npm:typescript@7`) supplies the **`tsc` binary**.
+  TS7 is the native (Go) compiler; `pnpm typecheck` runs it.
+- `typescript` is ALIASED to `npm:@typescript/typescript6` — the sanctioned
+  6.0 **compiler-API** compat shim. TS7 ships no classic API
+  (`require('typescript')` on real TS7 yields 2 keys: `version` + `unstable/*`),
+  so anything calling `ts.createProgram` needs this. Here that is **Next's own
+  TS integration** (`next build`'s "checking validity of types", `next dev`).
+  Nothing else does: eslint is unwired (no config/script — Biome lints), and
+  vitest transpiles via esbuild.
+No bin collision: typescript@7 ships `tsc`, typescript6 ships `tsc6`.
+`pnpm exec tsc --version` must say 7.x — if it says 6.x the alias is inverted.
+
+TS7 constraints that bit this repo (see `tsconfig.json`):
+- **`baseUrl` is REMOVED** (TS5102). Every `paths` mapping must be
+  `./`-prefixed and resolves relative to the tsconfig.
+- Side-effect imports of undeclared modules are now an error (TS2882). Next
+  only declares `*.module.css`, so global `import './globals.css'` needs the
+  ambient `declare module '*.css'` in `css.d.ts` — deleting that file breaks
+  `pnpm typecheck`.
+- TS6/7 default `types` to `[]`. No explicit array is needed here (node/react
+  types arrive via next-env.d.ts's `/// <reference types="next" />`, and every
+  test imports `vitest` explicitly rather than using bare globals) — but add
+  one if you introduce a dependency on ambient `@types/*` globals.
+
+GOTCHA: `pnpm check` (`biome check && tsc --noEmit`) fails on PRE-EXISTING
+formatter complaints in files nobody touched (demo snapshots, `gameUtils.ts`,
+`mp/game.ts`). CI runs `pnpm lint` + `pnpm typecheck`, which are green; don't
+chase `check` failures you didn't cause, and don't `pnpm format:write` (see
+the Formatting gotcha above).
 
 ### Shadcn MCP Server
 When a task requires building or modifying a user interface, you must use the tools available in the shadcn-ui MCP server.

--- a/css.d.ts
+++ b/css.d.ts
@@ -1,0 +1,8 @@
+// Global stylesheet side-effect imports (`import './globals.css'`).
+//
+// Next ships ambient types for '*.module.css' only, never plain '*.css'.
+// TypeScript <=5 let an undeclared side-effect import pass silently; TS7
+// rejects it with TS2882, so the stock Next pattern needs this declaration.
+// The more specific '*.module.css' pattern in next/types/global.d.ts still
+// wins for CSS modules.
+declare module '*.css'

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "prettier-plugin-tailwindcss": "^0.6.5",
     "shadcn-ui": "^0.9.4",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.5.3",
+    "@typescript/native": "npm:typescript@7.0.2",
+    "typescript": "npm:@typescript/typescript6@6.0.2",
     "vitest": "^3.0.6"
   },
   "ct3aMetadata": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.0.1
       '@t3-oss/env-nextjs':
         specifier: ^0.10.1
-        version: 0.10.1(typescript@5.7.3)(zod@3.24.2)
+        version: 0.10.1(@typescript/typescript6@6.0.2)(zod@3.24.2)
       '@vercel/functions':
         specifier: ^3.7.5
         version: 3.7.5(ws@8.21.1)
@@ -80,10 +80,13 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.1.0
-        version: 8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.24.1(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(@typescript/typescript6@6.0.2)(eslint@8.57.1)
       '@typescript-eslint/parser':
         specifier: ^8.1.0
-        version: 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+        version: 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
+      '@typescript/native':
+        specifier: npm:typescript@7.0.2
+        version: typescript@7.0.2
       drizzle-kit:
         specifier: ^0.31.4
         version: 0.31.4
@@ -92,7 +95,7 @@ importers:
         version: 8.57.1
       eslint-config-next:
         specifier: ^15.0.1
-        version: 15.1.7(eslint@8.57.1)(typescript@5.7.3)
+        version: 15.1.7(@typescript/typescript6@6.0.2)(eslint@8.57.1)
       eslint-plugin-drizzle:
         specifier: ^0.2.3
         version: 0.2.3(eslint@8.57.1)
@@ -107,13 +110,13 @@ importers:
         version: 0.6.11(prettier@3.5.2)
       shadcn-ui:
         specifier: ^0.9.4
-        version: 0.9.4(typescript@5.7.3)
+        version: 0.9.4(@typescript/typescript6@6.0.2)
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.17
       typescript:
-        specifier: ^5.5.3
-        version: 5.7.3
+        specifier: npm:@typescript/typescript6@6.0.2
+        version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: ^3.0.6
         version: 3.0.6(@types/node@20.17.19)(jiti@1.21.7)(yaml@2.7.0)
@@ -1286,6 +1289,130 @@ packages:
   '@typescript-eslint/visitor-keys@8.24.1':
     resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -3373,9 +3500,14 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.7.3:
-    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   unbox-primitive@1.1.0:
@@ -4395,18 +4527,18 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@t3-oss/env-core@0.10.1(typescript@5.7.3)(zod@3.24.2)':
+  '@t3-oss/env-core@0.10.1(@typescript/typescript6@6.0.2)(zod@3.24.2)':
     dependencies:
       zod: 3.24.2
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: '@typescript/typescript6@6.0.2'
 
-  '@t3-oss/env-nextjs@0.10.1(typescript@5.7.3)(zod@3.24.2)':
+  '@t3-oss/env-nextjs@0.10.1(@typescript/typescript6@6.0.2)(zod@3.24.2)':
     dependencies:
-      '@t3-oss/env-core': 0.10.1(typescript@5.7.3)(zod@3.24.2)
+      '@t3-oss/env-core': 0.10.1(@typescript/typescript6@6.0.2)(zod@3.24.2)
       zod: 3.24.2
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   '@ts-morph/common@0.19.0':
     dependencies:
@@ -4455,32 +4587,32 @@ snapshots:
     dependencies:
       '@types/node': 20.17.19
 
-  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.24.1(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(@typescript/typescript6@6.0.2)(eslint@8.57.1)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/type-utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/type-utils': 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
+      '@typescript-eslint/utils': 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
       '@typescript-eslint/visitor-keys': 8.24.1
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(@typescript/typescript6@6.0.2)
       '@typescript-eslint/visitor-keys': 8.24.1
       debug: 4.4.0
       eslint: 8.57.1
-      typescript: 5.7.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -4489,20 +4621,20 @@ snapshots:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/visitor-keys': 8.24.1
 
-  '@typescript-eslint/type-utils@8.24.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/type-utils@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(@typescript/typescript6@6.0.2)
+      '@typescript-eslint/utils': 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
       debug: 4.4.0
       eslint: 8.57.1
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.24.1': {}
 
-  '@typescript-eslint/typescript-estree@8.24.1(typescript@5.7.3)':
+  '@typescript-eslint/typescript-estree@8.24.1(@typescript/typescript6@6.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.24.1
       '@typescript-eslint/visitor-keys': 8.24.1
@@ -4511,19 +4643,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.1
-      ts-api-utils: 2.0.1(typescript@5.7.3)
-      typescript: 5.7.3
+      ts-api-utils: 2.0.1(@typescript/typescript6@6.0.2)
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.24.1(eslint@8.57.1)(typescript@5.7.3)':
+  '@typescript-eslint/utils@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.24.1
       '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/typescript-estree': 8.24.1(@typescript/typescript6@6.0.2)
       eslint: 8.57.1
-      typescript: 5.7.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - supports-color
 
@@ -4531,6 +4663,70 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.24.1
       eslint-visitor-keys: 4.2.0
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -4884,14 +5080,14 @@ snapshots:
     dependencies:
       is-what: 4.1.16
 
-  cosmiconfig@8.3.6(typescript@5.7.3):
+  cosmiconfig@8.3.6(@typescript/typescript6@6.0.2):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5205,21 +5401,21 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@15.1.7(eslint@8.57.1)(typescript@5.7.3):
+  eslint-config-next@15.1.7(@typescript/typescript6@6.0.2)(eslint@8.57.1):
     dependencies:
       '@next/eslint-plugin-next': 15.1.7
       '@rushstack/eslint-patch': 1.10.5
-      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.24.1(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(@typescript/typescript6@6.0.2)(eslint@8.57.1)
+      '@typescript-eslint/parser': 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.1.0(eslint@8.57.1)
     optionalDependencies:
-      typescript: 5.7.3
+      typescript: '@typescript/typescript6@6.0.2'
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
@@ -5244,15 +5440,15 @@ snapshots:
       stable-hash: 0.0.4
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@8.57.1)
@@ -5263,7 +5459,7 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5274,7 +5470,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.8.3)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5286,7 +5482,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
+      '@typescript-eslint/parser': 8.24.1(@typescript/typescript6@6.0.2)(eslint@8.57.1)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -6470,7 +6666,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  shadcn-ui@0.9.4(typescript@5.7.3):
+  shadcn-ui@0.9.4(@typescript/typescript6@6.0.2):
     dependencies:
       '@antfu/ni': 0.21.12
       '@babel/core': 7.26.9
@@ -6478,7 +6674,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.26.8(@babel/core@7.26.9)
       chalk: 5.2.0
       commander: 10.0.1
-      cosmiconfig: 8.3.6(typescript@5.7.3)
+      cosmiconfig: 8.3.6(@typescript/typescript6@6.0.2)
       diff: 5.2.0
       execa: 7.2.0
       fast-glob: 3.3.3
@@ -6777,9 +6973,9 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
-  ts-api-utils@2.0.1(typescript@5.7.3):
+  ts-api-utils@2.0.1(@typescript/typescript6@6.0.2):
     dependencies:
-      typescript: 5.7.3
+      typescript: '@typescript/typescript6@6.0.2'
 
   ts-interface-checker@0.1.13: {}
 
@@ -6842,7 +7038,30 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript@5.7.3: {}
+  typescript@6.0.3: {}
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,8 +23,8 @@
     "plugins": [{ "name": "next" }],
     "incremental": true,
 
-    /* Path Aliases */
-    "baseUrl": ".",
+    /* Path Aliases — TS7 removed 'baseUrl'; paths are resolved relative to
+       this file, so every mapping must be './'-prefixed. */
     "paths": {
       "~/*": ["./src/*"]
     }


### PR DESCRIPTION
## Intent

Move brass to **TypeScript 7 GA** (the native Go compiler) for faster typecheck/build, following the pattern proven in `Saidot-Ltd/monorepo#1913`. Brass is a single-package T3 app, so it needs materially less than that monorepo did — I verified each piece rather than porting it wholesale.

## Result: typecheck is 3.8× faster

Cold `pnpm typecheck` (`tsconfig.tsbuildinfo` removed before each run), same machine, both invoked via `pnpm exec`:

| | runs | median |
|---|---|---|
| **Before** (tsc 5.7.3) | 4.38 / 3.83 / 3.90 / 3.82 / 3.84 | **3.84s** |
| **After** (tsc 7.0.2 native) | 1.90 / 1.01 / 0.98 / 1.02 / 1.06 | **1.02s** |

**−73% (3.8× faster)**, re-confirmed after the final commit (1.23 / 1.01 / 1.03). The first run of each set is cold-cache; medians exclude that skew by construction.

## What changed

TypeScript ships as **two packages**, deliberately:

- **`@typescript/native`** (= `npm:typescript@7`) supplies the **`tsc` binary**.
- **`typescript`** is aliased to **`npm:@typescript/typescript6`**, the sanctioned 6.0 **compiler-API** compat shim.

Why the shim is required, verified rather than assumed: `require()` on real typescript@7 returns only **2 keys** (`version` + `unstable/*`) — TS7 ships no classic compiler API. Next's own TS integration calls `ts.createProgram`, so it needs the 6.0 API (2248 keys). I checked every other candidate:

| Tool | Needs the compat alias? |
|---|---|
| **Next.js** (`next build` type validation, `next dev`) | **Yes** — the reason the alias exists |
| eslint / typescript-eslint | No — eslint is entirely unwired here (no config, no script; Biome lints) |
| vitest | No — transpiles via esbuild |
| drizzle-kit | No — bundles its own |

The bins don't collide: typescript@7 ships `tsc`, typescript6 ships `tsc6`. `pnpm exec tsc --version` → `7.0.2`.

## New type errors TS7 surfaced (2, both fixed minimally)

1. **`TS5102: Option 'baseUrl' has been removed`** — TS7 dropped `baseUrl`. Brass's `paths` were already `./`-prefixed, so deleting `baseUrl` was the whole fix.
2. **`TS2882: Cannot find module or type declarations for side-effect import`** ×3 — TS≤5 let an undeclared side-effect import pass silently; TS7 rejects it. Next declares `*.module.css` but **never plain `*.css`**, yet `app/layout.tsx` importing `./globals.css` is the stock Next scaffold. Fixed with an ambient `declare module '*.css'` in a new `css.d.ts`. The more specific `*.module.css` pattern still wins for CSS modules.

**No `types` array needed** (unlike the reference PR): node/react types arrive via next-env.d.ts's `/// <reference types="next" />`, and every test file imports `vitest` explicitly rather than relying on bare globals — I swept all test files to confirm.

**CI needs no change**: `ci.yml` calls the `pnpm typecheck` *script*, not `tsc` directly, so it picks up TS7 through `node_modules/.bin`.

## Testing

- **`pnpm typecheck`** → exit 0, tsc 7.0.2.
- **`pnpm test`** → **47/47 test files, 393 passed, 3 skipped**, including every DB-backed suite (the run provisioned and cleaned up its own ephemeral Neon branch).
- **`pnpm build`** → green, incl. Next's own "Linting and checking validity of types" step — this is what actually exercises the compat alias.
- **`next dev`** → Ready in 1104ms, `GET / 200`, no TS complaints.
- **`pnpm lint`** (what CI runs) → clean, 163 files.

<details>
<summary>Two things that look like failures but are pre-existing — proven, not assumed</summary>

**1. Three DB suites fail without DB credentials.** This worktree's `.env` had an empty `DATABASE_URL`. I checked out the **pre-TS7 base commit into a throwaway worktree** and ran the same three suites on tsc 5.7.3: they fail identically with the same `No database connection string was provided to neon()`. Not a TS7 regression. Once I supplied a project-scoped `NEON_API_KEY` (giving the run its own ephemeral branch, per AGENTS.md), **all 47 files pass**.

**2. `pnpm check` fails on formatter complaints.** `pnpm check` is `biome check && tsc --noEmit`; the `biome check` half flags demo snapshots, `gameUtils.ts`, `mp/game.ts` and some tests. None are in this diff. Proven pre-existing by running the formatter against **base-commit content** of `gameUtils.ts` — it already complains there. My three touched files are clean. CI runs `pnpm lint` + `pnpm typecheck`, both green.
</details>

## Risk

⚠️ Low-medium. A toolchain swap has broad blast radius, but it touches no runtime app source — only build config and the lockfile — and every entry point (typecheck, build, dev, unit + DB tests, lint) is verified green. The one genuinely new runtime-adjacent artifact is `css.d.ts`, which only adds an ambient declaration.

## Follow-up (deliberately not in this PR)

The unused eslint devDeps (`eslint`, `eslint-config-next`, `@typescript-eslint/*`, `@types/eslint`, `eslint-plugin-drizzle`) now print unmet-peer warnings on install (typescript-eslint wants `<5.8.0`, sees 6.0.2). They are **provably dead** — no eslint config or script exists, and Biome does the linting — so the warnings are cosmetic. Removing them is a separate cleanup; `tsconfig.json`'s `include` also still lists a `.eslintrc.cjs` that doesn't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
