### PR TITLE
Hand tray: Hearthstone-style hover magnification + phone-width fit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,7 +702,12 @@ When updating this file, preserve this bar for all agents and keep entries conci
   the config) and only created in `e2e/global-db.ts`. (5) `configureLocalProxy`
   (`src/server/db/local-proxy.ts`) must stay a no-op for cloud urls —
   `neonConfig.fetchEndpoint` is global and the cloud default rewrites the host
-  (pinned by `local-proxy.test.ts`).
+  (pinned by `local-proxy.test.ts`). (6) if the postgres container is RECREATED
+  under a long-running proxy, the proxy keeps its dead pooled backends and every
+  query 500s ("Control plane request failed") — the detection probe then reads
+  as "no local DB" and the suites quietly fall through to the
+  `[test-db] no NEON_API_KEY` path rather than failing loudly.
+  `docker compose restart neon-proxy` fixes it.
 - LOCAL TEST DB ISOLATION (added 2026-07-16; now the FALLBACK when Docker isn't
   running — CI still uses this path): every local test run gets its
   OWN throwaway Neon branch — no more sharing `dev`, and parallel runs can't

--- a/e2e/hand-tray.spec.ts
+++ b/e2e/hand-tray.spec.ts
@@ -6,11 +6,16 @@ import { expect, test } from '@playwright/test'
  * Desktop: hovering a card raises a magnified lens (data-raised on the
  * button); neighbours slide aside dock-style; clicking while raised still
  * selects (the lens is pointer-events:none, the 108×156 button hitbox
- * never grows sideways).
+ * never grows sideways). A SELECTED card keeps a smaller persistent lens
+ * (scale 1.3) until it is deselected or the action completes.
  *
  * Touch: there is no hover, so the FIRST tap peeks (raises the lens) and
