### PR TITLE
Analytics: Vercel Web Analytics + live "tables in progress" counter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,6 +502,34 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   action's built-in default `claude-sonnet-4-20250514` 404s (id no longer
   served). Bump this when the model id changes.
 
+## Analytics (added 2026-07-17)
+
+- TRAFFIC = Vercel Web Analytics: `<Analytics/>` from `@vercel/analytics/next`
+  in `src/app/layout.tsx`. Off Vercel it self-disables (logs "Debug mode …
+  no requests will be sent"), so offline dev/test/e2e are unaffected and it
+  needs no env var. The package is INERT until Web Analytics is switched on in
+  the Vercel dashboard (Project → Analytics → Enable) — code alone collects
+  nothing.
+- LIVE COUNTS = `loadActivityStats` (`src/server/mp/store.ts`, the single DB
+  owner) → `GET /api/stats` → `<ActivityLine/>` on the charter. Aggregate
+  COUNTS ONLY (no tokens/names), so it needs no auth and `filterSnapshotForSeat`
+  is not involved. Egress discipline as per `loadAiPeek`: ONE aggregate round
+  trip, seats counted server-side with `jsonb_array_elements`, `snapshot` never
+  touched — it is a public endpoint refresh-spam can hit (`s-maxage=30` in front
+  of it). Liveness = `games.updatedAt` (bumped by every `saveGame`); finished
+  games excluded.
+- The UI half is deliberately split: pure `activity.ts` (fetch-and-swallow +
+  wording, unit-tested) vs the thin `activity-line.tsx` shell — same reason as
+  `mp/refusal.ts`/`turnNotify.ts`, since vitest runs `environment: 'node'` with
+  no testing-library. `/api/stats` failing must never break the page: an
+  unreachable endpoint and zero games both render NOTHING (never "0 games").
+- TEST GOTCHA (`store.stats.test.ts`): the stats query is GLOBAL and its window
+  has only a LOWER bound, over a DB shared with the other DB suites in parallel
+  workers — so past-stamped fixtures isolate NOTHING (every real 2026 row sorts
+  above a year-2000 cutoff and gets counted; this was a red run). Fixtures are
+  stamped in the FAR FUTURE with `now` injected to match, and deleted by token
+  after each test. Never blanket-wipe `games` there.
+
 ## NEVER `git stash` here (2026-07-16)
 
 This repo is worked by CONCURRENT agent worktrees sharing ONE `.git`, and

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@libsql/client": "^0.9.0",
     "@neondatabase/serverless": "^1.0.1",
     "@t3-oss/env-nextjs": "^0.10.1",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.5",
     "@xstate/react": "^6.1.0",
     "drizzle-orm": "^0.44.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@t3-oss/env-nextjs':
         specifier: ^0.10.1
         version: 0.10.1(@typescript/typescript6@6.0.2)(zod@3.24.2)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(next@15.5.20(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/functions':
         specifier: ^3.7.5
         version: 3.7.5(ws@8.21.1)
@@ -1416,6 +1419,35 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
 
   '@vercel/cli-config@0.2.0':
     resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
@@ -4729,6 +4761,11 @@ snapshots:
       '@typescript/old': typescript@6.0.3
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vercel/analytics@2.0.1(next@15.5.20(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    optionalDependencies:
+      next: 15.5.20(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
 
   '@vercel/cli-config@0.2.0':
     dependencies:

--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { loadActivityStats } from '~/server/mp/store'
+
+export const runtime = 'nodejs'
+// Counts change constantly; never let Next serve a build-time snapshot.
+export const dynamic = 'force-dynamic'
+
+/**
+ * Public liveness counts for the landing screen: how many tables are running
+ * right now. Aggregate ONLY — no tokens, no names — so it needs no auth.
+ *
+ * Cached at the edge for 30s (`s-maxage`): refresh-spam then costs Vercel's
+ * cache, not a Neon query. `stale-while-revalidate` keeps the line rendering
+ * during the refresh. A DB failure answers zeroes with a 200 rather than a 500
+ * — this is decoration on the charter screen, and the caller (`useActivity`)
+ * treats "unreachable" and "no games" identically anyway.
+ */
+export async function GET() {
+  try {
+    const stats = await loadActivityStats()
+    return NextResponse.json(stats, {
+      headers: {
+        'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=60',
+      },
+    })
+  } catch {
+    return NextResponse.json(
+      { activeGames: 0, activePlayers: 0 },
+      { headers: { 'Cache-Control': 'no-store' } },
+    )
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Analytics } from '@vercel/analytics/next'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
@@ -16,7 +17,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="dark">
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        {children}
+        {/* Vercel Web Analytics. Off Vercel (local dev, offline e2e) the
+            component renders a script that no-ops, so it costs nothing and
+            needs no env var. Collection ALSO requires Web Analytics to be
+            enabled on the project dashboard — the package alone is inert. */}
+        <Analytics />
+      </body>
     </html>
   )
 }

--- a/src/components/activity-line.tsx
+++ b/src/components/activity-line.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { type ActivityStats, activityLine, fetchActivity } from './activity'
+
+/**
+ * "2 tables in progress · 5 industrialists at play" under the charter.
+ *
+ * Client-side and best-effort by design: the charter screen is fully static
+ * otherwise, and a DB hiccup must not cost it a render. Renders nothing until
+ * data arrives, and nothing at all when the count is zero or `/api/stats` is
+ * unreachable (`activityLine` folds both to null) — so an offline dev/e2e boot
+ * sees exactly what it saw before this existed. Fetched once on mount: the
+ * number is flavour, not a live meter, and polling it would defeat the
+ * endpoint's 30s cache.
+ */
+export function ActivityLine() {
+  const [stats, setStats] = useState<ActivityStats | null>(null)
+
+  useEffect(() => {
+    const ac = new AbortController()
+    void fetchActivity(fetch, ac.signal).then(setStats)
+    return () => ac.abort()
+  }, [])
+
+  const line = activityLine(stats)
+  if (!line) return null
+
+  return (
+    <p
+      className="bb2-rise flex items-center justify-center gap-2 text-[11px] uppercase tracking-[0.18em]"
+      style={{ color: 'rgba(231,215,177,.45)', animationDelay: '0.2s' }}
+      data-testid="activity-line"
+    >
+      <span
+        className="inline-block h-1.5 w-1.5 flex-none rounded-full"
+        style={{ background: 'var(--bb-brass)' }}
+      />
+      {line}
+    </p>
+  )
+}

--- a/src/components/activity.test.ts
+++ b/src/components/activity.test.ts
@@ -1,0 +1,95 @@
+// The charter's "N tables in progress" line: wording, and — the part that
+// matters — that a broken/unreachable `/api/stats` degrades to silence rather
+// than an error or a "NaN games" render. DOM-free, like `mp/refusal.test.ts`.
+import { describe, expect, test } from 'vitest'
+import { activityLine, fetchActivity } from './activity'
+
+const jsonRes = (body: unknown, ok = true): Response =>
+  ({ ok, json: async () => body }) as Response
+
+const stubFetch = (impl: () => Promise<Response>) =>
+  impl as unknown as typeof fetch
+
+describe('activityLine', () => {
+  test('renders nothing when the stats are unavailable', () => {
+    expect(activityLine(null)).toBeNull()
+  })
+
+  test('renders nothing when no games are in progress', () => {
+    // Zero and "DB unreachable" must look identical on the page.
+    expect(activityLine({ activeGames: 0, activePlayers: 0 })).toBeNull()
+  })
+
+  test('singularizes a lone table and player', () => {
+    expect(activityLine({ activeGames: 1, activePlayers: 1 })).toBe(
+      '1 table in progress · 1 industrialist at play',
+    )
+  })
+
+  test('pluralizes multiple tables and players', () => {
+    expect(activityLine({ activeGames: 3, activePlayers: 7 })).toBe(
+      '3 tables in progress · 7 industrialists at play',
+    )
+  })
+
+  test('omits the player clause when a lobby has no claimed seats', () => {
+    expect(activityLine({ activeGames: 1, activePlayers: 0 })).toBe(
+      '1 table in progress',
+    )
+  })
+})
+
+describe('fetchActivity', () => {
+  test('returns the counts on a healthy response', async () => {
+    const stats = await fetchActivity(
+      stubFetch(async () => jsonRes({ activeGames: 2, activePlayers: 5 })),
+    )
+    expect(stats).toEqual({ activeGames: 2, activePlayers: 5 })
+  })
+
+  test('returns null when the endpoint is unreachable', async () => {
+    const stats = await fetchActivity(
+      stubFetch(() => Promise.reject(new Error('offline'))),
+    )
+    expect(stats).toBeNull()
+  })
+
+  test('returns null on a non-ok response', async () => {
+    const stats = await fetchActivity(
+      stubFetch(async () => jsonRes({ error: 'boom' }, false)),
+    )
+    expect(stats).toBeNull()
+  })
+
+  test('returns null when the body is not JSON', async () => {
+    const stats = await fetchActivity(
+      stubFetch(
+        async () =>
+          ({
+            ok: true,
+            json: async () => {
+              throw new SyntaxError('Unexpected token <')
+            },
+          }) as unknown as Response,
+      ),
+    )
+    expect(stats).toBeNull()
+  })
+
+  test('returns null on a malformed body rather than rendering NaN', async () => {
+    // A tunnel/proxy answering 200 with something that is not our shape.
+    const stats = await fetchActivity(
+      stubFetch(async () => jsonRes({ activeGames: 'lots' })),
+    )
+    expect(stats).toBeNull()
+  })
+
+  test('an aborted fetch degrades to silence', async () => {
+    const stats = await fetchActivity(
+      stubFetch(() =>
+        Promise.reject(new DOMException('Aborted', 'AbortError')),
+      ),
+    )
+    expect(stats).toBeNull()
+  })
+})

--- a/src/components/activity.ts
+++ b/src/components/activity.ts
@@ -1,0 +1,58 @@
+// The "N games in progress" line on the charter screen — the pure half.
+//
+// Kept DOM-free on purpose (same convention as `mp/refusal.ts` and
+// `mp/turnNotify.ts`): the fetch-and-swallow policy and the wording are the
+// parts worth pinning, and this repo's vitest runs `environment: 'node'` with
+// no testing-library. `<ActivityLine>` in `activity-line.tsx` is the thin React
+// shell over these two functions.
+import type { ActivityStats } from '~/server/mp/store'
+
+export type { ActivityStats }
+
+/**
+ * Read `/api/stats`, returning null on ANY failure — offline, DB down, a 500,
+ * malformed JSON, an aborted fetch during unmount. This line is decoration on
+ * the landing screen: it must never surface an error, and callers render
+ * nothing for null. Errors are swallowed silently, not logged, because a
+ * console error on every offline dev boot trains people to ignore the console.
+ */
+export async function fetchActivity(
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<ActivityStats | null> {
+  try {
+    const res = await fetchImpl('/api/stats', { signal })
+    if (!res.ok) return null
+    const body: unknown = await res.json()
+    if (typeof body !== 'object' || body === null) return null
+    const { activeGames, activePlayers } = body as Record<string, unknown>
+    // Guard the shape rather than trusting it: a proxy/tunnel serving an HTML
+    // error page with a 200 would otherwise render "NaN games in progress".
+    if (!Number.isFinite(activeGames) || !Number.isFinite(activePlayers)) {
+      return null
+    }
+    return {
+      activeGames: activeGames as number,
+      activePlayers: activePlayers as number,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The rendered sentence, or null when there is nothing worth saying — no data
+ * (DB unreachable) and zero games are deliberately the SAME outcome: the line
+ * simply is not there. Never renders "0 games in progress".
+ */
+export function activityLine(stats: ActivityStats | null): string | null {
+  if (!stats || stats.activeGames < 1) return null
+  const games = `${stats.activeGames} ${stats.activeGames === 1 ? 'table' : 'tables'}`
+  // Seat counts can lag the game count (a lobby nobody has claimed yet), so
+  // only mention players when there are actually some to mention.
+  if (stats.activePlayers < 1) return `${games} in progress`
+  const players = `${stats.activePlayers} ${
+    stats.activePlayers === 1 ? 'industrialist' : 'industrialists'
+  }`
+  return `${games} in progress · ${players} at play`
+}

--- a/src/components/setup-screen.tsx
+++ b/src/components/setup-screen.tsx
@@ -8,6 +8,7 @@ import { toast } from 'sonner'
 import { aiOpponentsEnabled } from '~/lib/features'
 import { AI_TIERS, type AiTierId } from '~/server/ai/types'
 import { type Player } from '~/store/gameStore'
+import { ActivityLine } from './activity-line'
 import { PLAYER_FILL } from './board/board-map'
 
 const AI_ENABLED = aiOpponentsEnabled(process.env.NEXT_PUBLIC_VERCEL_ENV)
@@ -300,6 +301,8 @@ export function SetupScreen({
           </button>
         )}
       </div>
+
+      <ActivityLine />
 
       {/* CC BY 3.0 attribution for the game-icons.net glyphs */}
       <p

--- a/src/server/mp/store.stats.test.ts
+++ b/src/server/mp/store.stats.test.ts
@@ -1,0 +1,149 @@
+// `loadActivityStats` — the aggregate behind GET /api/stats. DB-backed: it is
+// a real SQL aggregate over a jsonb column, which is exactly the part a mock
+// would not test.
+//
+// ISOLATION, and why it looks odd: the stats query is GLOBAL (no token filter)
+// and its window has only a LOWER bound, over a database shared with the other
+// DB suites in parallel workers. So a fixture stamped in the PAST isolates
+// nothing — every real game those suites create is lexicographically ABOVE any
+// past cutoff and lands in the count (this was a real red run: activeGames 5
+// where 1 was expected). Two things buy exact counts instead of flaky deltas:
+//   1. Fixtures are stamped in the FAR FUTURE and `now` is injected to match,
+//      so every genuinely-current row sits BELOW the cutoff and drops out. No
+//      other suite writes a year-2999 row.
+//   2. Those rows are deleted after each test, so a lower-bound-only window
+//      cannot see the previous test's fixtures either.
+import { randomUUID } from 'node:crypto'
+import { inArray } from 'drizzle-orm'
+import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest'
+import { ensureTestSchema } from '../../test/db-schema'
+import { db } from '../db'
+import { games } from '../db/schema'
+import {
+  ACTIVE_WINDOW_MS,
+  type GameRecord,
+  type SeatRecord,
+  loadActivityStats,
+  saveGame,
+} from './store'
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
+
+/** Far ABOVE any real game's `updatedAt`, so a window anchored here excludes
+ *  every concurrently-created row. See the isolation note above. */
+const BASE = Date.parse('2999-01-01T00:00:00.000Z')
+/** Query instant: a minute after the fixtures, well inside the 5m window. */
+const NOW = BASE + 60_000
+
+const seeded: string[] = []
+
+const seat = (seatId: number, name: string | null): SeatRecord => ({
+  seatId,
+  name,
+  color: 'red',
+  character: 'Eliza Tinsley',
+  claimed: name !== null,
+  secretHash: name === null ? null : 'x'.repeat(64),
+})
+
+/** A game row stamped `ageMs` before BASE, tracked for teardown. */
+async function seedGame(opts: {
+  ageMs?: number
+  phase?: GameRecord['phase']
+  seats: SeatRecord[]
+}): Promise<void> {
+  const token = randomUUID().replace(/-/g, '')
+  const stamp = new Date(BASE - (opts.ageMs ?? 0)).toISOString()
+  seeded.push(token)
+  await saveGame({
+    token,
+    phase: opts.phase ?? 'playing',
+    createdAt: stamp,
+    updatedAt: stamp,
+    version: 1,
+    seats: opts.seats,
+    snapshot: null,
+  })
+}
+
+beforeAll(async () => {
+  await ensureTestSchema()
+})
+
+afterEach(async () => {
+  // Delete BY TOKEN, never a blanket wipe: parallel workers are using this
+  // same database and their games must survive.
+  if (seeded.length > 0) {
+    await db.delete(games).where(inArray(games.token, seeded))
+    seeded.length = 0
+  }
+})
+
+describe('loadActivityStats', () => {
+  test('counts nothing when no game is in the window', async () => {
+    // Also pins the aggregate folding sum-of-nothing (NULL) to 0, not NaN.
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 0,
+      activePlayers: 0,
+    })
+  })
+
+  test('counts a recent game and its seated players', async () => {
+    await seedGame({ seats: [seat(0, 'Ada'), seat(1, 'Brunel')] })
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 1,
+      activePlayers: 2,
+    })
+  })
+
+  test('counts only seats that are taken, not empty ones', async () => {
+    // A half-full lobby: 4 seats, 1 named. Must not claim 4 players.
+    await seedGame({
+      phase: 'lobby',
+      seats: [seat(0, 'Ada'), seat(1, null), seat(2, null), seat(3, null)],
+    })
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 1,
+      activePlayers: 1,
+    })
+  })
+
+  test('sums seats across several concurrent games', async () => {
+    await seedGame({ seats: [seat(0, 'Ada'), seat(1, 'Brunel')] })
+    await seedGame({ seats: [seat(0, 'George'), seat(1, null)] })
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 2,
+      activePlayers: 3,
+    })
+  })
+
+  test('excludes a game last touched before the window', async () => {
+    // The point of the window: an abandoned table is not "in progress".
+    await seedGame({ ageMs: 30 * 60_000, seats: [seat(0, 'Ada')] })
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 0,
+      activePlayers: 0,
+    })
+  })
+
+  test('excludes a finished game even when it was just touched', async () => {
+    await seedGame({ phase: 'over', seats: [seat(0, 'Ada'), seat(1, 'Brunel')] })
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 0,
+      activePlayers: 0,
+    })
+  })
+
+  test('honours a custom window', async () => {
+    await seedGame({ ageMs: 20 * 60_000, seats: [seat(0, 'Ada')] })
+    // Outside the 5m default, inside a 60m window — same row, same instant.
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 0,
+      activePlayers: 0,
+    })
+    expect(await loadActivityStats(60 * 60_000, NOW)).toEqual({
+      activeGames: 1,
+      activePlayers: 1,
+    })
+  })
+})

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -10,7 +10,18 @@
 // `chat_messages` table (see below) so a message never rewrites the game row
 // nor bumps `version`. Swapping the DB engine later is a config change in
 // `drizzle.config.ts` + `src/server/db/index.ts`, not a rewrite of this module.
