### PR TITLE
Hover-to-locate: hovering any city name spotlights it on the map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,16 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
 - The hand tray (`hand-tray.tsx`) doubles as the card selector for every
   discard step; which steps select cards is centralized in
   `getHandSelection()` (`action-dock.tsx`).
+- HOVER-TO-LOCATE (2026-07-17): hovering/focusing any city NAME (journal,
+  source pickers, sale list, dock steps, ledger, card chips) spotlights its
+  plate on the map. Shared plumbing is `src/components/locate.tsx` (context +
+  `CityName` + `useLocateCity`); each surface owns the state and feeds
+  BoardMap's `locatedCity` prop (`data-located` on the `g[data-city]`, teal
+  `LocateMark`, deliberately distinct from the brass legal pulse;
+  reduced-motion drops the ping). Journal names resolve via `segmentPlaces`
+  (journal-model.ts) — by raw city ID, never display-name matching. The state
+  is ONE `cityId|null` on purpose so brass-card-map-sync (pan-into-view for
+  hovered cards) can reuse it.
 
 ## AI opponents (added 2026-07-15)
 

--- a/e2e/locate-city.spec.ts
+++ b/e2e/locate-city.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Hover-to-locate — hovering (or focusing) a city NAME anywhere in the UI
+ * spotlights that city's plate on the board map (`data-located` on the
+ * g[data-city] group), because finding cities on the map is genuinely hard.
+ *
+ * Offline: runs on the demo fixtures, no DB.
+ */
+import { expect, test } from '@playwright/test'
+
+test('hovering a journal place name spotlights that city on the map', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+
+  // The demo ledger's journal is full of engine entries naming places; every
+  // recognised place is a data-locate-city span. Take the first one and make
+  // sure the map answers with the locate mark on exactly that plate.
+  const name = page
+    .getByTestId('journal-entry')
+    .locator('[data-locate-city]')
+    .first()
+  await expect(name).toBeVisible()
+  const cityId = await name.getAttribute('data-locate-city')
+  expect(cityId).toBeTruthy()
+
+  await name.hover()
+  await expect(
+    page.locator(`g[data-city="${cityId}"][data-located="true"]`),
+  ).toBeVisible()
+
+  // Moving off the name releases the spotlight.
+  await page.getByTestId('era-plate').hover()
+  await expect(
+    page.locator(`g[data-city="${cityId}"][data-located="true"]`),
+  ).toHaveCount(0)
+})
+
+test('the beer-source picker locates breweries and merchants; focus counts as hover', async ({
+  page,
+}) => {
+  await page.goto('/?demo=beerchoice')
+  await page.getByTestId('action-sell').click()
+  await page.locator('button.bb2-card:not([disabled])').first().click()
+
+  // The sale list itself names places — hovering the goods' city name
+  // spotlights Leek before any sale is staged.
+  const saleOption = page
+    .getByTestId('sale-option')
+    .filter({ hasText: 'cotton at Leek' })
+  await saleOption.locator('[data-locate-city="leek"]').hover()
+  await expect(
+    page.locator('g[data-city="leek"][data-located="true"]'),
+  ).toBeVisible()
+
+  await saleOption.click()
+
+  // Hovering the own-brewery option points at Stone…
+  const sources = page.getByTestId('beer-source')
+  await sources.filter({ hasText: 'brewery at Stone' }).hover()
+  await expect(
+    page.locator('g[data-city="stone"][data-located="true"]'),
+  ).toBeVisible()
+
+  // …and keyboard focus on the merchant option points at the Warrington
+  // merchant plate (a11y: focus counts as hover; merchants count as places).
+  await sources.filter({ hasText: "Warrington merchant's barrel" }).focus()
+  await expect(
+    page.locator('g[data-city="warrington"][data-located="true"]'),
+  ).toBeVisible()
+  await expect(
+    page.locator('g[data-city="stone"][data-located="true"]'),
+  ).toHaveCount(0)
+})
+
+test('the iron-source picker locates rival works; the market locates nothing', async ({
+  page,
+}) => {
+  await page.goto('/?demo=ironchoice')
+  await page.getByTestId('action-develop').click()
+  await page.locator('button.bb2-card:not([disabled])').first().click()
+  // Confirming the tile step lands on the machine's iron-source step.
+  await page.getByTestId('develop-lowest').click()
+
+  const sources = page.getByTestId('iron-source')
+  await expect(sources.first()).toBeVisible()
+  const first = sources.first()
+  const cityId = await first
+    .locator('[data-locate-city]')
+    .first()
+    .getAttribute('data-locate-city')
+  expect(cityId).toBeTruthy()
+
+  await first.hover()
+  await expect(
+    page.locator(`g[data-city="${cityId}"][data-located="true"]`),
+  ).toBeVisible()
+
+  await page.getByTestId('era-plate').hover()
+  await expect(page.locator('g[data-located="true"]')).toHaveCount(0)
+})

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -25,6 +25,7 @@ import {
   doubleLinkDisabledReason,
   showsDoubleLinkOption,
 } from './double-link-availability'