- * the SECOND tap acts. Dimmed/disabled cards peek too (the seat wrapper
- * handles the tap — clicks don't fire on disabled buttons).
+ * the SECOND tap acts. A LONG-PRESS (350ms) also peeks, and keeping the
+ * finger down while sliding browses the fan Hearthstone-style — the raise
+ * follows the finger; releasing keeps the card under the finger peeked and
+ * NEVER selects (acting stays a deliberate tap on the raised card).
+ * Dimmed/disabled cards peek too (the seat wrapper handles the tap —
+ * clicks don't fire on disabled buttons).
  */
 
 /** The fan seat wrapper around a card button (carries the dock transform). */
@@ -53,9 +58,23 @@ test.describe('desktop hover magnification', () => {
     await expect(card).toHaveAttribute('data-selected', 'true')
     await expect(page.getByText('Play this card')).toBeVisible()
 
+    // The selected card STAYS enlarged after the mouse leaves — the
+    // persistent selected lens (1.3×), smaller than the hover lens.
+    await page.mouse.move(400, 200)
+    await expect(card).not.toHaveAttribute('data-raised', 'true')
+    await expect(card.locator('.bb2-card-lens')).toHaveAttribute(
+      'style',
+      /scale\(1\.3\)/,
+    )
+
     // Re-tap puts it back — nothing consumed (pinned deeper in card-first.spec).
     await card.click()
     await expect(page.getByText('Choose an action')).toBeVisible()
+    await page.mouse.move(400, 200)
+    await expect(card.locator('.bb2-card-lens')).not.toHaveAttribute(
+      'style',
+      /scale\(/,
+    )
   })
 
   test('reduced motion still raises and selects (end state, no transition)', async ({
@@ -74,9 +93,7 @@ test.describe('desktop hover magnification', () => {
 test.describe('phone: fit + tap-to-peek', () => {
   test.use({ viewport: { width: 375, height: 667 }, hasTouch: true })
 
-  test('a full 8-card opening hand fits a 375px viewport', async ({
-    page,
-  }) => {
+  test('a full 8-card opening hand fits a 375px viewport', async ({ page }) => {
     // A fresh game deals the worst case: 8 cards (the ?demo hand holds 5).
     await page.goto('/?fresh=1')
     await page.getByRole('button', { name: '2', exact: true }).tap()
@@ -119,9 +136,99 @@ test.describe('phone: fit + tap-to-peek', () => {
     await expect(card).toHaveAttribute('data-selected', 'true')
     await expect(page.getByText('Play this card')).toBeVisible()
 
+    // The selected card keeps the persistent lens (peek cleared on select).
+    await expect(card).not.toHaveAttribute('data-raised', 'true')
+    await expect(card.locator('.bb2-card-lens')).toHaveAttribute(
+      'style',
+      /scale\(1\.3\)/,
+    )
+
     // Put it back to leave the fixture untouched.
     await card.tap()
     await expect(page.getByText('Choose an action')).toBeVisible()
+  })
+
+  test('long-press browses the fan; release keeps the peek, never selects', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const start = page.getByTestId('card-birmingham_1')
+    const target = page.getByTestId('card-cotton_manufacturer_4')
+    await expect(start).toBeVisible()
+    const sBox = (await start.boundingBox())!
+    const tBox = (await target.boundingBox())!
+    const sx = sBox.x + sBox.width / 2
+    const sy = sBox.y + sBox.height / 2
+    const tx = tBox.x + tBox.width / 2
+
+    // Playwright's touchscreen only taps, so drive the long-press + slide
+    // with raw CDP touch events (trusted input, real pointer events).
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x: sx, y: sy }],
+    })
+    // Holding still for the long-press delay raises the pressed card.
+    await expect(start).toHaveAttribute('data-raised', 'true')
+    await expect(start).not.toHaveAttribute('data-selected', 'true')
+
+    // Sliding along the fan moves the raise to the card under the finger.
+    const steps = 8
+    for (let i = 1; i <= steps; i++) {
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: sx + ((tx - sx) * i) / steps, y: sy }],
+      })
+    }
+    await expect(target).toHaveAttribute('data-raised', 'true')
+    await expect(start).not.toHaveAttribute('data-raised', 'true')
+
+    // Release keeps the browsed card peeked — browsing can never select.
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchEnd',
+      touchPoints: [],
+    })
+    await expect(target).toHaveAttribute('data-raised', 'true')
+    await expect(target).not.toHaveAttribute('data-selected', 'true')
+    await expect(page.getByText('Play this card')).not.toBeVisible()
+
+    // The kept peek then acts on a normal tap (the existing second-tap rule).
+    await target.tap()
+    await expect(target).toHaveAttribute('data-selected', 'true')
+    await expect(page.getByText('Play this card')).toBeVisible()
+
+    // Put it back to leave the fixture untouched.
+    await target.tap()
+    await expect(page.getByText('Choose an action')).toBeVisible()
+  })
+
+  test('a slide that starts before the hold fires cancels the long-press', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const start = page.getByTestId('card-birmingham_1')
+    await expect(start).toBeVisible()
+    const sBox = (await start.boundingBox())!
+    const sx = sBox.x + sBox.width / 2
+    const sy = sBox.y + sBox.height / 2
+
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [{ x: sx, y: sy }],
+    })
+    // Slide immediately (beyond the 12px slop) — no browse, no peek.
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: sx + 40, y: sy }],
+    })
+    await page.waitForTimeout(500)
+    await expect(page.locator('[data-raised="true"]')).toHaveCount(0)
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchEnd',
+      touchPoints: [],
+    })
+    await expect(page.locator('[data-selected="true"]')).toHaveCount(0)
   })
 
   test('a display-only (disabled) card can still be peeked by tap', async ({

--- a/e2e/hand-tray.spec.ts
+++ b/e2e/hand-tray.spec.ts
@@ -1,0 +1,159 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Hand tray magnification + phone fit (offline, ?demo fixture).
+ *
+ * Desktop: hovering a card raises a magnified lens (data-raised on the
+ * button); neighbours slide aside dock-style; clicking while raised still
+ * selects (the lens is pointer-events:none, the 108×156 button hitbox
+ * never grows sideways).
+ *
+ * Touch: there is no hover, so the FIRST tap peeks (raises the lens) and
+ * the SECOND tap acts. Dimmed/disabled cards peek too (the seat wrapper
+ * handles the tap — clicks don't fire on disabled buttons).
+ */
+
+/** The fan seat wrapper around a card button (carries the dock transform). */
+function seatOf(page: import('@playwright/test').Page, cardId: string) {
+  return page.locator('.bb2-card-seat', {
+    has: page.getByTestId(`card-${cardId}`),
+  })
+}
+
+test.describe('desktop hover magnification', () => {
+  test('hover raises the card, shifts neighbours, and click still selects', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await expect(card).toBeVisible()
+
+    // No card is raised at rest.
+    await expect(card).not.toHaveAttribute('data-raised', 'true')
+
+    await card.hover()
+    await expect(card).toHaveAttribute('data-raised', 'true')
+
+    // The immediate neighbours slide away from the raised card.
+    await expect(seatOf(page, 'birmingham_1')).toHaveAttribute(
+      'style',
+      /translateX\(-/,
+    )
+    await expect(seatOf(page, 'cotton_manufacturer_6')).toHaveAttribute(
+      'style',
+      /translateX\((?!0px)/,
+    )
+
+    // Moving off the fan lowers the card again.
+    await page.mouse.move(400, 200)
+    await expect(card).not.toHaveAttribute('data-raised', 'true')
+
+    // Clicking a hovered card still selects it (card-first hold).
+    await card.click()
+    await expect(card).toHaveAttribute('data-selected', 'true')
+    await expect(page.getByText('Play this card')).toBeVisible()
+
+    // Re-tap puts it back — nothing consumed (pinned deeper in card-first.spec).
+    await card.click()
+    await expect(page.getByText('Choose an action')).toBeVisible()
+  })
+
+  test('reduced motion still raises and selects (end state, no transition)', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await card.hover()
+    await expect(card).toHaveAttribute('data-raised', 'true')
+    await card.click()
+    await expect(page.getByText('Play this card')).toBeVisible()
+  })
+})
+
+test.describe('phone: fit + tap-to-peek', () => {
+  test.use({ viewport: { width: 375, height: 667 }, hasTouch: true })
+
+  test('a full 8-card opening hand fits a 375px viewport', async ({
+    page,
+  }) => {
+    // A fresh game deals the worst case: 8 cards (the ?demo hand holds 5).
+    await page.goto('/?fresh=1')
+    await page.getByRole('button', { name: '2', exact: true }).tap()
+    await page.getByRole('button', { name: 'Open the ledger' }).tap()
+
+    const cards = page.locator('button.bb2-card')
+    await expect(cards.first()).toBeVisible()
+    expect(await cards.count()).toBe(8)
+    for (let i = 0; i < 8; i++) {
+      // boundingBox includes the fan rotation — the exact thing that used
+      // to push the outermost cards off screen.
+      const box = (await cards.nth(i).boundingBox())!
+      expect(box.x).toBeGreaterThanOrEqual(0)
+      expect(box.x + box.width).toBeLessThanOrEqual(375)
+    }
+  })
+
+  test('first tap peeks, second tap selects; outside tap dismisses', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await expect(card).toBeVisible()
+
+    // First tap: peek only — raised, NOT selected.
+    await card.tap()
+    await expect(card).toHaveAttribute('data-raised', 'true')
+    await expect(card).not.toHaveAttribute('data-selected', 'true')
+    await expect(page.getByText('Play this card')).not.toBeVisible()
+
+    // Tap far outside the tray: peek dismissed, still nothing selected.
+    await page.touchscreen.tap(187, 60)
+    await expect(card).not.toHaveAttribute('data-raised', 'true')
+    await expect(page.getByText('Play this card')).not.toBeVisible()
+
+    // Peek again, then tap the card again: NOW it selects.
+    await card.tap()
+    await expect(card).toHaveAttribute('data-raised', 'true')
+    await card.tap()
+    await expect(card).toHaveAttribute('data-selected', 'true')
+    await expect(page.getByText('Play this card')).toBeVisible()
+
+    // Put it back to leave the fixture untouched.
+    await card.tap()
+    await expect(page.getByText('Choose an action')).toBeVisible()
+  })
+
+  test('a display-only (disabled) card can still be peeked by tap', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+
+    // Loan: discard a card (peek-tap, then select-tap) → confirm step.
+    // (Eliza can't actually confirm — income is too low for another loan —
+    // but the confirm STEP is reached either way, which is what we need.)
+    await page.getByTestId('action-loan').tap()
+    const discard = page.getByTestId('card-brewery_2')
+    await discard.tap()
+    await discard.tap()
+    await expect(page.getByTestId('confirm-action')).toBeVisible()
+
+    // At the confirm step the hand is display-only: every card's button is
+    // disabled, so peeking rides the seat wrapper, not the button's click.
+    const other = page.getByTestId('card-birmingham_1')
+    await expect(other).toBeDisabled()
+    // tap() refuses disabled elements (actionability), which is the point:
+    // force it — the browser still dispatches real touch input at the spot.
+    await other.tap({ force: true })
+    await expect(other).toHaveAttribute('data-raised', 'true')
+
+    // A second tap folds it back down instead of selecting anything.
+    await other.tap({ force: true })
+    await expect(other).not.toHaveAttribute('data-raised', 'true')
+
+    // Unwind: confirm step → card step → idle.
+    await page.getByTestId('cancel-action').tap()
+    await page.getByTestId('cancel-action').tap()
+    await expect(page.getByText('Choose an action')).toBeVisible()
+  })
+})

--- a/src/components/hand-tray-layout.test.ts
+++ b/src/components/hand-tray-layout.test.ts
@@ -9,6 +9,7 @@ import {
   cardIndexAtX,
   dockShift,
   fanLayout,
+  hintClearance,
   lensReach,
   lensShiftX,
 } from './hand-tray-layout'
@@ -158,5 +159,25 @@ describe('cardIndexAtX (drag-to-browse)', () => {
   it('a single card owns the whole tray', () => {
     expect(cardIndexAtX(0, 1, spacing, width)).toBe(0)
     expect(cardIndexAtX(width, 1, spacing, width)).toBe(0)
+  })
+})
+
+describe('hintClearance', () => {
+  // The bug this pins: the hint pill used to sit right on top of the fan, so
+  // a selected card's persistent lens rendered straight through the
+  // instruction telling the player what to do with it.
+  it('clears the persistent selected lens on a fine pointer', () => {
+    expect(hintClearance(LENS_FINE)).toBeGreaterThan(lensReach(LENS_SELECTED))
+  })
+
+  it('clears the pointer lens on both fine and coarse', () => {
+    expect(hintClearance(LENS_FINE)).toBeGreaterThan(lensReach(LENS_FINE))
+    expect(hintClearance(LENS_COARSE)).toBeGreaterThan(lensReach(LENS_COARSE))
+  })
+
+  it('reserves for the tallest lens the device can raise, not the current one', () => {
+    // Static per device: a touch tray must hold room for its own big peek
+    // even while nothing is raised, or the pill would jump on every tap.
+    expect(hintClearance(LENS_COARSE)).toBeGreaterThan(hintClearance(LENS_FINE))
   })
 })

--- a/src/components/hand-tray-layout.test.ts
+++ b/src/components/hand-tray-layout.test.ts
@@ -4,7 +4,9 @@ import {
   FAN_SPACING,
   LENS_COARSE,
   LENS_FINE,
+  LENS_SELECTED,
   MIN_SPACING,
+  cardIndexAtX,
   dockShift,
   fanLayout,
   lensReach,
@@ -115,5 +117,46 @@ describe('lensReach', () => {
     // rise + the extra height gained by scaling from the bottom edge.
     expect(lensReach(LENS_FINE)).toBeCloseTo(40 + 156 * 0.6)
     expect(lensReach(LENS_COARSE)).toBeGreaterThan(lensReach(LENS_FINE))
+  })
+})
+
+describe('LENS_SELECTED (persistent selected-card lens)', () => {
+  it('is smaller than both transient lenses so it cannot occlude the dock', () => {
+    expect(LENS_SELECTED.scale).toBeLessThan(LENS_FINE.scale)
+    expect(LENS_SELECTED.scale).toBeLessThan(LENS_COARSE.scale)
+    expect(lensReach(LENS_SELECTED)).toBeLessThan(lensReach(LENS_FINE))
+  })
+
+  it('still visibly magnifies and lifts the card', () => {
+    expect(LENS_SELECTED.scale).toBeGreaterThan(1)
+    expect(LENS_SELECTED.rise).toBeGreaterThan(0)
+  })
+})
+
+describe('cardIndexAtX (drag-to-browse)', () => {
+  const width = 520
+  const spacing = 60
+
+  it('maps the fan centre to the middle card', () => {
+    // 8 cards: centres at width/2 + (i − 3.5)·spacing; x = width/2 sits
+    // between cards 3 and 4 — rounding picks one of the two, stably.
+    expect([3, 4]).toContain(cardIndexAtX(width / 2, 8, spacing, width))
+  })
+
+  it('maps each seat centre to its own card', () => {
+    for (let i = 0; i < 8; i++) {
+      const centerX = width / 2 + (i - 3.5) * spacing
+      expect(cardIndexAtX(centerX, 8, spacing, width)).toBe(i)
+    }
+  })
+
+  it('clamps sweeps past the fan ends to the edge cards', () => {
+    expect(cardIndexAtX(-100, 8, spacing, width)).toBe(0)
+    expect(cardIndexAtX(width + 100, 8, spacing, width)).toBe(7)
+  })
+
+  it('a single card owns the whole tray', () => {
+    expect(cardIndexAtX(0, 1, spacing, width)).toBe(0)
+    expect(cardIndexAtX(width, 1, spacing, width)).toBe(0)
   })
 })

--- a/src/components/hand-tray-layout.test.ts
+++ b/src/components/hand-tray-layout.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CARD_W,
+  FAN_SPACING,
+  LENS_COARSE,
+  LENS_FINE,
+  MIN_SPACING,
+  dockShift,
+  fanLayout,
+  lensReach,
+  lensShiftX,
+} from './hand-tray-layout'
+
+describe('fanLayout', () => {
+  it('keeps the classic fan when the width is unknown (SSR / first paint)', () => {
+    expect(fanLayout(8, null)).toEqual({ spacing: FAN_SPACING, marginX: -17 })
+  })
+
+  it('keeps the classic fan when there is room', () => {
+    // 768px tray (desktop max) holds 8 cards at full spacing: 108 + 7·74 = 626.
+    expect(fanLayout(8, 768).spacing).toBe(FAN_SPACING)
+  })
+
+  it('compresses the overlap so a full hand fits a phone-width tray', () => {
+    // 375px viewport at scale .72 → ~520 layout px.
+    const { spacing, marginX } = fanLayout(8, 520)
+    expect(spacing).toBeLessThan(FAN_SPACING)
+    // Total row width n·spacing must fit.
+    expect(8 * spacing).toBeLessThanOrEqual(520)
+    // marginX always reconstructs the spacing: card + 2·margin = spacing.
+    expect(CARD_W + 2 * marginX).toBeCloseTo(spacing)
+  })
+
+  it('accounts for the rotated overhang of the outermost cards', () => {
+    // 414px viewport at scale .72 → 575 layout px. The naive fit would be
+    // (575 − 108 − 12) / 7 ≈ 65px, but the edge cards rotate ±14° around a
+    // pivot below the card, swinging their top corners ~45px outward — the
+    // spacing must shrink to keep those corners on screen (regression: the
+    // fan visibly overflowed at 414×896 with 8 cards).
+    const { spacing } = fanLayout(8, 575)
+    expect(spacing).toBeGreaterThan(45)
+    expect(spacing).toBeLessThan(55)
+  })
+
+  it('never packs tighter than the minimum tappable slice', () => {
+    expect(fanLayout(30, 200).spacing).toBe(MIN_SPACING)
+  })
+
+  it('a single card needs no compression', () => {
+    expect(fanLayout(1, 100).spacing).toBe(FAN_SPACING)
+  })
+})
+
+describe('dockShift', () => {
+  it('is zero with nothing raised', () => {
+    expect(dockShift(3, null, LENS_FINE.scale)).toBe(0)
+  })
+
+  it('is zero for the raised card itself', () => {
+    expect(dockShift(3, 3, LENS_FINE.scale)).toBe(0)
+  })
+
+  it('pushes immediate neighbours apart, symmetric around the raised card', () => {
+    const left = dockShift(2, 3, LENS_FINE.scale)
+    const right = dockShift(4, 3, LENS_FINE.scale)
+    expect(left).toBeLessThan(0)
+    expect(right).toBeGreaterThan(0)
+    expect(left).toBe(-right)
+  })
+
+  it('falls off with distance and stops after two seats', () => {
+    const d1 = dockShift(4, 3, LENS_FINE.scale)
+    const d2 = dockShift(5, 3, LENS_FINE.scale)
+    expect(d2).toBeGreaterThan(0)
+    expect(d2).toBeLessThan(d1)
+    expect(dockShift(6, 3, LENS_FINE.scale)).toBe(0)
+  })
+
+  it('shifts further for the larger touch magnification', () => {
+    expect(dockShift(4, 3, LENS_COARSE.scale)).toBeGreaterThan(
+      dockShift(4, 3, LENS_FINE.scale),
+    )
+  })
+})
+
+describe('lensShiftX', () => {
+  const spacing = 60
+  const width = 520
+
+  it('leaves centre cards alone', () => {
+    expect(lensShiftX(3, 8, spacing, width, LENS_COARSE.scale)).toBe(0)
+  })
+
+  it('pulls the leftmost card right so the magnified visual stays on screen', () => {
+    const shift = lensShiftX(0, 8, spacing, width, LENS_COARSE.scale)
+    expect(shift).toBeGreaterThan(0)
+    // After shifting, the visual's left edge sits at the pad.
+    const centerX = width / 2 + (0 - 3.5) * spacing + shift
+    expect(centerX - (CARD_W * LENS_COARSE.scale) / 2).toBeCloseTo(8)
+  })
+
+  it('pulls the rightmost card left, mirroring the leftmost', () => {
+    const left = lensShiftX(0, 8, spacing, width, LENS_COARSE.scale)
+    const right = lensShiftX(7, 8, spacing, width, LENS_COARSE.scale)
+    expect(right).toBeCloseTo(-left)
+  })
+
+  it('does nothing when the width is unknown', () => {
+    expect(lensShiftX(0, 8, spacing, null, LENS_COARSE.scale)).toBe(0)
+  })
+})
+
+describe('lensReach', () => {
+  it('covers the full magnified visual above the seat', () => {
+    // rise + the extra height gained by scaling from the bottom edge.
+    expect(lensReach(LENS_FINE)).toBeCloseTo(40 + 156 * 0.6)
+    expect(lensReach(LENS_COARSE)).toBeGreaterThan(lensReach(LENS_FINE))
+  })
+})