-import { and, asc, desc, eq, gt, lt, notInArray, sql } from 'drizzle-orm'
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  gt,
+  gte,
+  lt,
+  ne,
+  notInArray,
+  sql,
+} from 'drizzle-orm'
 import { type AiLogEntry, type AiTierId, type AiUsageTotals } from '../ai/types'
 import { db } from '../db'
 import { chatMessages, games } from '../db/schema'
@@ -179,6 +190,61 @@ export async function loadAiPeek(token: string): Promise<AiPeek | null> {
     seats: row.seats,
     currentPlayerIndex:
       row.currentPlayerIndex === null ? null : Number(row.currentPlayerIndex),
+  }
+}
+
+/* ---------------- public activity stats (aggregate, no identifiers) ------- */
+
+/** How recently a game must have been touched to count as "in progress". */
+export const ACTIVE_WINDOW_MS = 5 * 60 * 1000
+
+/** Aggregate liveness counts. Deliberately COUNTS ONLY — no tokens, no seat
+ *  names — so this can be served to anyone from an unauthenticated endpoint. */
+export interface ActivityStats {
+  activeGames: number
+  activePlayers: number
+}
+
+/**
+ * Count the games touched within `windowMs` and the seated players in them.
+ *
+ * EGRESS: one aggregate round trip that pulls exactly two integers. `seats` is
+ * jsonb, so the per-row seated count is computed SERVER-side
+ * (`jsonb_array_elements` + `sum`) rather than by shipping the seat arrays here
+ * to be counted in JS — and the 28–65KB `snapshot` jsonb is never touched at
+ * all. Same discipline as `loadAiPeek`: this is a public endpoint that refresh
+ * -spam can hit, so it must stay O(bytes), not O(games).
+ *
+ * `updatedAt` bumps on every version-bumping write (`saveGame`), so it is the
+ * liveness signal; ISO-8601 text compares correctly against an ISO cutoff (same
+ * property `sweepStaleGames` relies on). Finished games are excluded — a table
+ * that ended 2 minutes ago is not "in progress". A seat counts as taken when it
+ * has a name, which covers AI seats (named at creation) as well as humans.
+ */
+export async function loadActivityStats(
+  windowMs = ACTIVE_WINDOW_MS,
+  now = Date.now(),
+): Promise<ActivityStats> {
+  const cutoff = new Date(now - windowMs).toISOString()
+  // Correlated scalar subquery per row; `sum()` then folds it across the
+  // matching games. COALESCE turns the no-active-games case (sum of an empty
+  // set is NULL) into 0 so the caller never special-cases it.
+  const seated = sql<number>`(
+    select count(*) from jsonb_array_elements(${games.seats}) as seat
+    where seat->>'name' is not null
+  )`
+  const rows = await db
+    .select({
+      activeGames: sql<number>`count(*)`,
+      activePlayers: sql<number>`coalesce(sum(${seated}), 0)`,
+    })
+    .from(games)
+    .where(and(gte(games.updatedAt, cutoff), ne(games.phase, 'over')))
+  const row = rows[0]
+  // Postgres count()/sum() are bigint — they arrive as strings over neon-http.
+  return {
+    activeGames: Number(row?.activeGames ?? 0),
+    activePlayers: Number(row?.activePlayers ?? 0),
   }
 }
 