+import { CityName, useLocateCity } from './locate'
 import {
   BuildIcon,
   CanalIcon,
@@ -49,8 +50,19 @@ export const INDUSTRY_TYPES: IndustryType[] = [
 
 export const SELLABLE: IndustryType[] = ['cotton', 'manufacturer', 'pottery']
 
-const cityName = (id: CityId | string | null | undefined) =>
-  id ? (cities[id as CityId]?.name ?? id) : '—'
+/** A route's two endpoints, each a hover-to-locate CityName. */
+function LinkLabel({
+  link,
+}: {
+  link: { from: CityId; to: CityId } | null | undefined
+}) {
+  if (!link) return <>— — —</>
+  return (
+    <>
+      <CityName cityId={link.from} /> — <CityName cityId={link.to} />
+    </>
+  )
+}
 
 /** On-board 'manufacturer' reads as "Goods" everywhere in the UI. */
 const industryLabel = (t: IndustryType | string) =>
@@ -252,12 +264,37 @@ function beerSourceCaption(option: BeerSourceOption): string {
     : `Flips ${option.ownerName}'s brewery when its last barrel goes — their income advances.`
 }
 
-function beerSourceTitle(option: BeerSourceOption): string {
+// Titles name a place, so the place is a hover-to-locate CityName. Passive:
+// the option BUTTON carries the locate handlers (whole row hovers/focuses),
+// the span only adds the dotted-underline affordance.
+function beerSourceTitle(option: BeerSourceOption): React.ReactNode {
+  const place = <CityName cityId={option.source.location} passive />
   if (option.source.kind === 'merchant') {
-    return `${cityName(option.source.location)} merchant's barrel`
+    return (
+      <>
+        {place}
+        {" merchant's barrel"}
+      </>
+    )
   }
-  const where = `brewery at ${cityName(option.source.location)}`
-  return option.own ? `Your ${where}` : `${option.ownerName}'s ${where}`
+  const where = (
+    <>
+      {'brewery at '}
+      {place}
+    </>
+  )
+  return option.own ? (
+    <>
+      {'Your '}
+      {where}
+    </>
+  ) : (
+    <>
+      {option.ownerName}
+      {"'s "}
+      {where}
+    </>
+  )
 }
 
 /**
@@ -283,6 +320,7 @@ function BeerSourcePicker({
   const takenFrom = (option: BeerSourceOption) =>
     picks.filter((p) => beerSourceKey(p) === beerSourceKey(option.source))
       .length
+  const { handlersFor } = useLocateCity()
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -304,6 +342,7 @@ function BeerSourcePicker({
             data-selected={taken > 0}
             disabled={full && picks.length < required}
             onClick={() => onPick(option.source)}
+            {...handlersFor(option.source.location)}
           >
             <IndustryGlyph type="brewery" size={16} />
             <span className="flex flex-col text-left">
@@ -327,12 +366,28 @@ function BeerSourcePicker({
 
 /* ----- iron source picker ----- */
 
-function ironSourceTitle(option: IronSourceOption): string {
+function ironSourceTitle(option: IronSourceOption): React.ReactNode {
   if (option.source.kind === 'market') {
     return option.price ? `The market — £${option.price} a cube` : 'The market'
   }
-  const where = `iron works at ${cityName(option.source.location)}`
-  return option.own ? `Your ${where}` : `${option.ownerName}'s ${where}`
+  const where = (
+    <>
+      {'iron works at '}
+      <CityName cityId={option.source.location} passive />
+    </>
+  )
+  return option.own ? (
+    <>
+      {'Your '}
+      {where}
+    </>
+  ) : (
+    <>
+      {option.ownerName}
+      {"'s "}
+      {where}
+    </>
+  )
 }
 
 function ironSourceCaption(option: IronSourceOption): string {
@@ -364,6 +419,7 @@ function IronSourcePicker({
   const takenFrom = (option: IronSourceOption) =>
     picks.filter((p) => ironSourceKey(p) === ironSourceKey(option.source))
       .length
+  const { handlersFor } = useLocateCity()
 
   return (
     <div className="flex flex-col gap-1.5">
@@ -384,6 +440,9 @@ function IronSourcePicker({
             data-selected={taken > 0}
             disabled={full && picks.length < required}
             onClick={() => onPick(option.source)}
+            {...handlersFor(
+              option.source.kind === 'market' ? null : option.source.location,
+            )}
           >
             <IndustryGlyph type="iron" size={16} />
             <span className="flex flex-col text-left">
@@ -653,6 +712,7 @@ export function ActionDock({
 }: ActionDockProps) {
   const is = (path: string) => snapshot.matches(path as never)
   const can = (event: GameEvent) => snapshot.can(event)
+  const { locate, unlocate } = useLocateCity()
   const c = snapshot.context
 
   // The six card-consuming actions — shared by the idle chooser and the
@@ -950,7 +1010,11 @@ export function ActionDock({
               className="font-semibold"
               style={{ color: 'var(--bb-parchment-bright)' }}
             >
-              {cityName(c.selectedLocation)}
+              {c.selectedLocation ? (
+                <CityName cityId={c.selectedLocation} />
+              ) : (
+                '—'
+              )}
             </span>
           </div>
         </div>
@@ -1034,7 +1098,7 @@ export function ActionDock({
       <Flow action="Network" steps={netSteps} active={2} onCancel={cancel}>
         <Note>
           <b style={{ color: 'var(--bb-parchment-bright)' }}>
-            {cityName(link?.from)} — {cityName(link?.to)}
+            <LinkLabel link={link} />
           </b>{' '}
           ({c.era})
         </Note>
@@ -1099,12 +1163,11 @@ export function ActionDock({
       >
         <Note>
           <b style={{ color: 'var(--bb-parchment-bright)' }}>
-            {cityName(c.selectedLink?.from)} — {cityName(c.selectedLink?.to)}
+            <LinkLabel link={c.selectedLink} />
           </b>{' '}
           and{' '}
           <b style={{ color: 'var(--bb-parchment-bright)' }}>
-            {cityName(c.selectedSecondLink?.from)} —{' '}
-            {cityName(c.selectedSecondLink?.to)}
+            <LinkLabel link={c.selectedSecondLink} />
           </b>
         </Note>
         <Confirm
@@ -1192,7 +1255,7 @@ export function ActionDock({
       >
         <Note>
           Where does the beer for {industryLabel(sale?.industryType ?? 'goods')}{' '}
-          at {cityName(sale?.location)} come from?
+          at {sale ? <CityName cityId={sale.location} /> : '—'} come from?
         </Note>
         {choice && (
           <BeerSourcePicker
@@ -1267,14 +1330,18 @@ export function ActionDock({
                     merchant: s.merchant,
                   })
                 }
+                // Two places on one row, so each NAME locates its own city;
+                // keyboard focus points at the goods' own city.
+                onFocus={() => locate(s.location)}
+                onBlur={() => unlocate(s.location)}
               >
                 <IndustryGlyph type={s.type} size={16} />
                 <span>
                   <b>{s.type === 'manufacturer' ? 'goods' : s.type}</b> at{' '}
-                  {cityName(s.location)}
+                  <CityName cityId={s.location} focusable={false} />
                   <span style={{ color: 'rgba(231,215,177,.55)' }}>
                     {' '}
-                    → {cityName(s.merchant)}
+                    → <CityName cityId={s.merchant} focusable={false} />
                   </span>
                 </span>
               </button>

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -193,6 +193,12 @@ export interface BoardMapProps {
   /** Cities spotlit while a hand card is hovered (soft preview hint). */
   hoverCities?: ReadonlySet<string> | null
   /**
+   * Hover-to-locate: the city whose NAME is hovered/focused somewhere in the
+   * UI right now (journal, pickers, ledger) — its plate gets the teal
+   * surveyor's mark so the player can find it on the map.
+   */
+  locatedCity?: string | null
+  /**
    * Game-end scoring overlay: VP earned per city and per route by ONE player
    * (null = off). Annotated places get a brass VP roundel; everything else
    * recedes, so the score reads off the board. Links are destroyed by era
@@ -222,6 +228,7 @@ export function BoardMap({
   networkCities = null,
   networkColor = null,
   hoverCities = null,
+  locatedCity = null,
   vpAnnotations = null,
   vpColor = null,
 }: BoardMapProps) {
@@ -799,6 +806,7 @@ export function BoardMap({
               }
               inNetwork={networkCities?.has(id) ?? false}
               networkColor={networkColor}
+              located={locatedCity === id}
               vp={vpAnnotations?.cities.get(id)}
               vpColor={vpColor}
             />
@@ -824,6 +832,7 @@ export function BoardMap({
                 inNetwork={networkCities?.has(id) ?? false}
                 networkColor={networkColor}
                 hoverHint={hoverCities?.has(id) ?? false}
+                located={locatedCity === id}
                 vp={vpAnnotations?.cities.get(id)}
                 vpColor={vpColor}
                 onClick={() => {
@@ -1020,6 +1029,50 @@ function plateGrid(cityId: CityId, slotCount: number): Array<[number, number]> {
   )
 }
 
+/**
+ * Hover-to-locate spotlight: a teal double ring with an outward ping,
+ * visually distinct from the brass legal pulse (colour, motion, rhythm) so
+ * it reads as "here it is", not "this is a legal choice". The ping extends
+ * well past the plate so a plate half-off the viewport edge still flags
+ * itself. Reduced motion keeps the static rings only (theme.css).
+ */
+function LocateMark({
+  plateW,
+  plateH,
+  rx,
+}: {
+  plateW: number
+  plateH: number
+  rx: number
+}) {
+  return (
+    <g pointerEvents="none">
+      <rect
+        x="-14"
+        y="-14"
+        width={plateW + 28}
+        height={plateH + 28}
+        rx={rx + 6}
+        fill="none"
+        stroke="#8fd8cd"
+        strokeWidth="3.5"
+        className="bb2-locate-ping"
+      />
+      <rect
+        x="-7"
+        y="-7"
+        width={plateW + 14}
+        height={plateH + 14}
+        rx={rx}
+        fill="rgba(143,216,205,.14)"
+        stroke="#8fd8cd"
+        strokeOpacity="0.95"
+        strokeWidth="2.5"
+      />
+    </g>
+  )
+}
+
 function CityPlate({
   cityId,
   occupants,
@@ -1031,6 +1084,7 @@ function CityPlate({
   inNetwork = false,
   networkColor = null,
   hoverHint = false,
+  located = false,
   vp = undefined,
   vpColor = null,
 }: {
@@ -1044,6 +1098,7 @@ function CityPlate({
   inNetwork?: boolean
   networkColor?: string | null
   hoverHint?: boolean
+  located?: boolean
   /** Game-end: VP the shown player earned here (undefined = none). */
   vp?: number
   vpColor?: string | null
@@ -1063,7 +1118,8 @@ function CityPlate({
       transform={`translate(${pos.x - plateW / 2}, ${pos.y - plateH / 2})`}
       data-city={cityId}
       data-legal={isLegal || undefined}
-      opacity={dimmed ? 0.45 : 1}
+      data-located={located || undefined}
+      opacity={dimmed && !located ? 0.45 : 1}
       onClick={onClick}
       role={clickable ? 'button' : undefined}
       aria-label={
@@ -1083,6 +1139,9 @@ function CityPlate({
         transition: 'opacity .2s',
       }}
     >
+      {located && (
+        <LocateMark plateW={plateW} plateH={plateH} rx={isFarm ? 18 : 12} />
+      )}
       {/* hovered-card spotlight — a dashed parchment ring */}
       {hoverHint && (
         <rect
@@ -1422,6 +1481,7 @@ function MerchantPlate({
   dimmed,
   inNetwork = false,
   networkColor = null,
+  located = false,
   vp = undefined,
   vpColor = null,
 }: {
@@ -1430,6 +1490,7 @@ function MerchantPlate({
   dimmed: boolean
   inNetwork?: boolean
   networkColor?: string | null
+  located?: boolean
   /** Game-end: VP the shown player took from this merchant's bonus. */
   vp?: number
   vpColor?: string | null
@@ -1452,9 +1513,12 @@ function MerchantPlate({
   return (
     <g
       transform={`translate(${pos.x - plateW / 2}, ${pos.y - plateH / 2})`}
-      opacity={dimmed ? 0.45 : closed ? 0.3 : 1}
+      data-city={cityId}
+      data-located={located || undefined}
+      opacity={dimmed && !located ? 0.45 : closed && !located ? 0.3 : 1}
       style={{ transition: 'opacity .2s' }}
     >
+      {located && <LocateMark plateW={plateW} plateH={plateH} rx={12} />}
       {vp !== undefined && (
         <rect
           x="-6"

--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -6,6 +6,7 @@
 import { type CityId, cities } from '~/data/board'
 import { type Card as GameCard, type IndustryType } from '~/data/cards'
 import { CardsIcon, IndustryFragment, WildIcon } from './icons'
+import { CityName } from './locate'
 
 const REGION_BAND: Record<string, string> = {
   blue: '#45719d',
@@ -218,7 +219,12 @@ export function CardChip({ card }: { card: GameCard }) {
       }}
     >
       <CardsIcon size={11} />
-      {cardTitle(card)}
+      {card.type === 'location' ? (
+        // A location card names a city — hovering it finds it on the map.
+        <CityName cityId={card.location} focusable={false} />
+      ) : (
+        cardTitle(card)
+      )}
     </span>
   )
 }

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -47,6 +47,7 @@ import { demoSnapshotSell } from './demo/demo-snapshot-sell'
 import { demoSnapshotWilds } from './demo/demo-snapshot-wilds'
 import { HandTray } from './hand-tray'
 import { computeHoverCities } from './hover-highlight'
+import { LocateCityProvider, useLocateCityState } from './locate'
 import { pendingBeerChoice } from '~/store/shared/resourceSources'
 import { GameOverScreen, PassGate, RoundCurtain } from './overlays'
 import { OpenMatButton, PlayerLedger } from './player-ledger'
@@ -400,6 +401,9 @@ function GameInner({
   )
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
+  // Hover-to-locate: which city's NAME (journal, pickers, ledger…) is under
+  // the cursor/focus right now — its plate gets the map's surveyor's mark.
+  const locateState = useLocateCityState()
   // The round the player has already seen the curtain for. Seeded from the
   // booted snapshot so resuming a save mid-game never replays an old round's
   // curtain; a round ending in play bumps roundSummary.round past it.
@@ -875,171 +879,174 @@ function GameInner({
     : null
 
   return (
-    <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
-      {/* ---------- masthead ---------- */}
-      <header className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 pb-2 pt-3">
-        <div className="flex items-baseline gap-2">
+    <LocateCityProvider value={locateState}>
+      <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
+        {/* ---------- masthead ---------- */}
+        <header className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 pb-2 pt-3">
+          <div className="flex items-baseline gap-2">
+            <span
+              className="bb2-display text-[22px] font-black leading-none tracking-[0.14em]"
+              style={{ color: 'var(--bb-brass-bright)' }}
+            >
+              BRASS
+            </span>
+            <span
+              className="bb2-display text-[13px] italic"
+              style={{ color: 'rgba(231,215,177,.55)' }}
+            >
+              Birmingham
+            </span>
+          </div>
+
           <span
-            className="bb2-display text-[22px] font-black leading-none tracking-[0.14em]"
-            style={{ color: 'var(--bb-brass-bright)' }}
+            className={`bb2-era-plate ${ctx.era === 'canal' ? 'bb2-era-canal' : 'bb2-era-rail'}`}
+            data-testid="era-plate"
           >
-            BRASS
+            {ctx.era} era
           </span>
-          <span
-            className="bb2-display text-[13px] italic"
-            style={{ color: 'rgba(231,215,177,.55)' }}
-          >
-            Birmingham
+          <span className="bb2-chip" data-testid="round-chip">
+            Round {ctx.round}
           </span>
+          <span className="bb2-chip">
+            Actions
+            <span className="flex items-center gap-1">
+              {Array.from({ length: maxActions }, (_, i) => (
+                <span
+                  key={i}
+                  className="bb2-pip"
+                  data-spent={i >= ctx.actionsRemaining}
+                />
+              ))}
+            </span>
+          </span>
+          {boot.kind !== 'fresh' && (
+            <span
+              className="bb2-chip hidden sm:inline-flex"
+              style={{ color: 'var(--bb-brass)', borderStyle: 'dashed' }}
+            >
+              Demonstration ledger
+            </span>
+          )}
+
+          <div className="ml-auto flex items-center gap-3">
+            <NewGameButton onConfirm={onNewGame} />
+          </div>
+        </header>
+
+        {/* ---------- player rail ---------- */}
+        <PlayerRail
+          players={ctx.players}
+          currentPlayerId={currentPlayer.id}
+          turnOrder={ctx.turnOrder}
+          playerSpending={ctx.playerSpending}
+          onOpenLedger={(id) => setLedgerFor(id)}
+        />
+
+        {/* ---------- main: board + dock ---------- */}
+        <div className="flex min-h-0 flex-col gap-3 px-3 pb-3 lg:flex-1 lg:flex-row">
+          <div className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1">
+            <div className="bb2-board-inner pb-9 lg:pb-[84px]">
+              <BoardMap
+                players={ctx.players}
+                era={ctx.era}
+                merchants={ctx.merchants}
+                legalCities={legalCities}
+                legalLinks={legalLinks}
+                selectedCity={inBuildFlow ? ctx.selectedLocation : null}
+                selectedLinks={selectedLinks}
+                prompt={boardPrompt}
+                onCityClick={onCityClick}
+                onLinkClick={onLinkClick}
+                networkCities={needsReveal ? null : networkCities}
+                networkColor={
+                  needsReveal ? null : PLAYER_FILL[currentPlayer.color]
+                }
+                hoverCities={
+                  needsReveal ? null : (beerCandidateCities ?? hoverCities)
+                }
+                locatedCity={locateState.locatedCity}
+              />
+            </div>
+          </div>
+
+          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
+            <div className="bb2-panel flex flex-col gap-3 p-4">
+              {!needsReveal && (
+                <ActionDock
+                  snapshot={state as GameStoreSnapshot}
+                  send={send}
+                  currentPlayer={currentPlayer}
+                  canSellAnything={canSellAnything}
+                  viableIndustries={viableIndustries}
+                  confirmOutcome={confirmOutcome}
+                  actionsLeft={{
+                    remaining: ctx.actionsRemaining,
+                    max: maxActions,
+                  }}
+                  legalSiteCount={pickingSite ? (legalCities?.size ?? 0) : null}
+                  onUndo={canUndo ? onUndo : null}
+                />
+              )}
+              {!needsReveal && (
+                <OpenMatButton onClick={() => setLedgerFor(currentPlayer.id)} />
+              )}
+            </div>
+            <MarketsPanel
+              coalMarket={ctx.coalMarket}
+              ironMarket={ctx.ironMarket}
+            />
+            <JournalPanel logs={ctx.logs} players={ctx.players} />
+          </aside>
         </div>
 
-        <span
-          className={`bb2-era-plate ${ctx.era === 'canal' ? 'bb2-era-canal' : 'bb2-era-rail'}`}
-          data-testid="era-plate"
-        >
-          {ctx.era} era
-        </span>
-        <span className="bb2-chip" data-testid="round-chip">
-          Round {ctx.round}
-        </span>
-        <span className="bb2-chip">
-          Actions
-          <span className="flex items-center gap-1">
-            {Array.from({ length: maxActions }, (_, i) => (
-              <span
-                key={i}
-                className="bb2-pip"
-                data-spent={i >= ctx.actionsRemaining}
-              />
-            ))}
-          </span>
-        </span>
-        {boot.kind !== 'fresh' && (
-          <span
-            className="bb2-chip hidden sm:inline-flex"
-            style={{ color: 'var(--bb-brass)', borderStyle: 'dashed' }}
-          >
-            Demonstration ledger
-          </span>
+        {/* ---------- hand tray ---------- */}
+        {!needsReveal && (
+          <HandTray
+            hand={currentPlayer.hand}
+            canSelect={
+              handSel
+                ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
+                : null
+            }
+            onSelect={(cardId) => send({ type: 'SELECT_CARD', cardId })}
+            selectedIds={handSel?.selectedIds ?? []}
+            hint={handSel?.hint ?? null}
+            onHoverCard={setHoveredCard}
+          />
         )}
 
-        <div className="ml-auto flex items-center gap-3">
-          <NewGameButton onConfirm={onNewGame} />
-        </div>
-      </header>
-
-      {/* ---------- player rail ---------- */}
-      <PlayerRail
-        players={ctx.players}
-        currentPlayerId={currentPlayer.id}
-        turnOrder={ctx.turnOrder}
-        playerSpending={ctx.playerSpending}
-        onOpenLedger={(id) => setLedgerFor(id)}
-      />
-
-      {/* ---------- main: board + dock ---------- */}
-      <div className="flex min-h-0 flex-col gap-3 px-3 pb-3 lg:flex-1 lg:flex-row">
-        <div className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1">
-          <div className="bb2-board-inner pb-9 lg:pb-[84px]">
-            <BoardMap
-              players={ctx.players}
-              era={ctx.era}
-              merchants={ctx.merchants}
-              legalCities={legalCities}
-              legalLinks={legalLinks}
-              selectedCity={inBuildFlow ? ctx.selectedLocation : null}
-              selectedLinks={selectedLinks}
-              prompt={boardPrompt}
-              onCityClick={onCityClick}
-              onLinkClick={onLinkClick}
-              networkCities={needsReveal ? null : networkCities}
-              networkColor={
-                needsReveal ? null : PLAYER_FILL[currentPlayer.color]
-              }
-              hoverCities={
-                needsReveal ? null : (beerCandidateCities ?? hoverCities)
-              }
-            />
-          </div>
-        </div>
-
-        <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
-          <div className="bb2-panel flex flex-col gap-3 p-4">
-            {!needsReveal && (
-              <ActionDock
-                snapshot={state as GameStoreSnapshot}
-                send={send}
-                currentPlayer={currentPlayer}
-                canSellAnything={canSellAnything}
-                viableIndustries={viableIndustries}
-                confirmOutcome={confirmOutcome}
-                actionsLeft={{
-                  remaining: ctx.actionsRemaining,
-                  max: maxActions,
-                }}
-                legalSiteCount={pickingSite ? (legalCities?.size ?? 0) : null}
-                onUndo={canUndo ? onUndo : null}
-              />
-            )}
-            {!needsReveal && (
-              <OpenMatButton onClick={() => setLedgerFor(currentPlayer.id)} />
-            )}
-          </div>
-          <MarketsPanel
-            coalMarket={ctx.coalMarket}
-            ironMarket={ctx.ironMarket}
+        {/* ---------- overlays ---------- */}
+        {ledgerPlayer && (
+          <PlayerLedger
+            player={ledgerPlayer}
+            era={ctx.era}
+            isCurrent={ledgerPlayer.id === currentPlayer.id}
+            onClose={() => setLedgerFor(null)}
           />
-          <JournalPanel logs={ctx.logs} players={ctx.players} />
-        </aside>
-      </div>
+        )}
 
-      {/* ---------- hand tray ---------- */}
-      {!needsReveal && (
-        <HandTray
-          hand={currentPlayer.hand}
-          canSelect={
-            handSel
-              ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
-              : null
-          }
-          onSelect={(cardId) => send({ type: 'SELECT_CARD', cardId })}
-          selectedIds={handSel?.selectedIds ?? []}
-          hint={handSel?.hint ?? null}
-          onHoverCard={setHoveredCard}
-        />
-      )}
-
-      {/* ---------- overlays ---------- */}
-      {ledgerPlayer && (
-        <PlayerLedger
-          player={ledgerPlayer}
-          era={ctx.era}
-          isCurrent={ledgerPlayer.id === currentPlayer.id}
-          onClose={() => setLedgerFor(null)}
-        />
-      )}
-
-      {/* Round end announces itself above the pass gate: what everyone spent
+        {/* Round end announces itself above the pass gate: what everyone spent
           and how the turn order moved because of it. */}
-      {ctx.roundSummary && ctx.roundSummary.round !== curtainSeen && (
-        <RoundCurtain
-          summary={ctx.roundSummary}
-          players={ctx.players}
-          onDismiss={() => setCurtainSeen(ctx.roundSummary!.round)}
-        />
-      )}
+        {ctx.roundSummary && ctx.roundSummary.round !== curtainSeen && (
+          <RoundCurtain
+            summary={ctx.roundSummary}
+            players={ctx.players}
+            onDismiss={() => setCurtainSeen(ctx.roundSummary!.round)}
+          />
+        )}
 
-      {needsReveal && (
-        <PassGate
-          player={currentPlayer}
-          round={ctx.round}
-          era={ctx.era}
-          onReveal={() => setRevealedFor(currentPlayer.id)}
-        />
-      )}
+        {needsReveal && (
+          <PassGate
+            player={currentPlayer}
+            round={ctx.round}
+            era={ctx.era}
+            onReveal={() => setRevealedFor(currentPlayer.id)}
+          />
+        )}
 
-      <Toaster theme="dark" position="top-right" />
-    </div>
+        <Toaster theme="dark" position="top-right" />
+      </div>
+    </LocateCityProvider>
   )
 }
 

--- a/src/components/journal-model.test.ts
+++ b/src/components/journal-model.test.ts
@@ -6,6 +6,7 @@ import {
   parseJournalEntry,
   prettifyPlaces,
   romanLevel,
+  segmentPlaces,
 } from './journal-model'
 
 const players: PlayerRef[] = [
@@ -401,5 +402,55 @@ describe('place-name prettifying', () => {
     expect(
       prettifyPlaces('1 beer from merchant at warrington (money +5)'),
     ).toBe('1 beer from merchant at Warrington (money +5)')
+  })
+})
+
+describe('place segmentation (hover-to-locate)', () => {
+  test('each recognised place carries its board id, plain runs carry null', () => {
+    expect(segmentPlaces('built cotton Level 1 at stoke')).toEqual([
+      { text: 'built cotton Level 1 at ', cityId: null },
+      { text: 'Stoke-on-Trent', cityId: 'stoke' },
+    ])
+  })
+
+  test('route lists yield one segment per endpoint', () => {
+    expect(segmentPlaces('dudley-walsall, walsall-tamworth')).toEqual([
+      { text: 'Dudley', cityId: 'dudley' },
+      { text: '-', cityId: null },
+      { text: 'Walsall', cityId: 'walsall' },
+      { text: ', ', cityId: null },
+      { text: 'Walsall', cityId: 'walsall' },
+      { text: '-', cityId: null },
+      { text: 'Tamworth', cityId: 'tamworth' },
+    ])
+  })
+
+  test('merchant and farm-brewery locations resolve like any city', () => {
+    expect(segmentPlaces('to merchant at warrington')).toEqual([
+      { text: 'to merchant at ', cityId: null },
+      { text: 'Warrington', cityId: 'warrington' },
+    ])
+    expect(segmentPlaces('beer at farmBrewery1')).toEqual([
+      { text: 'beer at ', cityId: null },
+      { text: 'Farm Brewery', cityId: 'farmBrewery1' },
+    ])
+  })
+
+  test('card ids and city-free text come back as one plain segment', () => {
+    expect(segmentPlaces('using stafford_1')).toEqual([
+      { text: 'using stafford_1', cityId: null },
+    ])
+    expect(segmentPlaces('took a loan')).toEqual([
+      { text: 'took a loan', cityId: null },
+    ])
+  })
+
+  test('prettifyPlaces is exactly the joined segment text', () => {
+    const raw = 'sold cotton at leek to merchant at warrington'
+    expect(prettifyPlaces(raw)).toBe(
+      segmentPlaces(raw)
+        .map((s) => s.text)
+        .join(''),
+    )
   })
 })

--- a/src/components/journal-model.ts
+++ b/src/components/journal-model.ts
@@ -307,11 +307,38 @@ const CITY_ID_RE = new RegExp(
   'g',
 )
 
+export interface PlaceSegment {
+  text: string
+  /** Board id when this segment is a city/merchant name; null = plain text. */
+  cityId: string | null
+}
+
+/**
+ * Split raw engine text into plain runs and recognised place names, each
+ * place carrying its board id (so the UI can wire hover-to-locate from
+ * structured data instead of re-parsing display names). Resolution is by
+ * whole-word city ID — the form the engine logs — never by display name.
+ */
+export function segmentPlaces(text: string): PlaceSegment[] {
+  const segments: PlaceSegment[] = []
+  let last = 0
+  // Fresh regex per call: matchAll seeds from the source regex's lastIndex.
+  for (const m of text.matchAll(new RegExp(CITY_ID_RE.source, 'g'))) {
+    const at = m.index ?? 0
+    if (at > last) segments.push({ text: text.slice(last, at), cityId: null })
+    const id = m[0] as keyof typeof cities
+    segments.push({ text: cities[id].name, cityId: id })
+    last = at + m[0].length
+  }
+  if (last < text.length)
+    segments.push({ text: text.slice(last), cityId: null })
+  return segments
+}
+
 export function prettifyPlaces(text: string): string {
-  return text.replace(
-    CITY_ID_RE,
-    (id) => cities[id as keyof typeof cities].name,
-  )
+  return segmentPlaces(text)
+    .map((s) => s.text)
+    .join('')
 }
 
 /* ---------------- entry parser ---------------- */

--- a/src/components/journal.tsx
+++ b/src/components/journal.tsx
@@ -25,8 +25,9 @@ import {
   type PlayerRef,
   decorateMain,
   parseJournalEntry,
-  prettifyPlaces,
+  segmentPlaces,
 } from './journal-model'
+import { CityName } from './locate'
 import { CollapsiblePanel } from './side-panels'
 
 const KIND_ICONS: Partial<Record<JournalKind, React.ReactNode>> = {
@@ -63,6 +64,35 @@ function emphasizeAmounts(text: string): React.ReactNode[] {
   }
   if (last < text.length) nodes.push(text.slice(last))
   return nodes
+}
+
+/**
+ * Raw engine text with each recognised place rendered as a hover-to-locate
+ * CityName (display name + dotted underline + map spotlight). Replaces the
+ * plain prettifyPlaces() at render time — same words, now interactive.
+ */
+function Places({
+  text,
+  emphasize = false,
+}: {
+  text: string
+  emphasize?: boolean
+}) {
+  return (
+    <>
+      {segmentPlaces(text).map((seg, i) =>
+        seg.cityId ? (
+          <CityName key={i} cityId={seg.cityId}>
+            {seg.text}
+          </CityName>
+        ) : (
+          <span key={i}>
+            {emphasize ? emphasizeAmounts(seg.text) : seg.text}
+          </span>
+        ),
+      )}
+    </>
+  )
 }
 
 function JournalDivider({ item }: { item: JournalItem }) {
@@ -112,14 +142,16 @@ function JournalRow({ item }: { item: JournalItem }) {
               </b>
             ) : span.role === 'place' ? (
               <b key={i} className="bb2-jind">
-                {prettifyPlaces(span.text)}
+                <Places text={span.text} />
               </b>
             ) : span.role === 'level' ? (
               <span key={i} className="bb2-jlevel">
                 {span.text}
               </span>
             ) : (
-              <span key={i}>{emphasizeAmounts(prettifyPlaces(span.text))}</span>
+              <span key={i}>
+                <Places text={span.text} emphasize />
+              </span>
             ),
           )}
           {item.chips.map((chip, i) => (
@@ -147,7 +179,7 @@ function JournalRow({ item }: { item: JournalItem }) {
                 }
               >
                 {i > 0 && <span className="bb2-jdetail-sep"> · </span>}
-                {prettifyPlaces(detail)}
+                <Places text={detail} />
               </span>
             ))}
           </div>

--- a/src/components/locate.tsx
+++ b/src/components/locate.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+// Hover-to-locate: hovering (or keyboard-focusing) a city NAME anywhere in
+// the UI spotlights that city's plate on the board map — finding cities on
+// the map is genuinely hard (captain's feedback). This module is the shared
+// plumbing used by both surfaces (game.tsx and mp/mp-game.tsx): each surface
+// owns the `locatedCity` state (so it can feed the map directly) and provides
+// it through this context; name-bearing UI reads only the setter.
+//
+// The state is deliberately a plain "one city id or null" value so the
+// queued brass-card-map-sync task (pan-into-view for hovered cards) can
+// reuse it unchanged.
+import {
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { type CityId, cities } from '~/data/board'
+
+export interface LocateCityState {
+  locatedCity: string | null
+  setLocatedCity: Dispatch<SetStateAction<string | null>>
+}
+
+// Default is a no-op so name components render fine outside a provider
+// (setup screen, unit renders) — they just locate nothing.
+const LocateCityContext = createContext<LocateCityState>({
+  locatedCity: null,
+  setLocatedCity: () => {
+    // no provider mounted — locating is a no-op
+  },
+})
+
+export const LocateCityProvider = LocateCityContext.Provider
+
+/** Surface-side state holder — call in game.tsx / mp-game.tsx, feed the map. */
+export function useLocateCityState(): LocateCityState {
+  const [locatedCity, setLocatedCity] = useState<string | null>(null)
+  return useMemo(() => ({ locatedCity, setLocatedCity }), [locatedCity])
+}
+
+export interface LocateHandlers {
+  onMouseEnter: () => void
+  onMouseLeave: () => void
+  onFocus: () => void
+  onBlur: () => void
+}
+
+/**
+ * Locate/unlocate callbacks plus a handler factory for elements that are
+ * already interactive (picker option buttons). `unlocate` clears only its
+ * own city, so interleaved hovers never wipe a fresher highlight.
+ */
+export function useLocateCity() {
+  const { setLocatedCity } = useContext(LocateCityContext)
+  return useMemo(() => {
+    const locate = (cityId: string) => setLocatedCity(cityId)
+    const unlocate = (cityId: string) =>
+      setLocatedCity((prev) => (prev === cityId ? null : prev))
+    const handlersFor = (
+      cityId: string | null | undefined,
+    ): LocateHandlers | undefined => {
+      if (!cityId) return undefined
+      const enter = () => locate(cityId)
+      const leave = () => unlocate(cityId)
+      return {
+        onMouseEnter: enter,
+        onMouseLeave: leave,
+        onFocus: enter,
+        onBlur: leave,
+      }
+    }
+    return { locate, unlocate, handlersFor }
+  }, [setLocatedCity])
+}
+
+/**
+ * A city name that locates its city on the map while hovered or focused.
+ * Renders the board's display name unless children are given. `passive`
+ * drops the handlers and focusability for names inside elements that already
+ * carry locate handlers themselves (picker buttons) — the span then only
+ * contributes the dotted-underline affordance.
+ */
+export function CityName({
+  cityId,
+  children,
+  passive = false,
+  focusable = true,
+}: {
+  cityId: string
+  children?: ReactNode
+  passive?: boolean
+  /** Set false inside interactive parents to keep them a single tab stop. */
+  focusable?: boolean
+}) {
+  const { locate, unlocate } = useLocateCity()
+  // If the name unmounts mid-hover (a picker step closing under the cursor)
+  // no mouseleave ever fires — release the highlight ourselves.
+  const hovering = useRef(false)
+  useEffect(() => {
+    return () => {
+      if (hovering.current) unlocate(cityId)
+    }
+  }, [cityId, unlocate])
+
+  const label = children ?? cities[cityId as CityId]?.name ?? cityId
+  if (passive) {
+    return (
+      <span className="bb2-locate-name" data-locate-city={cityId}>
+        {label}
+      </span>
+    )
+  }
+  const enter = () => {
+    hovering.current = true
+    locate(cityId)
+  }
+  const leave = () => {
+    hovering.current = false
+    unlocate(cityId)
+  }
+  return (
+    <span
+      className="bb2-locate-name"
+      data-locate-city={cityId}
+      tabIndex={focusable ? 0 : undefined}
+      onMouseEnter={enter}
+      onMouseLeave={leave}
+      onFocus={enter}
+      onBlur={leave}
+    >
+      {label}
+    </span>
+  )
+}

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -25,6 +25,7 @@ import { linkKey } from '../board/board-data'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
 import { HandTray } from '../hand-tray'
 import { computeHoverCities } from '../hover-highlight'
+import { LocateCityProvider, useLocateCityState } from '../locate'
 import { GameOverScreen, RoundCurtain } from '../overlays'
 import { OpenMatButton, PlayerLedger } from '../player-ledger'
 import { PlayerRail } from '../player-rail'
@@ -748,6 +749,9 @@ function MpTable({
 }) {
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
+  // Hover-to-locate: which city's NAME (journal, pickers, ledger…) is under
+  // the cursor/focus right now — its plate gets the map's surveyor's mark.
+  const locateState = useLocateCityState()
 
   // Read-only actor per broadcast: gives the dock/board the snapshot shape
   // (`matches`, `can`, context) they already understand.
@@ -1102,260 +1106,270 @@ function MpTable({
   const aiIsThinking = aiTurn && view.ai?.thinkingSeatId === currentSeat?.seatId
 
   return (
-    <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
-      {/* Global in-flight cue: a slim indeterminate bar + a polite live region
+    <LocateCityProvider value={locateState}>
+      <div className="flex min-h-screen flex-col lg:h-screen lg:overflow-hidden">
+        {/* Global in-flight cue: a slim indeterminate bar + a polite live region
           announcing that the last move is syncing with the server. */}
-      {inFlight && <div className="bb2-syncbar" aria-hidden="true" />}
-      <div className="sr-only" role="status" aria-live="polite">
-        {inFlight ? 'Syncing your move with the table…' : ''}
-      </div>
-      {/* masthead */}
-      <header className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 pb-2 pt-3">
-        <div className="flex items-baseline gap-2">
-          <span
-            className="bb2-display text-[22px] font-black leading-none tracking-[0.14em]"
-            style={{ color: 'var(--bb-brass-bright)' }}
-          >
-            BRASS
-          </span>
-          <span
-            className="bb2-display text-[13px] italic"
-            style={{ color: 'rgba(231,215,177,.55)' }}
-          >
-            Birmingham · online
-          </span>
+        {inFlight && <div className="bb2-syncbar" aria-hidden="true" />}
+        <div className="sr-only" role="status" aria-live="polite">
+          {inFlight ? 'Syncing your move with the table…' : ''}
         </div>
-        <span
-          className={`bb2-era-plate ${ctx.era === 'canal' ? 'bb2-era-canal' : 'bb2-era-rail'}`}
-          data-testid="era-plate"
-        >
-          {ctx.era} era
-        </span>
-        <span className="bb2-chip" data-testid="round-chip">
-          Round {ctx.round}
-        </span>
-        <span className="bb2-chip">
-          Actions
-          <span className="flex items-center gap-1">
-            {Array.from({ length: maxActions }, (_, i) => (
-              <span
-                key={i}
-                className="bb2-pip"
-                data-spent={i >= ctx.actionsRemaining}
-              />
-            ))}
-          </span>
-        </span>
-        <span
-          className="bb2-chip"
-          data-testid="you-chip"
-          style={{ color: 'var(--bb-brass)' }}
-        >
-          You are {me.name}
-        </span>
-        <div className="ml-auto flex items-center gap-3">
-          {inFlight && (
-            <span className="bb2-sync-pill" data-testid="mp-syncing">
-              <span className="bb2-sync-dot" />
-              Syncing
-            </span>
-          )}
-          {notifyPermission === 'default' && (
-            <button
-              type="button"
-              className="bb2-ghost-btn"
-              data-testid="notify-enable"
-              title="Get a browser notification when it becomes your turn while this tab is in the background"
-              onClick={() => {
-                void Notification.requestPermission().then(setNotifyPermission)
-              }}
+        {/* masthead */}
+        <header className="flex flex-wrap items-center gap-x-4 gap-y-2 px-4 pb-2 pt-3">
+          <div className="flex items-baseline gap-2">
+            <span
+              className="bb2-display text-[22px] font-black leading-none tracking-[0.14em]"
+              style={{ color: 'var(--bb-brass-bright)' }}
             >
-              🔔 Turn alerts
-            </button>
-          )}
-          {you === 0 && (
-            <SeatsButton token={token} creds={creds} seats={view.seats} />
-          )}
-          <ShareLink />
-        </div>
-      </header>
-
-      <PlayerRail
-        players={ctx.players}
-        currentPlayerId={currentPlayer.id}
-        turnOrder={ctx.turnOrder}
-        playerSpending={ctx.playerSpending}
-        onOpenLedger={(id) => setLedgerFor(id)}
-      />
-
-      <div className="flex min-h-0 flex-col gap-3 px-3 pb-3 lg:flex-1 lg:flex-row">
-        <div className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1">
-          <div className="bb2-board-inner pb-9 lg:pb-[84px]">
-            <BoardMap
-              players={ctx.players}
-              era={ctx.era}
-              merchants={ctx.merchants}
-              legalCities={legalCities}
-              legalLinks={legalLinks}
-              selectedCity={ctx.selectedLocation}
-              selectedLinks={selectedLinks}
-              prompt={myTurn ? boardPrompt : null}
-              onCityClick={onCityClick}
-              onLinkClick={onLinkClick}
-              networkCities={me ? playerNetworkCities(me) : null}
-              networkColor={me ? PLAYER_FILL[me.color] : null}
-              hoverCities={hoverCities}
-            />
+              BRASS
+            </span>
+            <span
+              className="bb2-display text-[13px] italic"
+              style={{ color: 'rgba(231,215,177,.55)' }}
+            >
+              Birmingham · online
+            </span>
           </div>
-        </div>
-
-        <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
-          <div
-            className={`bb2-panel flex flex-col gap-3 p-4 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
-            aria-busy={myTurn && inFlight}
+          <span
+            className={`bb2-era-plate ${ctx.era === 'canal' ? 'bb2-era-canal' : 'bb2-era-rail'}`}
+            data-testid="era-plate"
           >
-            {myTurn ? (
-              <ActionDock
-                snapshot={state}
-                send={send as never}
-                currentPlayer={currentPlayer}
-                canSellAnything={canSellAnything}
-                actionsLeft={{
-                  remaining: ctx.actionsRemaining,
-                  max: maxActions,
+            {ctx.era} era
+          </span>
+          <span className="bb2-chip" data-testid="round-chip">
+            Round {ctx.round}
+          </span>
+          <span className="bb2-chip">
+            Actions
+            <span className="flex items-center gap-1">
+              {Array.from({ length: maxActions }, (_, i) => (
+                <span
+                  key={i}
+                  className="bb2-pip"
+                  data-spent={i >= ctx.actionsRemaining}
+                />
+              ))}
+            </span>
+          </span>
+          <span
+            className="bb2-chip"
+            data-testid="you-chip"
+            style={{ color: 'var(--bb-brass)' }}
+          >
+            You are {me.name}
+          </span>
+          <div className="ml-auto flex items-center gap-3">
+            {inFlight && (
+              <span className="bb2-sync-pill" data-testid="mp-syncing">
+                <span className="bb2-sync-dot" />
+                Syncing
+              </span>
+            )}
+            {notifyPermission === 'default' && (
+              <button
+                type="button"
+                className="bb2-ghost-btn"
+                data-testid="notify-enable"
+                title="Get a browser notification when it becomes your turn while this tab is in the background"
+                onClick={() => {
+                  void Notification.requestPermission().then(
+                    setNotifyPermission,
+                  )
                 }}
+              >
+                🔔 Turn alerts
+              </button>
+            )}
+            {you === 0 && (
+              <SeatsButton token={token} creds={creds} seats={view.seats} />
+            )}
+            <ShareLink />
+          </div>
+        </header>
+
+        <PlayerRail
+          players={ctx.players}
+          currentPlayerId={currentPlayer.id}
+          turnOrder={ctx.turnOrder}
+          playerSpending={ctx.playerSpending}
+          onOpenLedger={(id) => setLedgerFor(id)}
+        />
+
+        <div className="flex min-h-0 flex-col gap-3 px-3 pb-3 lg:flex-1 lg:flex-row">
+          <div className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1">
+            <div className="bb2-board-inner pb-9 lg:pb-[84px]">
+              <BoardMap
+                players={ctx.players}
+                era={ctx.era}
+                merchants={ctx.merchants}
+                legalCities={legalCities}
+                legalLinks={legalLinks}
+                selectedCity={ctx.selectedLocation}
+                selectedLinks={selectedLinks}
+                prompt={myTurn ? boardPrompt : null}
+                onCityClick={onCityClick}
+                onLinkClick={onLinkClick}
+                networkCities={me ? playerNetworkCities(me) : null}
+                networkColor={me ? PLAYER_FILL[me.color] : null}
+                hoverCities={hoverCities}
+                locatedCity={locateState.locatedCity}
               />
-            ) : aiTurn ? (
-              <div className="flex flex-col gap-2" data-testid="ai-panel">
-                <span className="bb2-panel-title">The rival&rsquo;s desk</span>
-                <p
-                  className="text-[14px]"
-                  style={{ color: 'var(--bb-parchment)' }}
-                >
-                  <b style={{ color: 'var(--bb-brass-bright)' }}>
-                    {currentPlayer.name}
-                  </b>{' '}
-                  <span
-                    className="text-[11px] uppercase tracking-[0.12em]"
+            </div>
+          </div>
+
+          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
+            <div
+              className={`bb2-panel flex flex-col gap-3 p-4 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
+              aria-busy={myTurn && inFlight}
+            >
+              {myTurn ? (
+                <ActionDock
+                  snapshot={state}
+                  send={send as never}
+                  currentPlayer={currentPlayer}
+                  canSellAnything={canSellAnything}
+                  actionsLeft={{
+                    remaining: ctx.actionsRemaining,
+                    max: maxActions,
+                  }}
+                />
+              ) : aiTurn ? (
+                <div className="flex flex-col gap-2" data-testid="ai-panel">
+                  <span className="bb2-panel-title">
+                    The rival&rsquo;s desk
+                  </span>
+                  <p
+                    className="text-[14px]"
+                    style={{ color: 'var(--bb-parchment)' }}
+                  >
+                    <b style={{ color: 'var(--bb-brass-bright)' }}>
+                      {currentPlayer.name}
+                    </b>{' '}
+                    <span
+                      className="text-[11px] uppercase tracking-[0.12em]"
+                      style={{ color: 'rgba(231,215,177,.5)' }}
+                    >
+                      ({currentSeat?.aiTier?.difficulty ?? 'ai'})
+                    </span>{' '}
+                    {aiIsThinking ? (
+                      <span className="animate-pulse" data-testid="ai-thinking">
+                        is thinking…
+                      </span>
+                    ) : (
+                      <span>is moving…</span>
+                    )}
+                  </p>
+                  <p
+                    className="text-[12px]"
                     style={{ color: 'rgba(231,215,177,.5)' }}
                   >
-                    ({currentSeat?.aiTier?.difficulty ?? 'ai'})
-                  </span>{' '}
-                  {aiIsThinking ? (
-                    <span className="animate-pulse" data-testid="ai-thinking">
-                      is thinking…
-                    </span>
-                  ) : (
-                    <span>is moving…</span>
-                  )}
-                </p>
-                <p
-                  className="text-[12px]"
-                  style={{ color: 'rgba(231,215,177,.5)' }}
+                    Its moves and reasoning appear in the rival&rsquo;s journal
+                    below.
+                  </p>
+                </div>
+              ) : (
+                <div
+                  className="flex flex-col gap-2"
+                  data-testid="waiting-panel"
                 >
-                  Its moves and reasoning appear in the rival&rsquo;s journal
-                  below.
-                </p>
-              </div>
-            ) : (
-              <div className="flex flex-col gap-2" data-testid="waiting-panel">
-                <span className="bb2-panel-title">The table</span>
-                <p
-                  className="text-[14px]"
-                  style={{ color: 'var(--bb-parchment)' }}
-                >
-                  Waiting for{' '}
-                  <b style={{ color: 'var(--bb-brass-bright)' }}>
-                    {currentPlayer.name}
-                  </b>{' '}
-                  to act…
-                </p>
-                <p
-                  className="text-[12px]"
-                  style={{ color: 'rgba(231,215,177,.5)' }}
-                >
-                  Moves appear here live. Your hand stays private below.
-                </p>
-              </div>
-            )}
-            {/* Always yours, never the seat that happens to be acting. */}
-            {me && <OpenMatButton onClick={() => setLedgerFor(me.id)} />}
-          </div>
-          {view.ai && <AiMindPanel ai={view.ai} seats={view.seats} />}
-          <MarketsPanel
-            coalMarket={ctx.coalMarket}
-            ironMarket={ctx.ironMarket}
-          />
-          <ChatPanel
-            messages={view.messages ?? []}
-            you={you}
-            seats={view.seats}
-            onSend={(text) => {
-              void (async () => {
-                try {
-                  const res = await fetch('/api/mp/chat', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                      token,
-                      seatId: creds.seatId,
-                      seatSecret: creds.seatSecret,
-                      text,
-                    }),
-                  })
-                  const body = (await res.json()) as {
-                    ok: boolean
-                    view?: GameViewWire
+                  <span className="bb2-panel-title">The table</span>
+                  <p
+                    className="text-[14px]"
+                    style={{ color: 'var(--bb-parchment)' }}
+                  >
+                    Waiting for{' '}
+                    <b style={{ color: 'var(--bb-brass-bright)' }}>
+                      {currentPlayer.name}
+                    </b>{' '}
+                    to act…
+                  </p>
+                  <p
+                    className="text-[12px]"
+                    style={{ color: 'rgba(231,215,177,.5)' }}
+                  >
+                    Moves appear here live. Your hand stays private below.
+                  </p>
+                </div>
+              )}
+              {/* Always yours, never the seat that happens to be acting. */}
+              {me && <OpenMatButton onClick={() => setLedgerFor(me.id)} />}
+            </div>
+            {view.ai && <AiMindPanel ai={view.ai} seats={view.seats} />}
+            <MarketsPanel
+              coalMarket={ctx.coalMarket}
+              ironMarket={ctx.ironMarket}
+            />
+            <ChatPanel
+              messages={view.messages ?? []}
+              you={you}
+              seats={view.seats}
+              onSend={(text) => {
+                void (async () => {
+                  try {
+                    const res = await fetch('/api/mp/chat', {
+                      method: 'POST',
+                      headers: { 'Content-Type': 'application/json' },
+                      body: JSON.stringify({
+                        token,
+                        seatId: creds.seatId,
+                        seatSecret: creds.seatSecret,
+                        text,
+                      }),
+                    })
+                    const body = (await res.json()) as {
+                      ok: boolean
+                      view?: GameViewWire
+                    }
+                    // Apply the sender's fresh view (with the new message) at once,
+                    // same version-guarded path as an SSE frame.
+                    if (body.ok && body.view) applyView(body.view)
+                  } catch {
+                    toast.error('Could not send the message')
                   }
-                  // Apply the sender's fresh view (with the new message) at once,
-                  // same version-guarded path as an SSE frame.
-                  if (body.ok && body.view) applyView(body.view)
-                } catch {
-                  toast.error('Could not send the message')
-                }
-              })()
-            }}
+                })()
+              }}
+            />
+            <JournalPanel logs={ctx.logs} players={ctx.players} />
+          </aside>
+        </div>
+
+        {/* my hand — always mine, never anyone else's */}
+        <HandTray
+          hand={me.hand}
+          canSelect={
+            handSel && !inFlight
+              ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
+              : null
+          }
+          onSelect={(cardId) => send({ type: 'SELECT_CARD', cardId })}
+          selectedIds={handSel?.selectedIds ?? []}
+          hint={handSel?.hint ?? null}
+          onHoverCard={setHoveredCard}
+        />
+
+        {ledgerPlayer && (
+          <PlayerLedger
+            player={ledgerPlayer}
+            era={ctx.era}
+            isCurrent={ledgerPlayer.id === currentPlayer.id}
+            onClose={() => setLedgerFor(null)}
           />
-          <JournalPanel logs={ctx.logs} players={ctx.players} />
-        </aside>
-      </div>
+        )}
 
-      {/* my hand — always mine, never anyone else's */}
-      <HandTray
-        hand={me.hand}
-        canSelect={
-          handSel && !inFlight
-            ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
-            : null
-        }
-        onSelect={(cardId) => send({ type: 'SELECT_CARD', cardId })}
-        selectedIds={handSel?.selectedIds ?? []}
-        hint={handSel?.hint ?? null}
-        onHoverCard={setHoveredCard}
-      />
-
-      {ledgerPlayer && (
-        <PlayerLedger
-          player={ledgerPlayer}
-          era={ctx.era}
-          isCurrent={ledgerPlayer.id === currentPlayer.id}
-          onClose={() => setLedgerFor(null)}
-        />
-      )}
-
-      {/* Round end: spends + the order switch. Auto-lifts so it can never
+        {/* Round end: spends + the order switch. Auto-lifts so it can never
           stall the next player's turn on a shared, live board. */}
-      {ctx.roundSummary && ctx.roundSummary.round !== seenRound && (
-        <RoundCurtain
-          summary={ctx.roundSummary}
-          players={ctx.players}
-          autoDismissMs={MP_CURTAIN_MS}
-          onDismiss={() => setCurtainSeen(ctx.roundSummary!.round)}
-        />
-      )}
+        {ctx.roundSummary && ctx.roundSummary.round !== seenRound && (
+          <RoundCurtain
+            summary={ctx.roundSummary}
+            players={ctx.players}
+            autoDismissMs={MP_CURTAIN_MS}
+            onDismiss={() => setCurtainSeen(ctx.roundSummary!.round)}
+          />
+        )}
 
-      <Toaster theme="dark" position="top-right" />
-    </div>
+        <Toaster theme="dark" position="top-right" />
+      </div>
+    </LocateCityProvider>
   )
 }
 

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -6,7 +6,6 @@
 // level (cost, VP, resource needs, next-buildable highlight), plus the
 // works and routes already on the board.
 import { useEffect } from 'react'
-import { type CityId, cities } from '~/data/board'
 import { type IndustryType } from '~/data/cards'
 import { type Player } from '~/store/gameStore'
 import { PLAYER_FILL } from './board/board-map'
@@ -18,6 +17,7 @@ import {
   MatIcon,
   RailIcon,
 } from './icons'
+import { CityName } from './locate'
 
 const INDUSTRY_TYPES: IndustryType[] = [
   'cotton',
@@ -38,8 +38,6 @@ const LABEL: Record<IndustryType, string> = {
 }
 
 const ROMAN = ['', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII']
-
-const cityName = (id: CityId) => cities[id]?.name ?? id
 
 export function PlayerLedger({
   player,
@@ -371,7 +369,7 @@ export function PlayerLedger({
                     {LABEL[ind.type]} {ROMAN[ind.level] ?? ind.level}
                   </span>
                   <span style={{ color: 'rgba(231,215,177,.5)' }}>
-                    at {cityName(ind.location)}
+                    at <CityName cityId={ind.location} />
                   </span>
                   {ind.flipped && (
                     <span
@@ -407,7 +405,7 @@ export function PlayerLedger({
                   ) : (
                     <RailIcon size={13} />
                   )}
-                  {cityName(l.from)} — {cityName(l.to)}
+                  <CityName cityId={l.from} /> — <CityName cityId={l.to} />
                 </div>
               ))}
               {player.links.length === 0 && (

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -518,6 +518,55 @@ button.bb2-card {
   cursor: pointer;
 }
 
+/* hover-to-locate: the "here it is" surveyor's mark. Deliberately NOT the
+   brass legal pulse — teal, outward ping, faster rhythm — so it reads as
+   "found it", never "this is a legal choice". */
+@keyframes bb2-locate-ping {
+  0% {
+    transform: scale(0.92);
+    opacity: 0.95;
+  }
+  70%,
+  100% {
+    transform: scale(1.12);
+    opacity: 0;
+  }
+}
+.bb2-locate-ping {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: bb2-locate-ping 1.1s ease-out infinite;
+}
+
+/* the name affordance — a quiet dotted underline that brightens on hover,
+   so hover-to-locate is discoverable wherever a city is named */
+.bb2-locate-name {
+  text-decoration: underline dotted;
+  text-decoration-color: rgba(231, 215, 177, 0.4);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  border-radius: 2px;
+}
+.bb2-locate-name:hover,
+.bb2-locate-name:focus-visible,
+button:hover .bb2-locate-name,
+button:focus-visible .bb2-locate-name {
+  text-decoration-color: var(--bb-brass-bright);
+  color: var(--bb-parchment-bright);
+}
+.bb2-locate-name:focus-visible {
+  outline: none;
+  background: rgba(230, 189, 99, 0.14);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bb2-locate-ping {
+    animation: none;
+    opacity: 0.9;
+    transform: none;
+  }
+}
+
 /* ---------------- journal ---------------- */
 
 .bb2-journal {


### PR DESCRIPTION
## What

> "one of the biggest challenges is actually finding the cities." — captain

Hovering (or keyboard-focusing) a **city name anywhere in the UI** now spotlights that city's plate on the board map with a teal "surveyor's mark" — a soft halo plus an outward ping ring, deliberately distinct from the brass legal-move pulse (different colour, motion and rhythm) so it reads as *"here it is"*, never *"this is a legal choice"*. Every city-name element gets a quiet dotted underline so the affordance is discoverable.

## Where names are live

- **Journal** — every place in headlines *and* demoted detail lines (builds, links, sells, coal/beer consumption, merchants, farm breweries).
- **Beer/iron source pickers** — the whole option button locates its source city (hover + focus); the market option locates nothing.
- **Sale options** — two cities per row, so each name locates its own city (goods location and merchant); keyboard focus points at the goods' city.
- **Dock steps** — build-confirm Site row, the beer-step question, network link labels ("Derby — Burton upon Trent"), and the selected-card chip for location cards.
- **Player ledger** — works ("at Stone") and claimed routes.
- Merchant locations and the farm breweries are first-class: merchant plates now carry `data-city` and take the mark like any city plate.

## How

- `src/components/locate.tsx` — shared plumbing: a small controlled context (each surface owns a `cityId | null` state and feeds the map), the `CityName` span (mouse + focus handlers, unmount cleanup so a picker closing under the cursor never strands a highlight), and `useLocateCity()` for already-interactive elements. **The state shape is deliberately a single `cityId|null` so the queued `brass-card-map-sync` task (pan-into-view) can reuse it unchanged.**
- **Journal resolution is structured, not string-matched**: `segmentPlaces()` in `journal-model.ts` splits raw engine text on whole-word city IDs and carries the id per segment; `prettifyPlaces()` is now just its join, so every rendered word is unchanged (existing journal-text e2e pins all pass untouched).
- Board map: new `locatedCity` prop → `data-located` on the `g[data-city]` group (e2e-assertable) + `LocateMark` rings. A located plate is exempt from picking-time dimming. `prefers-reduced-motion` drops the ping animation, keeping the static rings.
- Both surfaces wired: hotseat `game.tsx` and networked `mp-game.tsx`.

**Touch:** taps don't break picker semantics — locate handlers are hover/focus only, clicks behave exactly as before. **Off-screen case:** the mark is local to the plate, so a city panned fully out of view shows nothing yet (no auto-pan in this task — `brass-card-map-sync` owns pan-into-view; the ping extends well past the plate so a partially-visible plate at the viewport edge still flags itself). **Hand tray:** location cards already spotlight their printed city via the existing card-preview ring (`computeHoverCities`), so they were left on that semantic; the dock's location `CardChip` uses the new locate.

## Screenshots

Journal name focused (Derby) → teal mark on the Derby plate, dotted underlines on every place name:

![journal hover derby](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-39-images/journal-hover-derby.png)

`/?demo=beerchoice` — "Your brewery at Stone" option → Stone rings on the map:

![beer picker stone](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-39-images/beer-picker-stone.png)

Merchant option focused (focus counts as hover) → the **Warrington merchant plate** takes the mark; note Stone keeps the *dashed parchment* candidate-brewery hint at the same time — the two highlights stay visually distinct:

![beer picker warrington](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-39-images/beer-picker-warrington-merchant.png)

## Testing

- Unit: `segmentPlaces` (per-id resolution, route lists, merchants, farm breweries, card-id non-matches, prettify equivalence) in `journal-model.test.ts`. Full suite: **52 files / 484 tests green**; `pnpm typecheck` + `pnpm lint` green.
- e2e: new `e2e/locate-city.spec.ts` (offline) — journal-hover → `data-located`, sale-option name hover, beer picker (merchant plate + focus-as-hover), iron picker (market locates nothing). **All 34 e2e green** including the DB-backed mp suite.
- Browser-verified on `/?demo` and `/?demo=beerchoice` (screenshots above).

Note: a stale `node_modules` in the worktree initially failed `gameStore.graph.test.ts` (xstate 5.19 installed vs ^5.32.5 pinned) — fixed by `pnpm install`, no code change; not related to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)