--- a/src/components/hand-tray-layout.ts
+++ b/src/components/hand-tray-layout.ts
@@ -1,0 +1,108 @@
+// Pure geometry for the hand fan: spacing that always fits the tray width,
+// macOS-dock style neighbour shifts around a raised card, and the horizontal
+// clamp that keeps a magnified edge card on screen. Kept free of React so the
+// unit suite can pin the math (see hand-tray-layout.test.ts).
+
+/** Card box in layout px — must match .bb2-card in theme.css. */
+export const CARD_W = 108
+export const CARD_H = 156
+
+/** Default centre-to-centre distance between fanned cards (108 − 2×17). */
+export const FAN_SPACING = 74
+
+/** Tightest packing we allow — the visible slice of a covered card. */
+export const MIN_SPACING = 26
+
+/** How a raised card magnifies: visual scale + how far it lifts, per pointer. */
+export interface LensPreset {
+  scale: number
+  rise: number
+}
+export const LENS_FINE: LensPreset = { scale: 1.6, rise: 40 }
+export const LENS_COARSE: LensPreset = { scale: 2.1, rise: 76 }
+
+/** Fan rotation of card `index` in a hand of `count`, degrees. */
+export function fanAngle(index: number, count: number): number {
+  return (index - (count - 1) / 2) * (count > 6 ? 4 : 5.5)
+}
+
+/** How far card `index` sinks toward the table edge, layout px. */
+export function fanLift(index: number, count: number): number {
+  return Math.abs(index - (count - 1) / 2) * (count > 6 ? 5 : 7)
+}
+
+/** Seat rotation pivot: transform-origin 50% 120% (see .bb2-hand in theme.css). */
+const PIVOT_Y = 1.2 * CARD_H
+
+/**
+ * Horizontal reach of an outermost card beyond its centre once rotated:
+ * the top outer corner (PIVOT_Y above the pivot) swings outward by sinθ.
+ */
+function rotatedReach(count: number): number {
+  const theta = (Math.abs(fanAngle(0, count)) * Math.PI) / 180
+  return (CARD_W / 2) * Math.cos(theta) + PIVOT_Y * Math.sin(theta)
+}
+
+export interface FanLayout {
+  /** Centre-to-centre distance between adjacent cards, layout px. */
+  spacing: number
+  /** Horizontal margin applied to each side of a card seat (negative = overlap). */
+  marginX: number
+}
+
+/**
+ * Spacing that fits `count` cards into `width` layout px — including the
+ * horizontal overhang the outermost cards gain from their fan rotation.
+ * Falls back to the classic fan when the width is unknown (SSR / first
+ * paint) or roomy.
+ */
+export function fanLayout(count: number, width: number | null): FanLayout {
+  let spacing = FAN_SPACING
+  if (count > 1 && width !== null) {
+    const pad = 8
+    const usable = width - 2 * pad - 2 * rotatedReach(count)
+    spacing = Math.max(MIN_SPACING, Math.min(FAN_SPACING, usable / (count - 1)))
+  }
+  return { spacing, marginX: (spacing - CARD_W) / 2 }
+}
+
+/**
+ * Dock effect: neighbours slide away from the raised card so its magnified
+ * visual (which overhangs by CARD_W·(scale−1)/2 per side) doesn't bury them.
+ */
+export function dockShift(
+  index: number,
+  raisedIndex: number | null,
+  scale: number,
+): number {
+  if (raisedIndex === null || index === raisedIndex) return 0
+  const d = index - raisedIndex
+  const falloff = Math.abs(d) === 1 ? 0.8 : Math.abs(d) === 2 ? 0.3 : 0
+  const overhang = (CARD_W * (scale - 1)) / 2
+  return Math.sign(d) * falloff * overhang
+}
+
+/**
+ * Horizontal correction for a raised card near the tray edge so the
+ * magnified visual stays inside the tray instead of running off screen.
+ */
+export function lensShiftX(
+  index: number,
+  count: number,
+  spacing: number,
+  width: number | null,
+  scale: number,
+): number {
+  if (width === null) return 0
+  const pad = 8
+  const centerX = width / 2 + (index - (count - 1) / 2) * spacing
+  const half = (CARD_W * scale) / 2
+  if (centerX - half < pad) return pad + half - centerX
+  if (centerX + half > width - pad) return width - pad - half - centerX
+  return 0
+}
+
+/** How far above its seat the magnified visual reaches, layout px. */
+export function lensReach(lens: LensPreset): number {
+  return lens.rise + CARD_H * (lens.scale - 1)
+}