### PR DESCRIPTION
Adds analytics in two independent halves. Neither touches game logic, the mp wire, or `filterSnapshotForSeat`.

## ⚠️ Post-merge step (required — one click)

**Flip Web Analytics ON: Vercel → project `brass-birmingham` → Analytics → Enable.** The package alone collects **nothing**; without this the traffic half is inert.

## 1. Traffic — Vercel Web Analytics

`<Analytics/>` from `@vercel/analytics/next` in `src/app/layout.tsx`, per [current Vercel docs](https://vercel.com/docs/analytics/quickstart) (fetched, not recalled — v2 of the package).

Offline-safe with no env var: off Vercel the component self-disables. Confirmed in a real browser on an offline dev boot:

> `[Vercel Web Analytics] Debug mode is enabled by default in development. No requests will be sent to the server.`

No console errors; unit + e2e suites unaffected.

## 2. Live "playing right now" — DB-derived

`loadActivityStats` in the store seam (kept the single DB owner) → `GET /api/stats` → a small line on the charter screen:

> ● 1 TABLE IN PROGRESS · 1 INDUSTRIALIST AT PLAY

**Egress discipline** (per the `loadAiPeek` lesson in AGENTS.md): **one** aggregate round trip returning two integers. Seats are counted server-side via `jsonb_array_elements` rather than shipped here to be counted in JS, and the 28–65KB `snapshot` jsonb is never touched. It's a public endpoint refresh-spam can hit, so `s-maxage=30, stale-while-revalidate=60` sits in front of it.

- **Liveness** = `games.updatedAt` (already on the schema, bumped by every `saveGame`) — **no migration needed**. Finished games are excluded: a table that ended 2 minutes ago isn't "in progress".
- **Privacy**: aggregate **counts only** — no tokens, no names — so no auth is needed and `filterSnapshotForSeat` stays untouched.
- **Never breaks the page**: fetched client-side, errors swallowed. An unreachable `/api/stats` and zero games render *identically* — nothing at all (never "0 games in progress").

The UI is split pure/shell, matching `mp/refusal.ts` and `turnNotify.ts`, because vitest runs `environment: 'node'` with no testing-library: `activity.ts` holds the fetch-and-swallow policy and wording (unit-tested); `activity-line.tsx` is the thin React shell.

## Tests

- **11 pure UI cases**: zero, unreachable, non-ok, non-JSON, malformed body (guards against rendering `NaN`), aborted fetch.
- **7 DB-backed store cases**: seated-vs-empty seats, multi-game sums, window exclusion, finished-game exclusion, custom window.

One gotcha worth flagging for review, now documented in AGENTS.md: the stats query is **global** with a **lower-bound-only** window, over a DB shared by parallel vitest workers. Past-stamped fixtures isolate *nothing* — every real 2026 row sorts above a year-2000 cutoff and gets counted. This was a genuine red run (`activeGames: 5` where 1 was expected) before fixtures moved to the far future + per-token cleanup.

## Verification

`pnpm test` 497 passed (twice, checking the parallel-isolation isn't flaky) · `pnpm exec playwright test` 31 passed · `pnpm build` · `pnpm lint` · `pnpm typecheck` — all green.

Beyond the suites, exercised for real: created a game via the API and watched `/api/stats` go `{0,0}` → `{1,1}`, then confirmed the line render and the Analytics no-op in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
