### PR TITLE
feat: durable append-only per-game intent log for reliable game reconstruction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -760,6 +760,24 @@ When updating this file, preserve this bar for all agents and keep entries conci
   "create a branch per preview deployment". Previews sit behind Vercel
   Deployment Protection (SSO) — viewable only when logged into the Vercel
   account.
+- INTENT LOG (2026-07-17): every ACCEPTED state-mutating engine write appends
+  one row to the append-only `game_intents` table (PK token+seq, chat pattern;
+  swept with the game) — the machine-replayable record for bug reproduction,
+  independent of the human-readable journal. Written ATOMICALLY with the
+  snapshot via `saveGame(game, intentLog)` (store.ts): ONE data-modifying-CTE
+  statement whose log INSERT selects FROM the version-guarded upsert's
+  RETURNING, so a lost concurrent write inserts NO phantom row. `kind='setup'`
+  rows carry the full initial snapshot (setup shuffles are random); refusals
+  are never logged (they don't mutate state). GOTCHA — the engine is
+  replay-deterministic EXCEPT the canal→rail transition (deck reshuffle,
+  `Math.random` in `eraTransitionToRail`): the intent crossing it must carry
+  `snapshot_after` (`eraCheckpoint` in intent.ts, called by actInGame AND the
+  AI runner) and `replayIntentLog` (replay.ts, pure/offline) re-bases there.
+  Server-side only: never in any client view, never read on the stream poll.
+  Reconstruct a bug-report game: `BB_REPLAY_TOKEN=<token> pnpm vitest run
+  src/server/mp/intentlog.test.ts -t 'BB_REPLAY_TOKEN'` (DATABASE_URL at the
+  branch holding it). Pinned by replay.test.ts (offline FULL mock-AI game,
+  both eras) + intentlog.test.ts (DB round-trip, concurrency, sweep).
 - Chat (normalized out 2026-07-16): chat lives in its OWN append-only
   `chat_messages` table (PK = game token + monotonic per-game `seq`, which is
   the wire `id`), NOT the game jsonb row. A POST /api/mp/chat appends ONE row

--- a/drizzle/0002_colossal_shadow_king.sql
+++ b/drizzle/0002_colossal_shadow_king.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "game_intents" (
+	"token" text NOT NULL,
+	"seq" integer NOT NULL,
+	"kind" text NOT NULL,
+	"seat_id" integer,
+	"payload" jsonb NOT NULL,
+	"snapshot_after" jsonb,
+	"version" integer NOT NULL,
+	"created_at" text NOT NULL,
+	CONSTRAINT "game_intents_token_seq_pk" PRIMARY KEY("token","seq")
+);
+--> statement-breakpoint
+CREATE INDEX "game_intents_token_idx" ON "game_intents" USING btree ("token");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,246 @@
+{
+  "id": "cd50dfce-bbe9-433f-aa8b-d75c2b6e2b13",
+  "prevId": "211a142d-2fd6-4bb3-a205-4a8bfb751330",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_token_idx": {
+          "name": "chat_messages_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_messages_token_seq_pk": {
+          "name": "chat_messages_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_intents": {
+      "name": "game_intents",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_after": {
+          "name": "snapshot_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_intents_token_idx": {
+          "name": "game_intents_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "game_intents_token_seq_pk": {
+          "name": "game_intents_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lobby'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seats": {
+          "name": "seats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai": {
+          "name": "ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784155157521,
       "tag": "0001_needy_peter_quill",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784286927201,
+      "tag": "0002_colossal_shadow_king",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -78,3 +78,47 @@ export const chatMessages = pgTable(
     index('chat_messages_token_idx').on(t.token),
   ],
 )
+
+/**
+ * The durable per-game INTENT LOG: one row per state-mutating engine write,
+ * appended in the SAME statement that persists the accepted snapshot (see
+ * `saveGame` in `../mp/store.ts`), so log and state cannot diverge — a save
+ * that loses the optimistic version guard inserts no log row.
+ *
+ * Purpose: reliable bug reproduction. The human-readable in-game journal is a
+ * rendering; this table is the machine-replayable record. `kind='setup'` rows
+ * carry the full initial persisted snapshot (setup shuffles are random, so
+ * replay must start from the captured state); `kind='intent'` rows carry the
+ * EXACT post-whitelist event as executed (human intents from `actInGame`, AI
+ * moves from the turn runner). Refusals are deliberately NOT recorded — they
+ * never mutate state, so replay does not need them.
+ *
+ * Server-side only: never shipped to clients, never read on the stream poll
+ * (egress discipline) — only by the replay tooling (`../mp/replay.ts`) and the
+ * TTL sweep. Same normalization pattern as `chat_messages`: PK (token, seq),
+ * swept when the game is swept.
+ */
+export const gameIntents = pgTable(
+  'game_intents',
+  {
+    token: text('token').notNull(),
+    /** monotonically increasing per game; allocated inside the save statement */
+    seq: integer('seq').notNull(),
+    kind: text('kind', { enum: ['setup', 'intent'] }).notNull(),
+    /** acting seat (AI seats included); null for the 'setup' system record */
+    seatId: integer('seat_id'),
+    /** the event as executed ('intent') or the initial snapshot ('setup') */
+    payload: jsonb('payload').notNull().$type<unknown>(),
+    /** replay checkpoint: the full resulting snapshot, present only when this
+     * intent crossed a nondeterministic engine boundary (the canal→rail
+     * transition reshuffles the deck), so replay re-bases on it */
+    snapshotAfter: jsonb('snapshot_after').$type<unknown>(),
+    /** the engine `games.version` this write produced */
+    version: integer('version').notNull(),
+    createdAt: text('created_at').notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.token, t.seq] }),
+    index('game_intents_token_idx').on(t.token),
+  ],
+)

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -10,7 +10,6 @@ import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { createActor } from 'xstate'
 import { gameStore } from '../../store/gameStore'
 import { STEP_SAFETY_BUDGET, aiDecideAndApply } from '../ai/driver'
-import { applyIntent, rehydrate } from './intent'
 import {
   gatewayBaseUrl,
   hasAnthropicKey,
@@ -25,6 +24,7 @@ import {
   emptyUsageTotals,
   isAiTierId,
 } from '../ai/types'
+import { applyIntent, eraCheckpoint, rehydrate } from './intent'
 import {
   type AiPeek,
   type ChatMessage,
@@ -338,7 +338,15 @@ export async function createGame(
   if (game.seats.every((s) => s.claimed)) {
     startEngine(game)
   }
-  await saveGame(game)
+  // A started engine writes the intent log's 'setup' record atomically with
+  // the row: setup shuffles are random, so replay must start from this exact
+  // captured snapshot (see replay.ts).
+  await saveGame(
+    game,
+    game.snapshot !== null
+      ? { kind: 'setup', seatId: null, payload: game.snapshot }
+      : undefined,
+  )
   void kickAiTurns(token)
   return { token, seatId: 0, seatSecret: secret }
 }
@@ -377,12 +385,21 @@ export async function joinGame(
     seat.claimed = true
     seat.name = name.slice(0, 24) || `Player ${seat.seatId + 1}`
     seat.secretHash = hash(secret)
-    if (game.phase === 'lobby' && game.seats.every((s) => s.claimed)) {
+    const startedNow =
+      game.phase === 'lobby' && game.seats.every((s) => s.claimed)
+    if (startedNow) {
       startEngine(game)
     }
     game.version++
     game.updatedAt = new Date().toISOString()
-    await saveGame(game)
+    // When THIS join started the engine, capture the initial snapshot as the
+    // intent log's 'setup' record (see createGame).
+    await saveGame(
+      game,
+      startedNow
+        ? { kind: 'setup', seatId: null, payload: game.snapshot }
+        : undefined,
+    )
     broadcast(token)
     void kickAiTurns(token)
     return { seatId: seat.seatId, seatSecret: secret }
@@ -440,11 +457,22 @@ export async function actInGame(
     const outcome = applyIntent(game.snapshot, seatId, event)
     if (!outcome.ok) return { ok: false, error: outcome.error }
 
+    // Log the ACCEPTED event exactly as executed, atomically with the
+    // snapshot it produced (refusals never reach here and are not logged —
+    // they don't mutate state, so replay doesn't need them). An intent that
+    // crossed the era boundary carries the resulting snapshot as a replay
+    // checkpoint — the rail deck reshuffle is nondeterministic.
+    const checkpoint = eraCheckpoint(game.snapshot, outcome.next)
     game.snapshot = outcome.next
     if (outcome.gameOver) game.phase = 'over'
     game.version++
     game.updatedAt = new Date().toISOString()
-    await saveGame(game)
+    await saveGame(game, {
+      kind: 'intent',
+      seatId,
+      payload: event,
+      snapshotAfter: checkpoint,
+    })
     broadcast(token)
     void kickAiTurns(token)
     // Return the actor's OWN fresh per-seat view so the client applies its
@@ -703,7 +731,15 @@ async function runAiTurns(token: string): Promise<void> {
       ai.usage.fallbacks += outcome.usage.fallbacks
       game.version++
       game.updatedAt = new Date().toISOString()
-      await saveGame(game)
+      // AI moves land in the same intent log as human ones: one applied
+      // engine event per decision, attributed to the AI seat (with the same
+      // era-boundary replay checkpoint as actInGame).
+      await saveGame(game, {
+        kind: 'intent',
+        seatId: seat.seatId,
+        payload: outcome.move.event,
+        snapshotAfter: eraCheckpoint(peek.snapshot, outcome.snapshot),
+      })
       aiThinking.delete(token)
       broadcast(token)
       return engineDone

--- a/src/server/mp/intent.ts
+++ b/src/server/mp/intent.ts
@@ -79,6 +79,24 @@ export function rehydrate(snapshot: unknown): unknown {
   return clone
 }
 
+/**
+ * Does the intent log need a replay CHECKPOINT for this accepted transition?
+ *
+ * The engine is deterministic given the setup snapshot and the event stream,
+ * with ONE exception: the canal→rail era transition reshuffles the discard +
+ * draw piles into a fresh deck and deals new hands (`Math.random`, see
+ * `eraTransitionToRail` in gameStore.ts). An event-sourced replay cannot
+ * reproduce that shuffle, so the log row for the intent that crossed the
+ * boundary must carry the full resulting snapshot; replay re-bases on it
+ * (`replayIntentLog` in replay.ts). Returns the checkpoint payload (the
+ * `after` snapshot) or null when none is needed.
+ */
+export function eraCheckpoint(before: unknown, after: unknown): unknown | null {
+  const eraOf = (s: unknown) =>
+    (s as { context?: { era?: string } } | null)?.context?.era
+  return eraOf(before) !== eraOf(after) ? after : null
+}
+
 export type IntentOutcome =
   | { ok: true; next: unknown; gameOver: boolean }
   | { ok: false; error: string }

--- a/src/server/mp/intentlog.test.ts
+++ b/src/server/mp/intentlog.test.ts
@@ -1,0 +1,267 @@
+// The durable intent log through the REAL store: every accepted intent lands
+// as one `game_intents` row written ATOMICALLY with the snapshot it produced;
+// refusals leave nothing; a lost concurrent write leaves NO phantom row; and
+// the logged rows replay to the exact stored final state. The offline
+// full-game replay proof (two eras, mock AI) lives in replay.test.ts.
+//
+// Reconstructing a bug-report game: with DATABASE_URL pointed at the branch
+// holding the game, run
+//   BB_REPLAY_TOKEN=<token> pnpm vitest run src/server/mp/intentlog.test.ts -t 'BB_REPLAY_TOKEN'
+// (see the guarded describe at the bottom), or export the rows with
+//   select * from game_intents where token = '<token>' order by seq
+// and feed them to `replayIntentLog` (replay.ts) offline.
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+import { ensureTestSchema } from '../../test/db-schema'
+import { actInGame, createGame, getGameView, joinGame } from './game'
+import { normalizeSnapshotForComparison, replayIntentLog } from './replay'
+import {
+  type GameRecord,
+  loadGame,
+  loadIntentLog,
+  saveGame,
+  sweepStaleGames,
+} from './store'
+
+// Every test drives several sequential round-trips to a real (network) DB —
+// same sizing as the other DB-backed mp suites.
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
+
+beforeAll(async () => {
+  process.env.BB_AI_MOCK = '1'
+  await ensureTestSchema()
+})
+
+afterAll(() => {
+  delete process.env.BB_AI_MOCK
+})
+
+type Ctx = {
+  players: Array<{ hand: Array<{ id: string }> }>
+  currentPlayerIndex: number
+}
+const ctxOf = (snapshot: unknown) => (snapshot as { context: Ctx }).context
+
+async function freshGame() {
+  const host = await createGame('Ada', 2)
+  const guest = await joinGame(host.token, 'Brunel')
+  return { host, guest }
+}
+
+/** Act as whichever seat is current; returns the sent events. */
+async function playLoanTurn(
+  token: string,
+  creds: Record<number, string>,
+): Promise<Array<Record<string, unknown>>> {
+  const game = await loadGame(token)
+  const seat = ctxOf(game!.snapshot).currentPlayerIndex
+  const secret = creds[seat]!
+  const view = await getGameView(token, seat, secret)
+  const cardId = ctxOf(view!.snapshot).players[seat]!.hand[0]!.id
+  const events = [
+    { type: 'TAKE_LOAN' },
+    { type: 'SELECT_CARD', cardId },
+    { type: 'CONFIRM' },
+  ]
+  for (const event of events) {
+    const res = await actInGame(token, seat, secret, event)
+    expect(res.ok).toBe(true)
+  }
+  return events
+}
+
+describe('intent log: append-on-accept', () => {
+  test('engine start writes the setup record; each accepted intent appends exactly one row', async () => {
+    const { host, guest } = await freshGame()
+    const creds = { 0: host.seatSecret, 1: guest.seatSecret }
+
+    // The join that started the engine captured the initial snapshot.
+    let rows = await loadIntentLog(host.token)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ seq: 1, kind: 'setup', seatId: null })
+    const started = await loadGame(host.token)
+    expect(rows[0]!.version).toBe(started!.version)
+    // the captured payload IS the stored initial snapshot
+    expect(rows[0]!.payload).toEqual(started!.snapshot)
+
+    const seat = ctxOf(started!.snapshot).currentPlayerIndex
+    const events = await playLoanTurn(host.token, creds)
+
+    rows = await loadIntentLog(host.token)
+    expect(rows).toHaveLength(4)
+    rows.slice(1).forEach((row, i) => {
+      expect(row.kind).toBe('intent')
+      expect(row.seatId).toBe(seat)
+      expect(row.seq).toBe(i + 2)
+      // the exact event as sent, none of them an era boundary
+      expect(row.payload).toEqual(events[i])
+      expect(row.snapshotAfter).toBeNull()
+    })
+    // each row records the version its write produced — strictly ascending,
+    // ending at the game's current version
+    const game = await loadGame(host.token)
+    expect(rows.map((r) => r.version)).toEqual([2, 3, 4, 5])
+    expect(rows[rows.length - 1]!.version).toBe(game!.version)
+  })
+
+  test('a refused intent appends nothing', async () => {
+    const { host, guest } = await freshGame()
+    const before = await loadIntentLog(host.token)
+
+    const game = await loadGame(host.token)
+    const seat = ctxOf(game!.snapshot).currentPlayerIndex
+    const secret = seat === 0 ? host.seatSecret : guest.seatSecret
+
+    // guard refusal: CONFIRM with nothing staged
+    const refused = await actInGame(host.token, seat, secret, {
+      type: 'CONFIRM',
+    })
+    expect(refused.ok).toBe(false)
+    // whitelist refusal: TEST_* never reaches the engine
+    const forged = await actInGame(host.token, seat, secret, {
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: 0,
+      hand: [],
+    })
+    expect(forged.ok).toBe(false)
+
+    expect(await loadIntentLog(host.token)).toEqual(before)
+  })
+
+  test('AI moves are logged like human ones, attributed to the AI seat', async () => {
+    // With the mock provider the AI takes its whole turn as soon as the
+    // engine starts (seat order is shuffled, so wait for quiescence).
+    const host = await createGame('Ada', 2, ['apprentice'])
+    const start = Date.now()
+    for (;;) {
+      const game = await loadGame(host.token)
+      if (
+        game &&
+        game.snapshot !== null &&
+        ctxOf(game.snapshot).currentPlayerIndex === 0
+      )
+        break
+      if (Date.now() - start > 8000) throw new Error('AI never yielded')
+      await new Promise((r) => setTimeout(r, 50))
+    }
+    // Ada plays a loan; the AI then takes its whole turn on its own.
+    await playLoanTurn(host.token, { 0: host.seatSecret })
+    for (;;) {
+      const game = await loadGame(host.token)
+      if (ctxOf(game!.snapshot).currentPlayerIndex === 0) break
+      if (Date.now() - start > 20000) throw new Error('AI turn never finished')
+      await new Promise((r) => setTimeout(r, 50))
+    }
+
+    const rows = await loadIntentLog(host.token)
+    expect(rows[0]!.kind).toBe('setup')
+    const bySeat = new Map<number | null, number>()
+    for (const row of rows.slice(1)) {
+      bySeat.set(row.seatId, (bySeat.get(row.seatId) ?? 0) + 1)
+    }
+    expect(bySeat.get(0)).toBeGreaterThanOrEqual(3)
+    expect(bySeat.get(1)).toBeGreaterThanOrEqual(1)
+
+    // and the mixed human+AI log replays to the stored state
+    const game = await loadGame(host.token)
+    const replayed = replayIntentLog(rows)
+    expect(normalizeSnapshotForComparison(replayed.snapshot)).toEqual(
+      normalizeSnapshotForComparison(game!.snapshot),
+    )
+  })
+})
+
+describe('intent log: atomicity with the version-guarded save', () => {
+  test('a lost concurrent write throws AND leaves no phantom log row', async () => {
+    const { host } = await freshGame()
+    const record = (await loadGame(host.token))!
+
+    // Two writers race the same read-modify-write: both bump to version+1.
+    const winner: GameRecord = { ...record, version: record.version + 1 }
+    await saveGame(winner, {
+      kind: 'intent',
+      seatId: 0,
+      payload: { type: 'PASS' },
+    })
+    const afterWinner = await loadIntentLog(host.token)
+
+    const loser: GameRecord = { ...record, version: record.version + 1 }
+    await expect(
+      saveGame(loser, {
+        kind: 'intent',
+        seatId: 1,
+        payload: { type: 'TAKE_LOAN' },
+      }),
+    ).rejects.toThrow(/Concurrent write/)
+
+    // the losing save inserted NOTHING — log and snapshot cannot diverge
+    expect(await loadIntentLog(host.token)).toEqual(afterWinner)
+    const stored = await loadGame(host.token)
+    expect(stored!.version).toBe(winner.version)
+  })
+
+  test('the sweep drops a stale game and its intent rows together', async () => {
+    const { host } = await freshGame()
+    const record = (await loadGame(host.token))!
+    expect((await loadIntentLog(host.token)).length).toBeGreaterThan(0)
+
+    // Backdate the game past the TTL, then sweep (bypassing the throttle by
+    // moving `now` forward; the cutoff stays ~7 days in the past, so other
+    // suites' fresh games are untouched).
+    await saveGame({
+      ...record,
+      version: record.version + 1,
+      updatedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
+    })
+    await sweepStaleGames(Date.now() + 2 * 60 * 60 * 1000)
+
+    expect(await loadGame(host.token)).toBeNull()
+    expect(await loadIntentLog(host.token)).toEqual([])
+  })
+})
+
+describe('intent log: DB round-trip replay', () => {
+  test('a played game reconstructs from its stored rows to the stored snapshot', async () => {
+    const { host, guest } = await freshGame()
+    const creds = { 0: host.seatSecret, 1: guest.seatSecret }
+
+    // A few real turns through the wire seam (both seats).
+    for (let turn = 0; turn < 4; turn++) {
+      await playLoanTurn(host.token, creds)
+    }
+
+    const game = await loadGame(host.token)
+    const rows = await loadIntentLog(host.token)
+    expect(rows).toHaveLength(1 + 4 * 3)
+
+    const replayed = replayIntentLog(rows)
+    expect(replayed.steps).toBe(rows.length - 1)
+    expect(replayed.version).toBe(game!.version)
+    expect(normalizeSnapshotForComparison(replayed.snapshot)).toEqual(
+      normalizeSnapshotForComparison(game!.snapshot),
+    )
+  })
+})
+
+// The bug-report tool: point DATABASE_URL at the branch holding the game and
+//   BB_REPLAY_TOKEN=<token> pnpm vitest run src/server/mp/intentlog.test.ts -t 'BB_REPLAY_TOKEN'
+// It replays the stored intent log through the real engine and asserts the
+// reconstruction matches the stored snapshot, printing a short summary.
+const REPLAY_TOKEN = process.env.BB_REPLAY_TOKEN
+describe.runIf(!!REPLAY_TOKEN)('intent log: BB_REPLAY_TOKEN tool', () => {
+  test('replays the game named by BB_REPLAY_TOKEN against its stored snapshot', async () => {
+    const token = REPLAY_TOKEN!
+    const game = await loadGame(token)
+    expect(game, `game ${token} not found`).toBeTruthy()
+    const rows = await loadIntentLog(token)
+    expect(rows.length, 'game has no intent log').toBeGreaterThan(0)
+
+    const replayed = replayIntentLog(rows)
+    console.log(
+      `[replay] ${token}: ${replayed.steps} intents replayed, ` +
+        `log version ${replayed.version}, stored version ${game!.version}`,
+    )
+    expect(normalizeSnapshotForComparison(replayed.snapshot)).toEqual(
+      normalizeSnapshotForComparison(game!.snapshot),
+    )
+  })
+})

--- a/src/server/mp/replay.test.ts
+++ b/src/server/mp/replay.test.ts
@@ -1,0 +1,189 @@
+// The intent-log replay contract, proven OFFLINE on a full real game: two
+// mock-driven AI seats play from setup to gameOver through the same
+// one-event-per-decision seam the server logs (`aiDecideAndApply`, exactly
+// what `runAiTurns` records), producing the row stream `game_intents` would
+// hold — then `replayIntentLog` reconstructs the identical final state from
+// the captured setup snapshot + events alone. The DB-backed half (rows
+// actually written/read through the store) lives in intentlog.test.ts.
+import { describe, expect, test, vi } from 'vitest'
+import { createActor } from 'xstate'
+import { gameStore } from '../../store/gameStore'
+import { STEP_SAFETY_BUDGET, aiDecideAndApply } from '../ai/driver'
+import { mockProvider } from '../ai/provider'
+import { AI_TIERS } from '../ai/types'
+import { eraCheckpoint } from './intent'
+import {
+  type ReplayRow,
+  normalizeSnapshotForComparison,
+  replayIntentLog,
+} from './replay'
+
+// A full two-era game is hundreds of engine decisions, each enumerating and
+// probing moves on scratch actors — well past the 5s engine-suite default.
+vi.setConfig({ testTimeout: 120_000 })
+
+const startPlayers = [
+  {
+    id: '1',
+    name: 'Ada',
+    color: 'red' as const,
+    character: 'Eliza Tinsley' as const,
+    money: 17,
+    victoryPoints: 0,
+    income: 10,
+    industryTilesOnMat: {} as never,
+  },
+  {
+    id: '2',
+    name: 'Brunel',
+    color: 'blue' as const,
+    character: 'Isambard Kingdom Brunel' as const,
+    money: 17,
+    victoryPoints: 0,
+    income: 10,
+    industryTilesOnMat: {} as never,
+  },
+]
+
+type Persisted = {
+  status?: string
+  context: { currentPlayerIndex: number; era: string; round: number }
+}
+
+/** Simulate jsonb storage: what was written is what a bug report exports. */
+const throughJson = (value: unknown): unknown =>
+  JSON.parse(JSON.stringify(value))
+
+function setupGame(): unknown {
+  const actor = createActor(gameStore)
+  actor.start()
+  actor.send({ type: 'START_GAME', players: startPlayers })
+  const persisted = actor.getPersistedSnapshot()
+  actor.stop()
+  return persisted
+}
+
+describe('replayIntentLog', () => {
+  test('a full mock-AI game replays from the logged rows to the identical final state', async () => {
+    let persisted = setupGame()
+    const rows: ReplayRow[] = [
+      // seq 1 = the setup record, exactly as createGame/joinGame log it
+      {
+        seq: 1,
+        kind: 'setup',
+        seatId: null,
+        payload: throughJson(persisted),
+        version: 1,
+      },
+    ]
+
+    // Both seats are mock-AI: every decision applies exactly ONE engine
+    // event (`outcome.move.event`) — the same thing runAiTurns persists.
+    // Mirror the runner's turn-local memory + safety budget too, or the
+    // model (mock included) forgets abandoned plans and loops forever —
+    // the exact stall the server-side budget exists to break.
+    let version = 1
+    let lastSeat = -1
+    let stepsThisTurn = 0
+    let turnNotes: string[] = []
+    for (let step = 0; step < 5000; step++) {
+      const snap = persisted as Persisted
+      if (snap.status === 'done') break
+      const seatIndex = snap.context.currentPlayerIndex
+      if (seatIndex !== lastSeat) {
+        lastSeat = seatIndex
+        stepsThisTurn = 0
+        turnNotes = []
+      }
+      stepsThisTurn += 1
+      const outcome = await aiDecideAndApply({
+        persisted,
+        seatIndex,
+        provider: mockProvider,
+        tier: AI_TIERS.apprentice,
+        turnNotes,
+        forceSafe: stepsThisTurn > STEP_SAFETY_BUDGET,
+      })
+      turnNotes.push(outcome.move.label)
+      version += 1
+      // Same checkpoint rule as the server: the intent that crosses the era
+      // boundary carries the resulting snapshot (rail deck reshuffle is
+      // nondeterministic — Math.random — so replay must re-base there).
+      const checkpoint = eraCheckpoint(persisted, outcome.snapshot)
+      rows.push({
+        seq: rows.length + 1,
+        kind: 'intent',
+        seatId: seatIndex,
+        payload: throughJson(outcome.move.event),
+        snapshotAfter: checkpoint === null ? null : throughJson(checkpoint),
+        version,
+      })
+      persisted = outcome.snapshot
+    }
+
+    // The game genuinely finished — this is an end-to-end, two-era run, and
+    // it crossed the one nondeterministic boundary (canal→rail reshuffle).
+    expect((persisted as Persisted).status).toBe('done')
+    expect((persisted as Persisted).context.era).toBe('rail')
+    expect(rows.length).toBeGreaterThan(100)
+    expect(rows.filter((r) => r.snapshotAfter != null)).toHaveLength(1)
+
+    const replayed = replayIntentLog(rows)
+    expect(replayed.steps).toBe(rows.length - 1)
+    expect(replayed.version).toBe(version)
+    expect(normalizeSnapshotForComparison(replayed.snapshot)).toEqual(
+      normalizeSnapshotForComparison(persisted),
+    )
+  })
+
+  test('refuses a log without its setup record', () => {
+    expect(() =>
+      replayIntentLog([
+        {
+          seq: 1,
+          kind: 'intent',
+          seatId: 0,
+          payload: { type: 'PASS' },
+          version: 2,
+        },
+      ]),
+    ).toThrow(/no leading setup record/)
+  })
+
+  test('a diverging event fails loudly, naming the seq and event', () => {
+    const persisted = setupGame()
+    expect(() =>
+      replayIntentLog([
+        {
+          seq: 1,
+          kind: 'setup',
+          seatId: null,
+          payload: throughJson(persisted),
+          version: 1,
+        },
+        // CONFIRM is never legal straight out of setup
+        {
+          seq: 2,
+          kind: 'intent',
+          seatId: (persisted as Persisted).context.currentPlayerIndex,
+          payload: { type: 'CONFIRM' },
+          version: 2,
+        },
+      ]),
+    ).toThrow(/seq 2/)
+  })
+
+  test('normalizeSnapshotForComparison drops only the log wall-clock', () => {
+    const persisted = setupGame() as {
+      context: { logs: Array<{ message: string; timestamp: unknown }> }
+    }
+    const normalized = normalizeSnapshotForComparison(persisted) as {
+      context: { logs: Array<{ message?: string; timestamp?: unknown }> }
+    }
+    expect(normalized.context.logs.length).toBeGreaterThan(0)
+    for (const entry of normalized.context.logs) {
+      expect(entry.timestamp).toBeUndefined()
+      expect(entry.message).toBeTruthy()
+    }
+  })
+})

--- a/src/server/mp/replay.ts
+++ b/src/server/mp/replay.ts
@@ -1,0 +1,97 @@
+// Reconstruct a multiplayer/AI game from its durable intent log.
+//
+// The `game_intents` table (see ../db/schema.ts) records, per game, the
+// initial engine snapshot ('setup' — setup shuffles are random, so replay must
+// start from the captured state) followed by every ACCEPTED state-mutating
+// event exactly as executed ('intent', human and AI seats alike). This module
+// replays that sequence through the REAL accepted-intent seam (`applyIntent`)
+// and hands back the final snapshot, so a bug-report game can be rebuilt
+// deterministically without relying on the human-readable in-game journal.
+//
+// Pure on purpose: no DB import, so it works offline on exported JSON rows
+// (fetch them with `loadIntentLog` in store.ts, or plain SQL — see the PR /
+// README note). The DB-backed round-trip proof lives in intentlog.test.ts.
+import { applyIntent } from './intent'
+
+/** The DB-independent shape of one log row — `IntentLogRow` from store.ts
+ * minus the fields replay doesn't need, so exported JSON qualifies. */
+export interface ReplayRow {
+  seq: number
+  kind: 'setup' | 'intent'
+  seatId: number | null
+  payload: unknown
+  /** replay checkpoint captured when this intent crossed a nondeterministic
+   * boundary (the canal→rail deck reshuffle) — replay re-bases on it */
+  snapshotAfter?: unknown | null
+  /** the engine `games.version` the original write produced */
+  version: number
+}
+
+export interface ReplayResult {
+  /** persisted snapshot after the last replayed intent */
+  snapshot: unknown
+  /** the `games.version` recorded by the last replayed row */
+  version: number
+  /** number of 'intent' rows replayed (the 'setup' row not counted) */
+  steps: number
+}
+
+/**
+ * Replay an intent log from its captured setup snapshot through every logged
+ * event, in seq order, via the same seam that accepted them originally.
+ * Throws (naming the failing seq/event) if any logged event no longer
+ * applies — that is the interesting bug-report signal, not a case to paper
+ * over.
+ */
+export function replayIntentLog(rows: ReplayRow[]): ReplayResult {
+  const ordered = [...rows].sort((a, b) => a.seq - b.seq)
+  const setup = ordered[0]
+  if (!setup || setup.kind !== 'setup') {
+    throw new Error(
+      'Intent log has no leading setup record — cannot replay without the captured initial snapshot.',
+    )
+  }
+  let snapshot: unknown = setup.payload
+  let version = setup.version
+  let steps = 0
+  for (const row of ordered.slice(1)) {
+    if (row.kind !== 'intent') {
+      throw new Error(`Unexpected extra '${row.kind}' record at seq ${row.seq}`)
+    }
+    if (row.seatId === null) {
+      throw new Error(`Intent row at seq ${row.seq} has no seat`)
+    }
+    const event = row.payload as { type: string } & Record<string, unknown>
+    const outcome = applyIntent(snapshot, row.seatId, event)
+    if (!outcome.ok) {
+      throw new Error(
+        `Replay diverged at seq ${row.seq} (seat ${row.seatId}, ${event.type}): ${outcome.error}`,
+      )
+    }
+    // An era-boundary intent recorded the resulting snapshot (the rail deck
+    // reshuffle is nondeterministic, so re-applying the event cannot
+    // reproduce it) — continue from the captured state, not the replayed one.
+    snapshot = row.snapshotAfter != null ? row.snapshotAfter : outcome.next
+    version = row.version
+    steps += 1
+  }
+  return { snapshot, version, steps }
+}
+
+/**
+ * Make two persisted snapshots comparable: a JSON round-trip (jsonb storage
+ * already turned `Infinity` into `null` and `Date` into ISO strings — apply
+ * the same transform to the live side) and drop the one wall-clock field,
+ * `logs[].timestamp`, which necessarily differs between the original run and
+ * a replay. Everything else — board, hands, markets, money, log MESSAGES and
+ * their order — must match exactly.
+ */
+export function normalizeSnapshotForComparison(persisted: unknown): unknown {
+  const clone = JSON.parse(JSON.stringify(persisted)) as {
+    context?: { logs?: Array<{ timestamp?: unknown }> }
+  }
+  for (const entry of clone.context?.logs ?? []) {
+    delete entry.timestamp
+  }
+  return clone
+}

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -13,7 +13,7 @@
 import { and, asc, desc, eq, gt, lt, notInArray, sql } from 'drizzle-orm'
 import { type AiLogEntry, type AiTierId, type AiUsageTotals } from '../ai/types'
 import { db } from '../db'
-import { chatMessages, games } from '../db/schema'
+import { chatMessages, gameIntents, games } from '../db/schema'
 
 export interface SeatRecord {
   seatId: number
@@ -276,7 +276,56 @@ export async function loadChatSince(
   return rows.map(rowToChat)
 }
 
-export async function saveGame(game: GameRecord): Promise<void> {
+/* ------------- the intent log (durable, append-only, per game) ------------- */
+
+/** What a state-mutating save appends to the intent log. `'setup'` payloads
+ * are the full initial persisted snapshot (setup shuffles are random, so a
+ * replay must start from the captured state); `'intent'` payloads are the
+ * exact post-whitelist event as executed. */
+export interface IntentLogEntry {
+  kind: 'setup' | 'intent'
+  /** the acting seat (AI seats included); null for the 'setup' record */
+  seatId: number | null
+  payload: unknown
+  /** replay checkpoint: the full resulting snapshot, set only when this
+   * intent crossed a nondeterministic engine boundary (the canal→rail
+   * transition reshuffles the deck) — see `eraCheckpoint` in intent.ts */
+  snapshotAfter?: unknown | null
+}
+
+/** One stored intent-log row (see `gameIntents` in the schema). */
+export interface IntentLogRow extends IntentLogEntry {
+  seq: number
+  /** the engine `games.version` this write produced */
+  version: number
+  at: string
+}
+
+/** The full intent log for a game, ascending by seq. Tooling/tests only —
+ * never called on the stream poll or any per-request path. */
+export async function loadIntentLog(token: string): Promise<IntentLogRow[]> {
+  if (!TOKEN_RE.test(token)) return []
+  const rows = await db
+    .select()
+    .from(gameIntents)
+    .where(eq(gameIntents.token, token))
+    .orderBy(asc(gameIntents.seq))
+  return rows.map((r) => ({
+    seq: r.seq,
+    kind: r.kind,
+    seatId: r.seatId,
+    payload: r.payload,
+    snapshotAfter: r.snapshotAfter ?? null,
+    version: r.version,
+    at: r.createdAt,
+  }))
+}
+
+export async function saveGame(
+  game: GameRecord,
+  /** append this to the intent log ATOMICALLY with the snapshot write */
+  intentLog?: IntentLogEntry,
+): Promise<void> {
   if (!TOKEN_RE.test(game.token)) throw new Error('Malformed game token')
   const row = recordToRow(game)
   // Single atomic upsert replaces the old tmp-file + rename dance; the caller
@@ -285,7 +334,7 @@ export async function saveGame(game: GameRecord): Promise<void> {
   // can race the same read-modify-write — the writer whose bumped version is
   // no longer ahead of the stored one loses, loudly, instead of silently
   // overwriting the row (which would also erase chat — messages live in it).
-  const written = await db
+  const upsert = db
     .insert(games)
     .values(row)
     .onConflictDoUpdate({
@@ -294,7 +343,42 @@ export async function saveGame(game: GameRecord): Promise<void> {
       setWhere: lt(games.version, row.version),
     })
     .returning({ token: games.token })
-  if (written.length === 0) {
+
+  if (!intentLog) {
+    const written = await upsert
+    if (written.length === 0) {
+      throw new Error('Concurrent write: the game changed under this save')
+    }
+    return
+  }
+
+  // Snapshot + log in ONE data-modifying-CTE statement, so they cannot
+  // diverge: the log INSERT selects FROM the upsert's RETURNING, which is
+  // empty exactly when the version guard rejected the write — a lost
+  // concurrent save inserts NO log row (no phantom), and a crash can never
+  // land between the two (they commit together). The next `seq` is computed
+  // inline; concurrent writers for the same token serialize on the `games`
+  // row lock taken by the upsert, and the loser's guard failure empties `up`,
+  // so the stale max(seq) it may have read is never used.
+  const result = await db.execute(sql`
+    with up as ${upsert}
+    insert into game_intents (token, seq, kind, seat_id, payload, snapshot_after, version, created_at)
+    select up.token,
+           (select coalesce(max(seq), 0) + 1 from game_intents where token = ${game.token}),
+           ${intentLog.kind},
+           ${intentLog.seatId}::int,
+           ${JSON.stringify(intentLog.payload)}::jsonb,
+           ${
+             intentLog.snapshotAfter != null
+               ? JSON.stringify(intentLog.snapshotAfter)
+               : null
+           }::jsonb,
+           ${game.version},
+           ${game.updatedAt}
+    from up
+    returning token
+  `)
+  if (result.rows.length === 0) {
     throw new Error('Concurrent write: the game changed under this save')
   }
 }
@@ -309,13 +393,22 @@ export async function sweepStaleGames(now = Date.now()): Promise<void> {
   // so a string `<` comparison is a correct TTL cutoff.
   const cutoff = new Date(now - GAME_TTL_MS).toISOString()
   await db.delete(games).where(lt(games.updatedAt, cutoff))
-  // Chat rows are tied to game lifetime; drop any now-orphaned by the sweep
-  // above (anti-join is cheap at this scale and keeps deletion in one place).
+  // Chat and intent-log rows are tied to game lifetime; drop any now-orphaned
+  // by the sweep above (anti-join is cheap at this scale and keeps deletion in
+  // one place).
   await db
     .delete(chatMessages)
     .where(
       notInArray(
         chatMessages.token,
+        db.select({ token: games.token }).from(games),
+      ),
+    )
+  await db
+    .delete(gameIntents)
+    .where(
+      notInArray(
+        gameIntents.token,
         db.select({ token: games.token }).from(games),
       ),
     )


### PR DESCRIPTION
## What

A durable, append-only per-game **intent log** (`game_intents` table) so any multiplayer/AI game can be reconstructed reliably for bug reproduction, independent of the human-readable in-game journal.

- **One row per accepted state-mutating engine write**, following the `chat_messages` normalization pattern: PK `(token, seq)`, per-game monotonic `seq`, acting seat (AI seats included, `null` for the setup system record), the exact post-whitelist event payload, the resulting engine `version`, ISO timestamp. Swept together with the game by the existing 7-day TTL sweep.
- **`kind='setup'` rows capture the full initial persisted snapshot** at engine start (createGame with all seats claimed, or the join that fills the table) — setup shuffles (deck, merchant tiles) are random, so replay must start from the captured state, not from `START_GAME`.
- **Refusals are deliberately NOT logged**: a refusal never mutates state or bumps `version`, so replay does not need it. Only accepted intents (the ones that persist a snapshot) produce rows.
- **AI turns are logged like human ones**: the turn runner records `outcome.move.event` (exactly one applied engine event per decision) attributed to the AI seat, through the same save path.

## Log and state cannot diverge

The log row is written **in the same SQL statement** as the version-guarded snapshot upsert (`saveGame(game, intentLog)` in `store.ts` — still the single DB seam): a data-modifying CTE where the log `INSERT ... SELECT FROM up` reads the upsert's `RETURNING`. When the optimistic version guard rejects the write (a lost concurrent save), `up` is empty and **no phantom log row is inserted**; a crash can never land between the two writes because they commit together. Concurrent seq allocation serializes on the `games` row lock the upsert takes. Pinned by the `a lost concurrent write throws AND leaves no phantom log row` test.

## Replay found a real determinism gap (and handles it)

The engine is replay-deterministic from the setup snapshot **except one spot**: the canal→rail era transition reshuffles discard+draw into a fresh deck with `Math.random` (`eraTransitionToRail` in `gameStore.ts`). Pure event-sourcing cannot cross that boundary — the first full-game replay attempt diverged exactly there. The intent that crosses the boundary therefore carries the resulting snapshot as a **checkpoint** (`snapshot_after` column; `eraCheckpoint` in `intent.ts`, called by both `actInGame` and the AI runner), and `replayIntentLog` (`replay.ts`, pure — no DB import, works on exported JSON) re-bases on it.

## Proof

- `replay.test.ts` (offline): a **full mock-AI game** — both eras, gameOver, 100+ logged events, the era checkpoint exercised — replays from the logged rows to the **identical** final state (deep-equal after normalizing only the log wall-clock timestamps).
- `intentlog.test.ts` (DB-backed; runs on the local Docker DB via `pnpm db:local` or a Neon branch): setup record + exactly one row per accepted intent with matching payload/seat/version, refusals append nothing, AI seat attribution + mixed human/AI replay, the concurrent-write/no-phantom-row case, the sweep dropping game + log together, and a DB round-trip replay against the stored snapshot.
- Full `pnpm test` (54 files), `pnpm typecheck`, `pnpm lint` green; DB-backed e2e `multiplayer.spec.ts` + `mp-playthrough.spec.ts` pass (every MP click now writes a log row through the real wire). Offline e2e untouched.

## Scope guarantees

No wire/UI changes; `filterSnapshotForSeat` untouched — the log is server-side only and never ships to clients. Egress discipline: nothing new is read on the stream poll (`loadIntentLog` is tooling/tests only); the only new per-intent cost is the small log row riding the existing save statement.

## Migration

`drizzle/0002_colossal_shadow_king.sql` (generated via `pnpm db:generate`). Test branches pick it up automatically through `ensureTestSchema()` (it applies `drizzle/*.sql` idempotently, and the existing `isBenignSchemaRace` handler covers the parallel-CREATE window). **After merge, re-migrate the long-lived `ci` parent branch** so ephemeral CI branches inherit the table: `neonctl connection-string ci --project-id muddy-night-85782525` → `pnpm db:migrate` (per the CI section of CLAUDE.md). Same for prod/preview via the normal deploy migration flow.

## Pulling a bug-report game's intent log

Point `DATABASE_URL` at the branch holding the game (prod = Neon `main`) and run `BB_REPLAY_TOKEN=<game-token> pnpm vitest run src/server/mp/intentlog.test.ts -t 'BB_REPLAY_TOKEN'` — it loads the stored rows, replays them through the real engine, asserts the reconstruction matches the stored snapshot, and prints a step/version summary; a divergence fails loudly naming the seq and event, which is exactly where the bug is. To hand the log around as a file instead, export it with `select * from game_intents where token = '<game-token>' order by seq` and feed the JSON rows to `replayIntentLog` (`src/server/mp/replay.ts` — pure, no DB needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
