### PR TITLE
fix: address the unresolved CodeRabbit findings on merged PR #26 (beer/iron source choice)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,13 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   - Merchant beer is only offered on a sale (never a network action, rules
     p.9); the IRON MARKET is a FALLBACK not an alternative (rules p.5) — it is
     never offered as a choice while any unflipped works has iron, though
-    consumption still falls back to it for cubes the works can't cover.
+    consumption still falls back to it for cubes the works can't cover. Both
+    layers enforce it off ONE flag — `fallbackOnly` on the option
+    (`getIronSourceOptions`): the choice filters it out, and the planner
+    refuses an EXPLICIT fallback-only preference at execution too. Both
+    layers enforce it off ONE flag — `fallbackOnly` on the option
+    (`getIronSourceOptions`): the choice filters it out, and the planner
+    refuses an EXPLICIT fallback-only preference at execution too.
   - These context fields are backfilled in `rehydrateSnapshot`
     (`src/server/ai/driver.ts`) AND read defensively (`?? []`) everywhere,
     because demo fixtures and pre-deploy saved/MP games were frozen without

--- a/e2e/coverage.spec.ts
+++ b/e2e/coverage.spec.ts
@@ -104,13 +104,12 @@ test('Network: rail-era double-link build (two routes, £15 + coal + beer)', asy
     await expect(secondPrompt).toBeHidden({ timeout: 1000 })
   }).toPass()
 
-  // Whether a Beer step appears depends on how many breweries reach the second
-  // rail (see beer-source.spec for the picker itself). Answer it if it's there,
-  // then confirm — either way the double build completes.
+  // The second rail brings more than one brewery into reach, so this fixture
+  // always stops at the machine's Beer step (see beer-source.spec for the
+  // picker itself). Assert it, answer it, then confirm.
   const beer = page.getByTestId('beer-source')
-  if ((await beer.count()) > 0) {
-    await beer.first().click()
-  }
+  await expect(beer.first()).toBeVisible()
+  await beer.first().click()
   const confirm = page.getByTestId('confirm-action')
   await expect(confirm).toBeEnabled()
   await confirm.click()