--- a/src/components/hand-tray-layout.ts
+++ b/src/components/hand-tray-layout.ts
@@ -115,6 +115,37 @@ export function lensReach(lens: LensPreset): number {
   return lens.rise + CARD_H * (lens.scale - 1)
 }
 
+/** Layout height of the tray box — must match .bb2-handbox in theme.css. */
+export const HANDBOX_H = 150
+
+/**
+ * Gap the hint pill must hold above the tray box so no lens can ever reach
+ * it, in layout px (the caller scales it by the tray's own scale).
+ *
+ * Deliberately a STATIC per-device value — the worst case of the two lenses
+ * that device can show (`lens` = the pointer's hover/peek preset, or the
+ * persistent selected one) rather than whatever is raised right now. A pill
+ * that re-measured per raise would jump ~70px on every hover, and the reserve
+ * must hold in the resting state too: a selected card keeps its lens for the
+ * whole flow, which is exactly the state that used to bury the instruction.
+ *
+ * A card is CARD_H tall in a HANDBOX_H box aligned to its bottom, so it
+ * already pokes out the top before any lens applies. HINT_PAD covers what
+ * this box model doesn't: the seat's own rotation about the 50% 120% pivot
+ * lifts a card's top corner, and lensReach measures the lens rather than its
+ * rotated bounding box (measured ~6px on the demo fan — the pad is rounded up
+ * so the reserve stays honest rather than exact-and-brittle).
+ */
+const HINT_PAD = 10
+
+export function hintClearance(lens: LensPreset): number {
+  return (
+    Math.max(lensReach(lens), lensReach(LENS_SELECTED)) +
+    (CARD_H - HANDBOX_H) +
+    HINT_PAD
+  )
+}
+
 /**
  * Which card of the fan sits under layout-x position `x` — the drag-to-browse
  * mapping. Uses the resting seat centres (width/2 + (i − (n−1)/2)·spacing),

--- a/src/components/hand-tray-layout.ts
+++ b/src/components/hand-tray-layout.ts
@@ -21,6 +21,14 @@ export interface LensPreset {
 export const LENS_FINE: LensPreset = { scale: 1.6, rise: 40 }
 export const LENS_COARSE: LensPreset = { scale: 2.1, rise: 76 }
 
+/**
+ * A selected card keeps a persistent, smaller lens until it is deselected or
+ * the action completes. Deliberately modest: it must not bury neighbours
+ * (no dock shifts in the persistent state) nor occlude the dock's controls,
+ * which sit right above the tray on phones.
+ */
+export const LENS_SELECTED: LensPreset = { scale: 1.3, rise: 18 }
+
 /** Fan rotation of card `index` in a hand of `count`, degrees. */
 export function fanAngle(index: number, count: number): number {
   return (index - (count - 1) / 2) * (count > 6 ? 4 : 5.5)
@@ -105,4 +113,23 @@ export function lensShiftX(
 /** How far above its seat the magnified visual reaches, layout px. */
 export function lensReach(lens: LensPreset): number {
   return lens.rise + CARD_H * (lens.scale - 1)
+}
+
+/**
+ * Which card of the fan sits under layout-x position `x` — the drag-to-browse
+ * mapping. Uses the resting seat centres (width/2 + (i − (n−1)/2)·spacing),
+ * NOT the live DOM boxes: dock shifts move seats while browsing, and mapping
+ * against moving targets makes the highlight jitter under a still finger.
+ * Positions beyond the outermost centres clamp to the edge cards, so a sweep
+ * past the fan's end stays on the last card instead of dropping the raise.
+ */
+export function cardIndexAtX(
+  x: number,
+  count: number,
+  spacing: number,
+  width: number,
+): number {
+  if (count <= 1) return 0
+  const i = Math.round((x - width / 2) / spacing + (count - 1) / 2)
+  return Math.max(0, Math.min(count - 1, i))
 }

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -21,6 +21,7 @@ import {
   fanAngle,
   fanLayout,
   fanLift,
+  hintClearance,
   lensReach,
   lensShiftX,
 } from './hand-tray-layout'
@@ -188,17 +189,20 @@ export function HandTray({
   return (
     <div
       ref={rootRef}
-      className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[392px]"
+      className="bb2-handtray pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[392px]"
+      style={
+        { '--bb-hint-clear': `${hintClearance(lens)}px` } as React.CSSProperties
+      }
     >
       {hint && (
-        // The pill stacks above the fan so the persistent selected lens can
-        // never bury the instruction — but while a card is transiently
-        // raised (hover/peek) the pill yields, fading out of the lens's way.
-        // Two nested divs because bb2-rise's fill-mode pins the outer
-        // element's opacity, so the fade must live on its own node. It is
-        // click-transparent: on phones the dock scrolls behind it, and the
-        // pill must never eat a tap aimed at an action button.
-        <div className="bb2-rise relative z-[1] mb-2">
+        // The pill stacks above the fan, clearing the tallest lens this
+        // device can raise (--bb-hint-clear, scaled with the tray) so no
+        // card — resting, selected or magnified — ever reaches it. It stays
+        // fully opaque and put: the reserve is static, so hovering never
+        // moves or dims the instruction. It is click-transparent: on phones
+        // the dock scrolls behind it, and the pill must never eat a tap
+        // aimed at an action button.
+        <div className="bb2-hand-hint bb2-rise relative z-[1]">
           <div
             className="rounded border px-4 py-1.5 text-[12px] font-semibold uppercase tracking-[0.18em]"
             style={{
@@ -206,8 +210,6 @@ export function HandTray({
               borderColor: 'var(--bb-brass)',
               color: 'var(--bb-brass-bright)',
               boxShadow: '0 6px 18px rgba(0,0,0,.5)',
-              opacity: raisedIndex === -1 ? 1 : 0.12,
-              transition: 'opacity 0.15s ease',
             }}
           >
             {hint}

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -2,8 +2,23 @@
 
 // The player's hand as a fan of real cards along the bottom of the table.
 // When an action flow needs a discard the fan itself becomes the selector.
+//
+// A hovered (mouse) or peeked (touch: first tap) card magnifies dock-style:
+// the visual lens scales up while its 108×156 button hitbox stays put, and
+// neighbours slide aside. Pure geometry lives in hand-tray-layout.ts.
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { type Card as GameCard } from '~/data/cards'
 import { CardFaceContent } from './cards'
+import {
+  LENS_COARSE,
+  LENS_FINE,
+  dockShift,
+  fanAngle,
+  fanLayout,
+  fanLift,
+  lensReach,
+  lensShiftX,
+} from './hand-tray-layout'
 
 export interface HandTrayProps {
   hand: GameCard[]
@@ -27,8 +42,68 @@ export function HandTray({
   const n = hand.length
   const selecting = canSelect !== null
 
+  // Mouse hover and touch peek both raise a card; peek wins so a stray
+  // synthetic mouse event after a tap can't dismiss it.
+  const [hoveredId, setHoveredId] = useState<string | null>(null)
+  const [peekedId, setPeekedId] = useState<string | null>(null)
+  const [coarse, setCoarse] = useState(false)
+  const [fanWidth, setFanWidth] = useState<number | null>(null)
+  const rootRef = useRef<HTMLDivElement | null>(null)
+  const fanRef = useRef<HTMLDivElement | null>(null)
+  // Pointer type of the press that produced the next click, consumed there —
+  // per-interaction, so hybrid (touch + mouse) devices do the right thing.
+  const lastPointerType = useRef<string | null>(null)
+
+  useLayoutEffect(() => {
+    const el = fanRef.current
+    if (!el) return
+    const measure = () => setFanWidth(el.offsetWidth)
+    measure()
+    const ro = new ResizeObserver(measure)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  useEffect(() => {
+    const mq = window.matchMedia('(pointer: coarse)')
+    const update = () => setCoarse(mq.matches)
+    update()
+    mq.addEventListener('change', update)
+    return () => mq.removeEventListener('change', update)
+  }, [])
+
+  // A tap anywhere outside the tray dismisses the peek.
+  useEffect(() => {
+    if (!peekedId) return
+    const onDown = (e: PointerEvent) => {
+      if (rootRef.current?.contains(e.target as Node)) return
+      setPeekedId(null)
+      onHoverCard?.(null)
+    }
+    document.addEventListener('pointerdown', onDown)
+    return () => document.removeEventListener('pointerdown', onDown)
+  }, [peekedId, onHoverCard])
+
+  // The peeked card may leave the hand (played, era end) under the peek.
+  useEffect(() => {
+    if (peekedId && !hand.some((c) => c.id === peekedId)) setPeekedId(null)
+  }, [hand, peekedId])
+
+  const setPeek = (card: GameCard | null) => {
+    setPeekedId(card?.id ?? null)
+    onHoverCard?.(card)
+  }
+
+  const raisedId = peekedId ?? hoveredId
+  const raisedIndex = raisedId ? hand.findIndex((c) => c.id === raisedId) : -1
+  const lens = coarse ? LENS_COARSE : LENS_FINE
+  const { spacing, marginX } = fanLayout(n, fanWidth)
+
   return (
-    <div className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[392px]">
+    <div
+      ref={rootRef}
+      className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[392px]"
+    >
       {hint && (
         <div
           className="bb2-rise pointer-events-auto mb-2 rounded border px-4 py-1.5 text-[12px] font-semibold uppercase tracking-[0.18em]"
@@ -42,14 +117,25 @@ export function HandTray({
           {hint}
         </div>
       )}
-      <div className="bb2-hand -mb-5 h-[150px] w-full max-w-3xl origin-bottom scale-[0.72] sm:scale-90 lg:scale-100">
+      <div
+        ref={fanRef}
+        className="bb2-hand bb2-handbox"
+        style={{ '--bb-card-mx': `${marginX}px` } as React.CSSProperties}
+      >
         {hand.map((card, i) => {
-          const angle = (i - (n - 1) / 2) * (n > 6 ? 4 : 5.5)
-          const lift = Math.abs(i - (n - 1) / 2) * (n > 6 ? 5 : 7)
+          const angle = fanAngle(i, n)
+          const lift = fanLift(i, n)
           const selected = selectedIds.includes(card.id)
           const enabled = selecting
             ? (canSelect?.(card.id) ?? false) || selected
             : false
+          const disabled = selecting ? !enabled : true
+          const raised = i === raisedIndex
+          const shift = dockShift(
+            i,
+            raisedIndex === -1 ? null : raisedIndex,
+            lens.scale,
+          )
           return (
             // The fan transform and hover events live on a wrapper: mouse
             // events don't fire on disabled buttons, but the hover preview
@@ -58,30 +144,84 @@ export function HandTray({
               key={card.id}
               className="bb2-card-seat"
               style={{
-                transform: `rotate(${angle}deg) translateY(${lift}px)`,
-                zIndex: i,
+                transform: `translateX(${shift}px) rotate(${angle}deg) translateY(${lift}px)`,
+                zIndex: raised ? 60 : selected ? 40 : i,
               }}
-              onMouseEnter={() => onHoverCard?.(card)}
-              onMouseLeave={() => onHoverCard?.(null)}
+              onPointerEnter={(e) => {
+                if (e.pointerType !== 'touch') {
+                  setHoveredId(card.id)
+                  onHoverCard?.(card)
+                }
+              }}
+              onPointerLeave={(e) => {
+                if (e.pointerType !== 'touch') {
+                  setHoveredId((h) => (h === card.id ? null : h))
+                  onHoverCard?.(null)
+                }
+              }}
+              onPointerDown={(e) => {
+                lastPointerType.current = e.pointerType
+              }}
+              onPointerUp={(e) => {
+                // Disabled buttons swallow click, so a display-only or
+                // dimmed card's touch peek toggles here instead.
+                if (e.pointerType === 'touch' && disabled)
+                  setPeek(peekedId === card.id ? null : card)
+              }}
             >
               <button
                 type="button"
-                className="bb2-card"
+                className="bb2-card bb2-card-hit"
                 data-testid={`card-${card.id}`}
                 data-selected={selected || undefined}
                 data-dimmed={(selecting && !enabled && !selected) || undefined}
-                disabled={selecting ? !enabled : true}
-                onClick={() => enabled && onSelect?.(card.id)}
-                style={{
-                  cursor: selecting
-                    ? enabled
-                      ? 'pointer'
-                      : 'not-allowed'
-                    : 'default',
+                data-raised={raised || undefined}
+                disabled={disabled}
+                onClick={() => {
+                  const viaTouch = lastPointerType.current === 'touch'
+                  lastPointerType.current = null
+                  // Touch has no hover: the first tap peeks, the second acts.
+                  // A card the player already selected acts immediately —
+                  // they know it; re-tapping means deselect/put back.
+                  if (viaTouch && !selected && peekedId !== card.id) {
+                    setPeek(card)
+                    return
+                  }
+                  if (enabled) {
+                    if (peekedId) setPeek(null)
+                    onSelect?.(card.id)
+                  }
                 }}
+                onFocus={(e) => {
+                  // Keyboard focus reads like hover; mouse clicks (not
+                  // :focus-visible) must not pin the card raised.
+                  if (e.target.matches(':focus-visible')) setHoveredId(card.id)
+                }}
+                onBlur={() => setHoveredId((h) => (h === card.id ? null : h))}
+                style={
+                  {
+                    cursor: selecting
+                      ? enabled
+                        ? 'pointer'
+                        : 'not-allowed'
+                      : 'default',
+                    '--bb-lens-reach': `${lensReach(lens)}px`,
+                  } as React.CSSProperties
+                }
                 aria-label={`Card: ${card.id}`}
               >
-                <CardFaceContent card={card} />
+                <span
+                  className="bb2-card bb2-card-lens"
+                  style={
+                    raised
+                      ? {
+                          transform: `translate(${lensShiftX(i, n, spacing, fanWidth, lens.scale)}px, ${-lens.rise}px) rotate(${-angle}deg) scale(${lens.scale})`,
+                        }
+                      : undefined
+                  }
+                >
+                  <CardFaceContent card={card} />
+                </span>
               </button>
             </span>
           )

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -3,15 +3,20 @@
 // The player's hand as a fan of real cards along the bottom of the table.
 // When an action flow needs a discard the fan itself becomes the selector.
 //
-// A hovered (mouse) or peeked (touch: first tap) card magnifies dock-style:
-// the visual lens scales up while its 108×156 button hitbox stays put, and
-// neighbours slide aside. Pure geometry lives in hand-tray-layout.ts.
+// A hovered (mouse) or peeked (touch) card magnifies dock-style: the visual
+// lens scales up while its 108×156 button hitbox stays put, and neighbours
+// slide aside. Touch reaches the peek two ways: a tap, or a long-press that
+// then browses the fan Hearthstone-style (slide left/right, release keeps
+// the card under the finger peeked). A selected card keeps a smaller
+// persistent lens. Pure geometry lives in hand-tray-layout.ts.
 import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { type Card as GameCard } from '~/data/cards'
 import { CardFaceContent } from './cards'
 import {
   LENS_COARSE,
   LENS_FINE,
+  LENS_SELECTED,
+  cardIndexAtX,
   dockShift,
   fanAngle,
   fanLayout,
@@ -19,6 +24,20 @@ import {
   lensReach,
   lensShiftX,
 } from './hand-tray-layout'
+
+/** Hold this long (without sliding) to start browsing the fan. */
+const LONG_PRESS_MS = 350
+/** Finger drift allowed before the hold is read as a slide and cancelled. */
+const BROWSE_SLOP_PX = 12
+
+interface BrowseGesture {
+  pointerId: number
+  startX: number
+  startY: number
+  timer: number
+  /** Set when the long-press fires; from then on sliding browses the fan. */
+  active: boolean
+}
 
 export interface HandTrayProps {
   hand: GameCard[]
@@ -53,6 +72,12 @@ export function HandTray({
   // Pointer type of the press that produced the next click, consumed there —
   // per-interaction, so hybrid (touch + mouse) devices do the right thing.
   const lastPointerType = useRef<string | null>(null)
+  // In-progress long-press/browse gesture; document-level move/up handlers
+  // drive it so the finger may wander off the pressed card mid-browse.
+  const browseRef = useRef<BrowseGesture | null>(null)
+  // A browse release still synthesizes a click on the pressed card — that
+  // click must neither act nor re-toggle the peek the browse just set.
+  const suppressClickRef = useRef(false)
 
   useLayoutEffect(() => {
     const el = fanRef.current
@@ -78,11 +103,10 @@ export function HandTray({
     const onDown = (e: PointerEvent) => {
       if (rootRef.current?.contains(e.target as Node)) return
       setPeekedId(null)
-      onHoverCard?.(null)
     }
     document.addEventListener('pointerdown', onDown)
     return () => document.removeEventListener('pointerdown', onDown)
-  }, [peekedId, onHoverCard])
+  }, [peekedId])
 
   // The peeked card may leave the hand (played, era end) under the peek.
   useEffect(() => {
@@ -91,13 +115,75 @@ export function HandTray({
 
   const setPeek = (card: GameCard | null) => {
     setPeekedId(card?.id ?? null)
-    onHoverCard?.(card)
   }
 
   const raisedId = peekedId ?? hoveredId
   const raisedIndex = raisedId ? hand.findIndex((c) => c.id === raisedId) : -1
+
+  // The shell's hover preview follows whichever card is actually raised —
+  // one derived notification instead of per-handler calls, so a peek can't
+  // fight a stale mouse hover and a raised card leaving the hand clears the
+  // preview. Deduped by id: hand arrays are rebuilt per snapshot and the
+  // shell shouldn't re-render for an identity-only change.
+  const raisedCard = raisedId
+    ? (hand.find((c) => c.id === raisedId) ?? null)
+    : null
+  const notifiedHoverRef = useRef<string | null>(null)
+  useEffect(() => {
+    const id = raisedCard?.id ?? null
+    if (notifiedHoverRef.current === id) return
+    notifiedHoverRef.current = id
+    onHoverCard?.(raisedCard)
+  }, [onHoverCard, raisedCard])
   const lens = coarse ? LENS_COARSE : LENS_FINE
   const { spacing, marginX } = fanLayout(n, fanWidth)
+
+  // Long-press browse: once the hold fires, sliding moves the raised
+  // highlight to the card whose resting seat is under the finger; releasing
+  // keeps that card peeked (never selects — acting stays a deliberate tap on
+  // the already-raised card). Listeners live on the document because touch
+  // implicit-captures pointer events to the pressed element, so per-seat
+  // handlers would never see the finger crossing the fan.
+  useEffect(() => {
+    const onMove = (e: PointerEvent) => {
+      const g = browseRef.current
+      if (!g || e.pointerId !== g.pointerId) return
+      if (!g.active) {
+        // Sliding before the hold fires is not a browse — cancel it.
+        if (
+          Math.hypot(e.clientX - g.startX, e.clientY - g.startY) >
+          BROWSE_SLOP_PX
+        ) {
+          clearTimeout(g.timer)
+          browseRef.current = null
+        }
+        return
+      }
+      const el = fanRef.current
+      if (!el || fanWidth === null || hand.length === 0) return
+      const rect = el.getBoundingClientRect()
+      if (rect.width === 0) return
+      // Client → layout px (the fan is scaled down on phones).
+      const layoutX = ((e.clientX - rect.left) / rect.width) * fanWidth
+      const under = hand[cardIndexAtX(layoutX, hand.length, spacing, fanWidth)]
+      if (under && under.id !== peekedId) setPeek(under)
+    }
+    const onEnd = (e: PointerEvent) => {
+      const g = browseRef.current
+      if (!g || e.pointerId !== g.pointerId) return
+      clearTimeout(g.timer)
+      browseRef.current = null
+      if (g.active && e.type === 'pointerup') suppressClickRef.current = true
+    }
+    document.addEventListener('pointermove', onMove)
+    document.addEventListener('pointerup', onEnd)
+    document.addEventListener('pointercancel', onEnd)
+    return () => {
+      document.removeEventListener('pointermove', onMove)
+      document.removeEventListener('pointerup', onEnd)
+      document.removeEventListener('pointercancel', onEnd)
+    }
+  })
 
   return (
     <div
@@ -105,16 +191,27 @@ export function HandTray({
       className="pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[392px]"
     >
       {hint && (
-        <div
-          className="bb2-rise pointer-events-auto mb-2 rounded border px-4 py-1.5 text-[12px] font-semibold uppercase tracking-[0.18em]"
-          style={{
-            background: 'rgba(20,16,11,.92)',
-            borderColor: 'var(--bb-brass)',
-            color: 'var(--bb-brass-bright)',
-            boxShadow: '0 6px 18px rgba(0,0,0,.5)',
-          }}
-        >
-          {hint}
+        // The pill stacks above the fan so the persistent selected lens can
+        // never bury the instruction — but while a card is transiently
+        // raised (hover/peek) the pill yields, fading out of the lens's way.
+        // Two nested divs because bb2-rise's fill-mode pins the outer
+        // element's opacity, so the fade must live on its own node. It is
+        // click-transparent: on phones the dock scrolls behind it, and the
+        // pill must never eat a tap aimed at an action button.
+        <div className="bb2-rise relative z-[1] mb-2">
+          <div
+            className="rounded border px-4 py-1.5 text-[12px] font-semibold uppercase tracking-[0.18em]"
+            style={{
+              background: 'rgba(20,16,11,.92)',
+              borderColor: 'var(--bb-brass)',
+              color: 'var(--bb-brass-bright)',
+              boxShadow: '0 6px 18px rgba(0,0,0,.5)',
+              opacity: raisedIndex === -1 ? 1 : 0.12,
+              transition: 'opacity 0.15s ease',
+            }}
+          >
+            {hint}
+          </div>
         </div>
       )}
       <div
@@ -136,6 +233,10 @@ export function HandTray({
             raisedIndex === -1 ? null : raisedIndex,
             lens.scale,
           )
+          // Transient hover/peek beats the persistent selected lens; the
+          // selected state deliberately shifts no neighbours (rise carries
+          // the signal without churning the fan for a whole flow).
+          const lensPreset = raised ? lens : selected ? LENS_SELECTED : null
           return (
             // The fan transform and hover events live on a wrapper: mouse
             // events don't fire on disabled buttons, but the hover preview
@@ -148,25 +249,46 @@ export function HandTray({
                 zIndex: raised ? 60 : selected ? 40 : i,
               }}
               onPointerEnter={(e) => {
-                if (e.pointerType !== 'touch') {
-                  setHoveredId(card.id)
-                  onHoverCard?.(card)
-                }
+                if (e.pointerType !== 'touch') setHoveredId(card.id)
               }}
               onPointerLeave={(e) => {
-                if (e.pointerType !== 'touch') {
+                if (e.pointerType !== 'touch')
                   setHoveredId((h) => (h === card.id ? null : h))
-                  onHoverCard?.(null)
-                }
               }}
               onPointerDown={(e) => {
                 lastPointerType.current = e.pointerType
+                suppressClickRef.current = false
+                if (e.pointerType === 'touch') {
+                  // A second finger replaces the pending gesture outright.
+                  if (browseRef.current) clearTimeout(browseRef.current.timer)
+                  const g: BrowseGesture = {
+                    pointerId: e.pointerId,
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    timer: 0,
+                    active: false,
+                  }
+                  g.timer = window.setTimeout(() => {
+                    if (browseRef.current !== g) return
+                    g.active = true
+                    setPeek(card)
+                  }, LONG_PRESS_MS)
+                  browseRef.current = g
+                }
               }}
               onPointerUp={(e) => {
+                // A browse release is handled at the document level (keeps
+                // the browsed card peeked) — not a tap.
+                if (browseRef.current?.active) return
                 // Disabled buttons swallow click, so a display-only or
                 // dimmed card's touch peek toggles here instead.
                 if (e.pointerType === 'touch' && disabled)
                   setPeek(peekedId === card.id ? null : card)
+              }}
+              onContextMenu={(e) => {
+                // Android fires contextmenu on long-press — that press is
+                // our browse gesture, never a context menu.
+                if (browseRef.current) e.preventDefault()
               }}
             >
               <button
@@ -178,6 +300,12 @@ export function HandTray({
                 data-raised={raised || undefined}
                 disabled={disabled}
                 onClick={() => {
+                  // The click synthesized after a browse release is not a
+                  // tap — swallow it so browsing can never act.
+                  if (suppressClickRef.current) {
+                    suppressClickRef.current = false
+                    return
+                  }
                   const viaTouch = lastPointerType.current === 'touch'
                   lastPointerType.current = null
                   // Touch has no hover: the first tap peeks, the second acts.
@@ -205,7 +333,7 @@ export function HandTray({
                         ? 'pointer'
                         : 'not-allowed'
                       : 'default',
-                    '--bb-lens-reach': `${lensReach(lens)}px`,
+                    '--bb-lens-reach': `${lensReach(lensPreset ?? lens)}px`,
                   } as React.CSSProperties
                 }
                 aria-label={`Card: ${card.id}`}
@@ -213,9 +341,9 @@ export function HandTray({
                 <span
                   className="bb2-card bb2-card-lens"
                   style={
-                    raised
+                    lensPreset
                       ? {
-                          transform: `translate(${lensShiftX(i, n, spacing, fanWidth, lens.scale)}px, ${-lens.rise}px) rotate(${-angle}deg) scale(${lens.scale})`,
+                          transform: `translate(${lensShiftX(i, n, spacing, fanWidth, lensPreset.scale)}px, ${-lensPreset.rise}px) rotate(${-angle}deg) scale(${lensPreset.scale})`,
                         }
                       : undefined
                   }

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -450,6 +450,13 @@ button.bb2-card {
   display: block;
   flex: none;
   transition: transform 0.18s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+  /* The long-press browse gesture owns touches that start on a card: no
+   * page scroll, no iOS callout/selection. Only the seats claim this —
+   * touches elsewhere scroll and pan as usual. */
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 /* The tray sizes cards by scaling the whole fan; the width compensates the
@@ -501,10 +508,12 @@ button.bb2-card {
     var(--bb-brass-bright), 0 0 24px rgba(230, 189, 99, 0.55), 0 10px 20px
     rgba(0, 0, 0, 0.6);
 }
-/* While raised, extend the hitbox straight UP over the magnified visual
- * (its vertical reach is set inline) — but never sideways, so neighbours
- * stay clickable. Tapping the enlarged card is what confirms on touch. */
-.bb2-card-hit[data-raised="true"]::after {
+/* While raised (hover/peek) or holding the persistent selected lens, extend
+ * the hitbox straight UP over the magnified visual (its vertical reach is
+ * set inline) — but never sideways, so neighbours stay clickable. Tapping
+ * the enlarged card is what confirms on touch. */
+.bb2-card-hit[data-raised="true"]::after,
+.bb2-card-hit[data-selected="true"]::after {
   content: "";
   position: absolute;
   left: 0;

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -461,24 +461,38 @@ button.bb2-card {
 
 /* The tray sizes cards by scaling the whole fan; the width compensates the
  * scale (100% / s) so the usable layout width stays the full viewport —
- * without it a phone tray would waste 28% of an already-narrow screen. */
+ * without it a phone tray would waste 28% of an already-narrow screen.
+ * The scale lives on the tray root, not the box, because the hint pill is a
+ * SIBLING of the fan and has to reserve its clearance in the same scale. */
+.bb2-handtray {
+  --bb-hand-scale: 0.72;
+}
 .bb2-handbox {
   flex: none;
   height: 150px;
   margin-bottom: -20px;
   transform-origin: bottom center;
-  transform: scale(0.72);
-  width: calc(100% / 0.72);
+  transform: scale(var(--bb-hand-scale));
+  width: calc(100% / var(--bb-hand-scale));
+}
+/* Lens reach is layout px inside the fan; the pill sits outside it, so the
+ * reserve has to be scaled by hand. The 8px is the visual gap on top. */
+.bb2-hand-hint {
+  margin-bottom: calc(8px + var(--bb-hint-clear, 71px) * var(--bb-hand-scale));
 }
 @media (min-width: 640px) {
+  .bb2-handtray {
+    --bb-hand-scale: 0.9;
+  }
   .bb2-handbox {
-    transform: scale(0.9);
     width: min(53.34rem, calc(100% / 0.9));
   }
 }
 @media (min-width: 1024px) {
+  .bb2-handtray {
+    --bb-hand-scale: 1;
+  }
   .bb2-handbox {
-    transform: scale(1);
     width: min(48rem, 100%);
   }
 }

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -443,21 +443,82 @@ button.bb2-card {
 }
 .bb2-hand > * {
   pointer-events: auto;
-  margin: 0 -17px;
+  margin: 0 var(--bb-card-mx, -17px);
   transform-origin: 50% 120%;
 }
 .bb2-card-seat {
   display: block;
   flex: none;
-  transition: transform 0.16s cubic-bezier(0.2, 0.9, 0.3, 1.3);
+  transition: transform 0.18s cubic-bezier(0.2, 0.9, 0.3, 1.2);
 }
-.bb2-hand > *:hover {
-  transform: translateY(-26px) scale(1.06) rotate(0deg) !important;
-  z-index: 30 !important;
+
+/* The tray sizes cards by scaling the whole fan; the width compensates the
+ * scale (100% / s) so the usable layout width stays the full viewport —
+ * without it a phone tray would waste 28% of an already-narrow screen. */
+.bb2-handbox {
+  flex: none;
+  height: 150px;
+  margin-bottom: -20px;
+  transform-origin: bottom center;
+  transform: scale(0.72);
+  width: calc(100% / 0.72);
 }
-.bb2-hand > *[data-selected="true"] {
-  transform: translateY(-30px) scale(1.05) rotate(0deg) !important;
-  z-index: 29 !important;
+@media (min-width: 640px) {
+  .bb2-handbox {
+    transform: scale(0.9);
+    width: min(53.34rem, calc(100% / 0.9));
+  }
+}
+@media (min-width: 1024px) {
+  .bb2-handbox {
+    transform: scale(1);
+    width: min(48rem, 100%);
+  }
+}
+
+/* Magnification splits each card in two: the button (.bb2-card-hit) is the
+ * fixed 108×156 hitbox e2e and pointers see; the lens inside carries the
+ * .bb2-card chrome and is what actually scales. pointer-events:none on the
+ * lens means an enlarged visual never steals a click aimed at a neighbour. */
+.bb2-card-hit {
+  position: relative;
+  background: none;
+  border: 0;
+  box-shadow: none;
+  overflow: visible;
+}
+.bb2-card-hit[data-selected="true"] {
+  box-shadow: none;
+}
+.bb2-card-lens {
+  display: block;
+  pointer-events: none;
+  transform-origin: 50% 100%;
+  transition: transform 0.18s cubic-bezier(0.2, 0.9, 0.3, 1.2);
+}
+.bb2-card-hit[data-selected="true"] > .bb2-card-lens {
+  box-shadow: inset 0 0 0 3px rgba(120, 96, 48, 0.18), 0 0 0 2px
+    var(--bb-brass-bright), 0 0 24px rgba(230, 189, 99, 0.55), 0 10px 20px
+    rgba(0, 0, 0, 0.6);
+}
+/* While raised, extend the hitbox straight UP over the magnified visual
+ * (its vertical reach is set inline) — but never sideways, so neighbours
+ * stay clickable. Tapping the enlarged card is what confirms on touch. */
+.bb2-card-hit[data-raised="true"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: calc(-1 * var(--bb-lens-reach, 134px));
+}
+
+/* Magnification is decorative; motion-sensitive players get the end state. */
+@media (prefers-reduced-motion: reduce) {
+  .bb2-card-seat,
+  .bb2-card-lens {
+    transition: none;
+  }
 }
 
 /* ---------------- board ---------------- */


### PR DESCRIPTION
Improves the hand-card tray in two ways: Hearthstone / macOS-dock style hover magnification on desktop, and a genuinely usable phone layout with a Hearthstone-style touch model — long-press + drag-to-browse, tap-to-peek, and a persistent lens on the selected card. Task: brass-hand-tray-hover (+ captain feedback round: brass-hand-tray-touch).

## 1. Hover magnification (desktop)

Hovering a card raises a magnified (1.6×) upright lens above the fan; immediate neighbours slide aside dock-style (falloff over two seats) so the raised card has room. Keyboard `:focus-visible` raises too, and `prefers-reduced-motion` gets the end state with no transition.

**How the hitbox stays honest:** the card `<button>` (still `class="bb2-card"`, still `data-testid="card-<id>"` / `disabled` / `data-selected` / `data-dimmed` — the whole e2e selector spine is unchanged) is now a fixed 108×156 transparent hitbox; the card chrome moved to an inner `.bb2-card-lens` with `pointer-events: none`, and only the lens scales. An enlarged card therefore never steals a click aimed at a neighbour. While raised, the hitbox extends straight **up** over the magnified visual (`::after`, never sideways) so clicking/tapping the big card works everywhere it is visible.

The raised state is React-driven (`data-raised`) rather than CSS `:hover`, which is what lets neighbours react and touch share the same code path. All fan geometry (spacing, dock shifts, edge clamping, and now the browse position→card mapping) is pure math in `hand-tray-layout.ts` with unit tests.

| Before (hover) | After (hover) |
|---|---|
| ![before hover](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/before-desktop-hover.png) | ![after hover](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/after-desktop-hover.png) |

## 2. Phone fit

**Layout choice: compressed fan, not a scrollable tray.** The tray keeps its single fan and compresses the card overlap to fit the measured width, Hearthstone-mobile style. Justification: a scroll/snap tray would hide part of the hand (bad for a game where you constantly weigh all 8 cards), add a second gesture axis on top of board pan/zoom, and diverge the phone DOM from the desktop one (two code paths through every discard flow). Thin slices are fine *because* the browse/peek magnification is one gesture away — the same trade Hearthstone mobile makes.

Two concrete fixes behind that:
- The tray sizes cards by scaling the whole fan (`scale(0.72)` on phones); previously that also shrank the *usable width* to 72% of an already narrow screen. The scale wrapper now compensates (`width: 100%/s`), so a 375px viewport keeps its full 375px.
- Fan spacing is computed from the measured tray width **including the horizontal overhang the outermost cards gain from fan rotation** (±14° around a pivot below the card swings the top corners ~45px outward). Without that term the fan visibly ran off screen at 414×896 — measured bounds are 8..406 in a 414 viewport and 7..368 in a 375 one, for the worst-case 8-card opening hand.

| Before 375×667 (8 cards, overflowing both edges) | After 375×667 | After 414×896 |
|---|---|---|
| ![before phone](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/before-phone-375.png) | ![after phone](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/after-phone-375.png) | ![414](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/after-phone-414.png) |

## 3. Touch model: long-press + drag-to-browse, tap-to-peek ("what Hearthstone does")

There is no hover on touch, so the tray offers **two roads to the same peeked state**:

- **Tap**: the first tap peeks (bigger 2.1× lens, clamped on-screen for edge cards), the second tap acts. A tap on a card the player already *selected* acts immediately (re-tap = deselect/put back); disabled/display-only cards still peek; a tap outside the tray dismisses the peek.
- **Long-press + drag-to-browse** (new): holding a card for 350ms raises it, and **keeping the finger down while sliding left/right moves the raise from card to card across the fan** — exactly Hearthstone's hand browsing. The card under the finger is computed from the fan's *resting* seat centres (`cardIndexAtX` in `hand-tray-layout.ts`), not live DOM boxes, so the dock-shift animation can't make the highlight jitter under a still finger. Sweeping past the fan's edge clamps to the outermost card.

**Release semantics: releasing keeps the card under the finger peeked — it never selects.** Chosen because it makes browsing risk-free (a browse sweep can end anywhere; selection from release would make mis-picks easy in flows where a discard needs CANCEL to unwind), it composes with the existing model (the long-press is just a richer road to "peeked"; acting stays the same deliberate tap on the already-raised card), and it works uniformly when the hand is display-only or an mp intent is in flight (peeking is view-only, so browsing is always available while selection stays gated). The click the browser synthesizes after a browse release is suppressed, so a browse can never act by accident.

**Gesture containment:** only the card seats claim touches (`touch-action: none` + `user-select: none` on `.bb2-card-seat` — the tray strip between/above cards stays `pointer-events: none`), so scrolling and board panning elsewhere are untouched. An early slide (>12px before the hold fires) cancels the long-press; `contextmenu` during a press is suppressed (Android long-press).

| Browse / peek (2.1× lens, edge-clamped) | Multiplayer surface, same component |
|---|---|
| ![browse peek](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/touch2-phone-browse.png) | ![mp selected](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/touch2-mp-selected.png) |

## 4. Selected card stays enlarged

A selected card now keeps a **persistent smaller lens** (1.3×, rise 18 — `LENS_SELECTED`) until it is deselected, cancelled, or the action completes — instead of only the highlight ring. It is deliberately more modest than the transient lenses: it shifts no neighbours (the rise carries the signal without churning the fan for a whole flow) and cannot occlude the dock. Hover/peek still wins over it (hovering a selected card shows the full 1.6×/2.1× lens). Because it derives from `selectedIds` (machine state), it survives multiplayer round-trips — the intent POSTs, the server broadcasts, and the rebuilt view re-renders the same persistent lens.

Layout guards that came out of verifying this on phones:
- The hint pill now stacks **above** the fan (so the persistent lens can never bury the instruction), **fades to 12%** while a card is transiently raised (hover/peek gets the full Hearthstone moment), and is **click-transparent** — on phones the dock scrolls behind the pill, and it used to eat taps aimed at action buttons back there (hit-tested fix).
- The selected hitbox extends up over the enlarged visual exactly like the raised one (`::after`, never sideways), so "tap it again to put it back" works anywhere on the big card — and only where the card is actually visible.

| Desktop: selected stays enlarged, dock + pill readable | Phone: selected persistent | Scout 3/3: multi-select persistent |
|---|---|---|
| ![desktop selected](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/touch2-desktop-selected.png) | ![phone selected](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/touch2-phone-selected.png) | ![scout](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/touch2-phone-scout.png) |

Also in this round (CodeRabbit review finding): `onHoverCard` is now derived from `raisedId` in a single effect (peek wins over hover, deduped by id, cleared when the raised card leaves the hand) instead of independent per-handler calls — mouse movement during a peek can no longer preview a different card than the one visually raised, and keyboard focus previews too.

**Vercel preview:** https://brass-birmingham-frd3tj85g-julius-retzers-projects.vercel.app (branch alias: https://brass-birmingham-git-fm-brass-hand-tray-hover-julius-retzers-projects.vercel.app)

## Testing

- `pnpm test` — 53 files / 501 tests green (`hand-tray-layout.test.ts` grew: `cardIndexAtX` seat mapping + edge clamping, `LENS_SELECTED` smaller-than-transient invariants).
- Full Playwright suite green (38 tests), including the DB-backed mp specs against the local Docker DB.
- `e2e/hand-tray.spec.ts` (offline) now also covers: long-press → raise → slide moves the raise across the fan → release keeps the peek and never selects (raw CDP touch events — Playwright's touchscreen only taps); an early slide cancelling the long-press; the persistent selected lens on both desktop (after mouse leaves) and phone (after the select tap); and the existing hover/tap/disabled-peek journeys.
- Browser-verified via chrome-devtools-axi emulation at 1440×900, 375×667 and 414×896: hotseat `/?demo` + `/?fresh=1` (8-card browse sweep raising all 8 in order at 414) and a live 3-seat `/g/<token>` game on the local DB (browse + tap-select over real intents; dock buttons hit-tested through the pill). Desktop hover/click behaviour unchanged.

Screenshots are hosted as release assets on the `pr-36-images` prerelease (nothing committed); delete with `gh release delete pr-36-images --yes --cleanup-tag` after merge.

---

## Follow-up: the hint pill no longer overlaps the cards

Captain's report on the card-selected state: *"this shouldn't overlap the cards (the text)"* — the "PICK AN ACTION FOR THIS CARD" banner rendered straight through the raised card's top edge and the neighbours' headers.

**Cause:** the pill stacked above the tray *box*, but cards overflow that box — a card is `CARD_H` (156) tall in a `HANDBOX_H` (150) box, and every lens (hover, touch peek, the persistent selected one) grows upward from there via **transforms**, which reserve no layout space at all. The old dodge was fading the pill to `opacity: .12` while a card was transiently raised; that never covered the *selected* lens, which persists for the whole flow — exactly the state in the report.

**Fix:** reserve the space for real. `hintClearance()` (`hand-tray-layout.ts`) sizes the gap from the tallest lens the device can raise — `max(pointer lens, LENS_SELECTED)` plus the box overflow and a pad for the rotated seat. The tray scale moved to a `--bb-hand-scale` var on the tray root so the pill, a sibling of the fan and outside the scaled box, applies the reserve in the same scale at every breakpoint (.72 / .9 / 1).

The reserve is **static per device**, not per raise: the pill neither jumps on hover nor needs the fade, so the instruction now stays put and **fully readable in every state**. Nothing animates, so reduced-motion needs no special case. Both surfaces get it — `HandTray` is shared by hotseat and mp.

### Before → after (desktop 1440×900, card selected)

| Before — banner over the raised card + neighbours' headers | After — banner clear, fully opaque |
|---|---|
| ![before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/banner-before-desktop.png) | ![after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/banner-after-desktop.png) |

Phone (375×812, `pointer: coarse`) — the worst case, clearing the full `LENS_COARSE` peek:

![phone](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-36-images/banner-after-phone.png)

### Verification

- Measured clearance in-browser (pill bottom vs. topmost card rect): **12px** desktop with a card selected *and* one hover-raised (the tightest case), **58px** on coarse/375 and 414 with the giant peek up. Never negative.
- `pnpm test` — 53 files / **504 tests** green. `hand-tray-layout.test.ts` gains a `hintClearance` block pinning that the reserve clears `LENS_SELECTED`, clears each pointer's own lens, and is per-device-static (coarse > fine).
- Full Playwright suite green (**38 tests**), incl. the DB-backed mp specs. No e2e asserted the pill's position, so none needed adjusting.
- `pnpm lint` + `pnpm typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hand-tray card magnification and selection on desktop and touch devices.
  * Added tap-to-peek, long-press browsing, sliding card previews, and outside-tap dismissal.
  * Added responsive fan layout behavior to keep cards visible across screen sizes.
  * Added persistent visual emphasis for selected cards and improved disabled-card previews.
  * Added reduced-motion support for hand-tray interactions.

* **Bug Fixes**
  * Improved card positioning and neighboring-card movement when previewing cards.
  * Prevented enlarged card visuals from blocking interactions with nearby cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->