@@ -136,18 +135,17 @@ test('Sell: gated with an explanation when nothing can be sold', async ({
 
 /**
  * Stage a sale and see it through. A sale whose beer could come from more than
- * one place stops at the machine's beer step; assigning the last (here, only)
- * barrel flips the industry. A single-source sale never stops.
+ * one place stops at the machine's beer step; assigning the barrel flips the
+ * industry. A single-source sale never stops. The caller states which case the
+ * fixture puts it in (`expectBeerChoice`) so the step is asserted, not probed —
+ * isVisible()/count() don't auto-wait and silently skipped the pick on a slow
+ * render.
  */
-async function takeSale(page: Page, index = 0) {
-  await page.getByTestId('sale-option').nth(index).click()
-  const sources = page.getByTestId('beer-source')
-  if (
-    await sources
-      .first()
-      .isVisible()
-      .catch(() => false)
-  ) {
+async function takeSale(page: Page, expectBeerChoice: boolean) {
+  await page.getByTestId('sale-option').first().click()
+  if (expectBeerChoice) {
+    const sources = page.getByTestId('beer-source')
+    await expect(sources.first()).toBeVisible()
     await sources.first().click()
   }
 }
@@ -163,10 +161,12 @@ test('Sell: multi-sale — flip two industries in one action', async ({
   await sell.click()
   await page.locator('button.bb2-card:not([disabled])').first().click()
 
-  // First sale, then a second one from the refreshed option list.
-  await takeSale(page)
+  // First sale, then a second one from the refreshed option list. The first
+  // stops at the beer step (own Stafford brewery vs the merchant barrel);
+  // draining the brewery leaves the second sale a single source — no stop.
+  await takeSale(page, true)
   await expect(page.getByText(/Flipped 1 industry this action/)).toBeVisible()
-  await takeSale(page)
+  await takeSale(page, false)
   await expect(page.getByText(/Flipped 2 industries this action/)).toBeVisible()
 
   await page.getByTestId('confirm-action').click()
@@ -355,10 +355,11 @@ test('Undo: the first action of a turn can be taken back in full', async ({
   await expect(treasuryOf(page, 'George')).toHaveText('£9')
   await expect(page.getByTestId('undo-action')).toHaveCount(0)
 
-  // First action: sell one industry.
+  // First action: sell one industry (its beer needs the picker — see the
+  // multi-sale test above for why the first sale of this fixture stops).
   await page.getByTestId('action-sell').click()
   await page.locator('button.bb2-card:not([disabled])').first().click()
-  await takeSale(page)
+  await takeSale(page, true)
   await expect(page.getByText(/Flipped 1 industry this action/)).toBeVisible()
   await page.getByTestId('confirm-action').click()
   await expect(

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -978,7 +978,14 @@ export function ActionDock({
     return (
       <Flow
         action={building ? 'Build' : 'Develop'}
-        steps={building ? buildSteps : ['Card', 'Tiles', 'Confirm']}
+        // An Iron step joins the rail while the question is open — exactly
+        // like the Beer step on a sale or double rail. Without it the rail
+        // marked Confirm active while the player was still picking iron.
+        steps={
+          building
+            ? ['Card', 'Industry', 'Site', 'Iron', 'Confirm']
+            : ['Card', 'Tiles', 'Iron', 'Confirm']
+        }
         active={building ? 3 : 2}
         onCancel={cancel}
       >

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -720,17 +720,26 @@ function GameInner({
     setHoveredCard(null)
   }, [currentPlayer?.id])
 
-  // While the machine is asking WHERE a sale's beer comes from, spotlight the
-  // places it could come from — the choice is about the board, so it belongs
-  // on it. Both the question and the answers are the engine's.
+  // While the machine is asking WHERE beer comes from — a staged sale's
+  // barrels or the double rail's one — spotlight the places it could come
+  // from; the choice is about the board, so it belongs on it. Gated on the
+  // machine STATE (not on pendingSale) so the double-link beer step lights
+  // up too. Both the question and the answers are the engine's.
   const beerCandidateCities = useMemo(() => {
-    if (!ctx.pendingSale) return null
+    if (
+      !state.matches('playing.action.selling.choosingBeerSource' as never) &&
+      !state.matches(
+        'playing.action.networking.choosingDoubleLinkBeer' as never,
+      )
+    ) {
+      return null
+    }
     const choice = pendingBeerChoice(ctx)
     if (!choice?.hasChoice) return null
     return new Set<string>(
       choice.options.map((option) => option.source.location),
     )
-  }, [ctx])
+  }, [state, ctx])
 
   const boardPrompt = useMemo(() => {
     if (pickingSite) {

--- a/src/store/gameStore.sourcechoice.test.ts
+++ b/src/store/gameStore.sourcechoice.test.ts
@@ -8,6 +8,8 @@
 import { afterEach, describe, expect, test } from 'vitest'
 import { createActor } from 'xstate'
 import { type Merchant, gameStore } from './gameStore'
+import { consumeIronFromSources } from './market/marketActions'
+import { explainRefusal } from './refusal'
 import {
   beerChoiceForSale,
   ironChoiceForConfirm,
@@ -963,5 +965,213 @@ describe('Resource source choice - the engine answers what a step is asking', ()
     expect(choice.required).toBe(2)
     expect(choice.options.map((o) => o.source.kind)).toEqual(['ironworks'])
     expect(choice.hasChoice).toBe(false)
+  })
+})
+
+describe('Iron market is fallback-only — the consumption layer enforces it too', () => {
+  // Regression (PR #26 review): the pick guard already refused an explicit
+  // market pick while a works had iron, but consumeIronFromSources planned
+  // from the UNFILTERED option list — so an explicit market preference
+  // reaching execution bought market iron while unflipped works remained,
+  // violating rules p.5 ("If there are NO unflipped Iron Works, you can
+  // purchase iron from the Iron Market").
+  test('an explicit market pick is refused while any unflipped works has iron', () => {
+    const { actor } = setupGame()
+    const developerIndex = actor.getSnapshot().context.currentPlayerIndex
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: developerIndex,
+      money: 30,
+      industries: [
+        makeIndustry('birmingham', ironTile, { ironCubesOnTile: 1 }),
+      ],
+    })
+
+    const context = actor.getSnapshot().context
+    const result = consumeIronFromSources(context, 1, [{ kind: 'market' }])
+
+    expect(result.success).toBe(false)
+    expect(result.errorMessage).toMatch(/fallback/)
+    // Nothing was bought or drained on the refused attempt
+    expect(result.ironCost).toBe(0)
+    expect(result.updatedIronMarket).toEqual(context.ironMarket)
+  })
+
+  test('the market pick is accepted once no unflipped works remains', () => {
+    const { actor } = setupGame()
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 0, industries: [] })
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 1, industries: [] })
+
+    const context = actor.getSnapshot().context
+    const result = consumeIronFromSources(context, 1, [{ kind: 'market' }])
+
+    expect(result.success).toBe(true)
+    expect(result.ironCost).toBeGreaterThan(0)
+  })
+
+  test('the automatic fallback still covers cubes the works cannot supply', () => {
+    const { actor } = setupGame()
+    const developerIndex = actor.getSnapshot().context.currentPlayerIndex
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: developerIndex,
+      money: 30,
+      industries: [
+        makeIndustry('birmingham', ironTile, { ironCubesOnTile: 1 }),
+      ],
+    })
+    const developerId = actor.getSnapshot().context.players[developerIndex]!.id
+
+    const context = actor.getSnapshot().context
+    // Prefer the works for cube 1; cube 2 exceeds what any works can give, so
+    // the planner's default falls back to the market — which rules p.5 allows
+    // exactly then (no unflipped works is left holding iron).
+    const result = consumeIronFromSources(context, 2, [
+      { kind: 'ironworks', ownerId: developerId, location: 'birmingham' },
+    ])
+
+    expect(result.success).toBe(true)
+    expect(result.ironCost).toBeGreaterThan(0)
+  })
+})
+
+describe('Refusals name what is wrong with a source pick', () => {
+  // Regression (PR #26 review): explainRefusal only checked MEMBERSHIP of the
+  // picked source in the step's options. A source that IS offered but already
+  // drained by this step's earlier picks fell through to null — the player got
+  // the generic "not legal right now" instead of the actual reason.
+  const developWithTwoWorks = () => {
+    const { actor } = setupGame()
+    const developerIndex = actor.getSnapshot().context.currentPlayerIndex
+    const opponentIndex = developerIndex === 0 ? 1 : 0
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: developerIndex,
+      money: 30,
+      industries: [
+        makeIndustry('birmingham', ironTile, { ironCubesOnTile: 1 }),
+      ],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: opponentIndex,
+      industries: [makeIndustry('dudley', ironTile, { ironCubesOnTile: 2 })],
+    })
+    const hand = actor.getSnapshot().context.players[developerIndex]!.hand
+    actor.send({ type: 'DEVELOP' })
+    actor.send({ type: 'SELECT_CARD', cardId: hand[0]!.id })
+    actor.send({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['cotton', 'coal'],
+    })
+    // 2 cubes required, 3 available across two works: the step is open
+    expect(
+      actor.getSnapshot().matches({
+        playing: { action: { developing: 'choosingIronSource' } },
+      }),
+    ).toBe(true)
+    return { actor, developerIndex, opponentIndex }
+  }
+
+  test('an exhausted iron works is refused as exhausted, not "unavailable"', () => {
+    const { actor, developerIndex } = developWithTwoWorks()
+    const developerId = actor.getSnapshot().context.players[developerIndex]!.id
+    const own = {
+      kind: 'ironworks',
+      ownerId: developerId,
+      location: 'birmingham',
+    } as const
+
+    // Its only cube — a second pick from the same works must be refused
+    actor.send({ type: 'SELECT_IRON_SOURCE', source: own })
+    const snap = actor.getSnapshot()
+    const again = { type: 'SELECT_IRON_SOURCE', source: own } as const
+    expect(snap.can(again)).toBe(false)
+    expect(explainRefusal(snap, again)).toBe(
+      'That iron source has already supplied all available cubes.',
+    )
+  })
+
+  test('an explicit market pick while works remain is named as the fallback rule', () => {
+    const { actor } = developWithTwoWorks()
+    const snap = actor.getSnapshot()
+    const pick = {
+      type: 'SELECT_IRON_SOURCE',
+      source: { kind: 'market' },
+    } as const
+    expect(snap.can(pick)).toBe(false)
+    expect(explainRefusal(snap, pick)).toBe(
+      'The iron market is a fallback — it can only be bought from when no unflipped iron works has iron.',
+    )
+  })
+
+  test('a works this step never offered is refused as unavailable', () => {
+    const { actor } = developWithTwoWorks()
+    const snap = actor.getSnapshot()
+    const pick = {
+      type: 'SELECT_IRON_SOURCE',
+      source: { kind: 'ironworks', ownerId: '99', location: 'coventry' },
+    } as const
+    expect(snap.can(pick)).toBe(false)
+    expect(explainRefusal(snap, pick)).toBe(
+      'That iron source is not available for this action.',
+    )
+  })
+
+  test('an exhausted brewery is refused as exhausted, not "unavailable"', () => {
+    // The 2-beer board from the mixed-allocation test: own 1-barrel brewery,
+    // connected opponent brewery and the merchant barrel = 3 for 2 required.
+    const { actor } = setupGame()
+    buildLinkToGloucester(actor)
+    passCurrentPlayer(actor)
+    const sellerIndex = actor.getSnapshot().context.currentPlayerIndex
+    const opponentIndex = sellerIndex === 0 ? 1 : 0
+    actor.send({
+      type: 'TEST_SET_MERCHANTS',
+      merchants: [gloucesterMerchant()],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: sellerIndex,
+      money: 20,
+      income: 10,
+      industries: [
+        makeIndustry('worcester', { ...cottonTile, beerRequired: 2 }),
+        makeIndustry('worcester', breweryTile, { beerBarrelsOnTile: 1 }),
+      ],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: opponentIndex,
+      industries: [
+        makeIndustry('gloucester', breweryTile, { beerBarrelsOnTile: 1 }),
+      ],
+    })
+    actor.send({ type: 'SELL' })
+    actor.send({
+      type: 'SELECT_CARD',
+      cardId: actor.getSnapshot().context.players[sellerIndex]!.hand[0]!.id,
+    })
+    actor.send({
+      type: 'SELECT_SALE',
+      location: 'worcester',
+      industryType: 'cotton',
+      merchant: 'gloucester',
+    })
+
+    const sellerId = actor.getSnapshot().context.players[sellerIndex]!.id
+    const own = {
+      kind: 'brewery',
+      ownerId: sellerId,
+      location: 'worcester',
+    } as const
+    actor.send({ type: 'SELECT_BEER_SOURCE', source: own })
+
+    const snap = actor.getSnapshot()
+    const again = { type: 'SELECT_BEER_SOURCE', source: own } as const
+    expect(snap.can(again)).toBe(false)
+    expect(explainRefusal(snap, again)).toBe(
+      'That beer source has already supplied all available barrels.',
+    )
   })
 })

--- a/src/store/refusal.ts
+++ b/src/store/refusal.ts
@@ -38,6 +38,8 @@ import {
 import { getCurrentPlayer } from './shared/gameUtils'
 import {
   beerSourceKey,
+  canChooseBeerSource,
+  canChooseIronSource,
   ironSourceKey,
   pendingBeerChoice,
   pendingIronChoice,
@@ -238,25 +240,34 @@ export function explainRefusal(
       return validateSale(context, event).error ?? null
 
     case 'SELECT_BEER_SOURCE': {
-      // canChooseBeerSource refuses a source this step never offered.
+      // Delegate to the guard's own validator, then tell apart the two ways
+      // it says no: a source this step offered but the earlier picks already
+      // drained, vs one it never offered at all.
       const choice = pendingBeerChoice(context)
       if (!choice?.hasChoice) return 'There is no beer source to choose here.'
+      if (canChooseBeerSource(context, event.source)) return null
       const offered = choice.options.some(
         (o) => beerSourceKey(o.source) === beerSourceKey(event.source),
       )
       return offered
-        ? null
+        ? 'That beer source has already supplied all available barrels.'
         : 'That beer source is not available for this action.'
     }
 
     case 'SELECT_IRON_SOURCE': {
       const choice = pendingIronChoice(context)
       if (!choice?.hasChoice) return 'There is no iron source to choose here.'
+      if (canChooseIronSource(context, event.source)) return null
+      // The market is absent from the offer exactly when a works has iron —
+      // name the fallback rule rather than a bare "unavailable" (rules p.5).
+      if (event.source.kind === 'market') {
+        return 'The iron market is a fallback — it can only be bought from when no unflipped iron works has iron.'
+      }
       const offered = choice.options.some(
         (o) => ironSourceKey(o.source) === ironSourceKey(event.source),
       )
       return offered
-        ? null
+        ? 'That iron source has already supplied all available cubes.'
         : 'That iron source is not available for this action.'
     }
 

--- a/src/store/shared/resourceSources.ts
+++ b/src/store/shared/resourceSources.ts
@@ -65,6 +65,12 @@ export interface IronSourceOption {
   price?: number
   /** Taking this works' LAST cube flips it, advancing its owner's income. */
   flipsOwnerTile: boolean
+  /**
+   * The source may only be reached by the automatic fallback, never by an
+   * explicit pick. Rules p.5: the market opens only when NO unflipped iron
+   * works has iron — while one does, the market is not an alternative.
+   */
+  fallbackOnly?: boolean
 }
 
 /**
@@ -231,7 +237,9 @@ export function getIronSourceOptions(
   }
 
   // The iron market is always reachable (no merchant connection required) and
-  // never runs dry — the top level sells at a fallback price forever.
+  // never runs dry — the top level sells at a fallback price forever. But it
+  // is fallback-ONLY while any unflipped works holds iron (rules p.5): the
+  // planner may spill into it, an explicit pick of it must be refused.
   const cheapest = context.ironMarket.find((level) => level.cubes > 0)
   options.push({
     source: { kind: 'market' },
@@ -241,6 +249,7 @@ export function getIronSourceOptions(
     // always names the market's real cost rather than showing it as free.
     price: cheapest?.price ?? GAME_CONSTANTS.IRON_FALLBACK_PRICE,
     flipsOwnerTile: false,
+    fallbackOnly: options.length > 0,
   })
 
   return options
@@ -275,12 +284,12 @@ export function describeIronSource(
  * auto-pick, unit for unit and log line for log line).
  *
  * A preference naming a source that is not legal here — or that has already
- * been drained — is refused rather than silently re-pointed: the player asked
- * for something specific.
+ * been drained, or that only the fallback may reach — is refused rather than
+ * silently re-pointed: the player asked for something specific.
  */
 export function planResourceSources<
   S,
-  O extends { source: S; available: number },
+  O extends { source: S; available: number; fallbackOnly?: boolean },
 >(
   options: O[],
   required: number,
@@ -319,6 +328,13 @@ export function planResourceSources<
         plan: [],
         allocated: 0,
         error: `${describe(source)} is not a legal source here.`,
+      }
+    }
+    if (byKey.get(key)!.fallbackOnly) {
+      return {
+        plan: [],
+        allocated: 0,
+        error: `${describe(source)} is only a fallback here — it cannot be chosen while another source can still supply this.`,
       }
     }
     if ((remaining.get(key) ?? 0) <= 0) {
@@ -481,9 +497,10 @@ export function ironChoiceForConfirm(
   // falls back to it for any cubes the works cannot cover (at that moment
   // there are no unflipped works left, which is exactly when the rule allows
   // it) — that fallback lives in the planner, not in this choice.
+  // getIronSourceOptions stamps the market `fallbackOnly` whenever a works
+  // exists; both this filter and the planner's refusal key off that one flag.
   const all = getIronSourceOptions(context, currentPlayer)
-  const works = all.filter((option) => option.source.kind === 'ironworks')
-  const options = works.length > 0 ? works : all
+  const options = all.filter((option) => !option.fallbackOnly)
   return {
     resource: 'iron',
     required,


### PR DESCRIPTION
Post-merge fix pass for the CodeRabbit review comments PR #26 was merged with. Every unresolved finding was verified against current `main` first — one review round's inline comments had failed to post (GitHub 503s), so this covers those seven findings too, not just the three visible unresolved threads.

## Fixed

**Iron market enforced as fallback-only at the consumption layer** ([comment 3598959757](https://github.com/julius-retzer/brass-birmingham/pull/26#discussion_r3598959757), 🟠) — the pick guard already refused an explicit market pick while an unflipped works held iron, but `consumeIronFromSources` planned from the **unfiltered** option list, so an explicit `{kind:'market'}` preference reaching execution bought market iron while works remained — against rules p.5 (*"If there are no unflipped Iron Works, you can purchase iron from the Iron Market"*). Not reachable through the UI/MP/AI wire (all pass the guard), but the shared contract now enforces it: `getIronSourceOptions` stamps the market option `fallbackOnly` whenever a works exists, and both the choice filter and the planner's explicit-preference refusal key off that one flag. The **automatic** fallback (cubes no works can cover) is unchanged. Regression-tested first (red → green).

**Refusals delegate to the guard validators** ([comment 3598959751](https://github.com/julius-retzer/brass-birmingham/pull/26#discussion_r3598959751), 🟡) — `explainRefusal` only checked membership, so a source that *was* offered but drained by this step's earlier picks fell through to `null` (generic message). It now calls `canChooseBeerSource`/`canChooseIronSource` and tells exhausted ("has already supplied all available barrels/cubes") apart from unavailable; an explicit market pick is answered with the fallback rule by name.

**Deterministic e2e conditionals** ([comment 3598959748](https://github.com/julius-retzer/brass-birmingham/pull/26#discussion_r3598959748), 🟠) — `takeSale` now takes an explicit `expectBeerChoice` flag and asserts the picker (auto-waiting) instead of probing `isVisible().catch()`; the rail double-link asserts its Beer step instead of `count() > 0`. The expected values were pinned by driving the engine directly on the frozen fixture snapshots: in `?demo=sell` the first sale stops at the beer step (own Stafford brewery vs merchant barrel) and the second doesn't (single source left); in `?era=rail` the double link always stops.

**Dock progress rail shows an Iron step** (failed-to-post round, 🟡) — `choosingIronSource` rendered the rail with **Confirm** active while the player was still picking iron. An `Iron` step now joins the rail while the question is open, exactly like the Beer step on a sale / double rail.

**Board beer highlights gate on the machine state** (failed-to-post round, 🟡) — `beerCandidateCities` keyed off `ctx.pendingSale` only, so the `choosingDoubleLinkBeer` step got no board spotlight. It now gates on `state.matches(...)` for both beer-choice states.

## Verified as already fixed on `main` (skipped)

From the review round whose inline comments failed to post (never got replies):

- **Clear the staged sale after execution** — `executeStagedSale` resets `pendingSale`/`chosenBeerSources` on both the success and failure paths (`gameStore.ts:1584,1748`).
- **Route location-card builds through iron selection** — the `SELECT_INDUSTRY_TYPE` location-card branch targets `choosingIronSource` (`gameStore.ts:3295`), pinned by the sourcechoice suite.
- **Reset beer picks entering the double-link choice** — `choosingDoubleLinkBeer` has `entry: 'enterDoubleLinkBeerStep'` which clears `chosenBeerSources`, pinned by the cancel-and-reselect test.
- **Inspector load failure blocking the splash** — `loadInspect` `.catch`es to `undefined`, so `ready` always flips true.
- **Fallback market price / provisional double-link network / iron "paid" caption** — fixed in `135bfad` during the PR (CodeRabbit acknowledged the first two; the caption only describes `kind === 'market'` as paid).

## Deliberately not changed

- **The `toPass()` retry around the second-rail click** (`coverage.spec.ts:97`) — it exists because a single trusted click on the bowed stroke can physically miss (documented board-map gotcha); the retry is bounded and converges, and CodeRabbit's final review round did not re-raise it. Removing it risks reintroducing the flake under the `retries: 0` policy.
- **Moving `ActionDock` above its helpers / named prop interfaces** (trivial nitpick) — pure churn in a 1,363-line file that other in-flight work touches; skipped to keep this surgical.

## Tests

- 8 new regression tests in `gameStore.sourcechoice.test.ts` (market-pick refusal + fallback still works + exhausted/unavailable/market refusal messages), written failing-first.
- Full suite: 431 unit tests green, 31/31 Playwright e2e green (including the DB-backed mp-playthrough).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
