### PR TITLE
fix(journal): render human city/card names, never raw slot ids

### DIFF
--- a/src/components/journal-model.test.ts
+++ b/src/components/journal-model.test.ts
@@ -149,14 +149,14 @@ describe('sell entries', () => {
 
 describe('other actions', () => {
   test('a loan surfaces amount and penalty as chips', () => {
-    const item = parse('Ada took a loan (£30, -3 income) using stafford_1')
+    const item = parse('Ada took a loan (£30, -3 income) using stafford (blue)')
     expect(item.kind).toBe('loan')
     expect(item.main).toBe('took a loan')
     expect(item.chips).toEqual([
       { text: '£30', tone: 'money' },
       { text: '−3 income', tone: 'penalty' },
     ])
-    expect(item.details).toEqual(['using stafford_1'])
+    expect(item.details).toEqual(['using stafford (blue)'])
   })
 
   test('develop promotes the tile count, demotes the iron', () => {
@@ -387,8 +387,16 @@ describe('place-name prettifying', () => {
     )
   })
 
-  test('card ids and partial matches stay untouched', () => {
-    expect(prettifyPlaces('using stafford_1')).toBe('using stafford_1')
+  test('raw card/slot ids resolve to human names', () => {
+    // The regression: a bare location-card slot id must never render raw.
+    expect(prettifyPlaces('using coventry_1')).toBe('using Coventry')
+    expect(prettifyPlaces('using stafford_1')).toBe('using Stafford')
+    // Same class of leak for the other card families.
+    expect(prettifyPlaces('using iron_4')).toBe('using iron industry')
+    expect(prettifyPlaces('using cotton_manufacturer_6')).toBe(
+      'using cotton/manufacturer industry',
+    )
+    expect(prettifyPlaces('using wild_location_2')).toBe('using wild location')
     expect(prettifyPlaces('coalbrookdale')).toBe('Coalbrookdale')
   })
 

--- a/src/components/journal-model.test.ts
+++ b/src/components/journal-model.test.ts
@@ -391,10 +391,11 @@ describe('place-name prettifying', () => {
     // The regression: a bare location-card slot id must never render raw.
     expect(prettifyPlaces('using coventry_1')).toBe('using Coventry')
     expect(prettifyPlaces('using stafford_1')).toBe('using Stafford')
-    // Same class of leak for the other card families.
-    expect(prettifyPlaces('using iron_4')).toBe('using iron industry')
+    // Same class of leak for the other card families — industry words also
+    // pick up proper display case (the round-2 capitalization requirement).
+    expect(prettifyPlaces('using iron_4')).toBe('using Iron industry')
     expect(prettifyPlaces('using cotton_manufacturer_6')).toBe(
-      'using cotton/manufacturer industry',
+      'using Cotton/Manufacturer industry',
     )
     expect(prettifyPlaces('using wild_location_2')).toBe('using wild location')
     expect(prettifyPlaces('coalbrookdale')).toBe('Coalbrookdale')
@@ -411,12 +412,30 @@ describe('place-name prettifying', () => {
       prettifyPlaces('1 beer from merchant at warrington (money +5)'),
     ).toBe('1 beer from merchant at Warrington (money +5)')
   })
+
+  test('industry/card-type names are capitalized like city names', () => {
+    // Round-2 regression: these used to render lowercase in discard/sell lines.
+    expect(prettifyPlaces('discarded cotton/manufacturer industry')).toBe(
+      'discarded Cotton/Manufacturer industry',
+    )
+    expect(prettifyPlaces('sold cotton industry for £6')).toBe(
+      'sold Cotton industry for £6',
+    )
+    expect(prettifyPlaces('discarded pottery industry')).toBe(
+      'discarded Pottery industry',
+    )
+    expect(prettifyPlaces('2 iron from iron works (free)')).toBe(
+      '2 Iron from Iron works (free)',
+    )
+  })
 })
 
 describe('place segmentation (hover-to-locate)', () => {
   test('each recognised place carries its board id, plain runs carry null', () => {
     expect(segmentPlaces('built cotton Level 1 at stoke')).toEqual([
-      { text: 'built cotton Level 1 at ', cityId: null },
+      { text: 'built ', cityId: null },
+      { text: 'Cotton', cityId: null, industry: true },
+      { text: ' Level 1 at ', cityId: null },
       { text: 'Stoke-on-Trent', cityId: 'stoke' },
     ])
   })
@@ -444,10 +463,22 @@ describe('place segmentation (hover-to-locate)', () => {
     ])
   })
 
-  test('card ids and city-free text come back as one plain segment', () => {
+  test('a location-card id resolves to its city and stays locatable', () => {
     expect(segmentPlaces('using stafford_1')).toEqual([
-      { text: 'using stafford_1', cityId: null },
+      { text: 'using ', cityId: null },
+      { text: 'Stafford', cityId: 'stafford' },
     ])
+  })
+
+  test('an industry-card id resolves to a bold, capitalized industry name', () => {
+    expect(segmentPlaces('using iron_4')).toEqual([
+      { text: 'using ', cityId: null },
+      { text: 'Iron', cityId: null, industry: true },
+      { text: ' industry', cityId: null },
+    ])
+  })
+
+  test('city-free, entity-free text comes back as one plain segment', () => {
     expect(segmentPlaces('took a loan')).toEqual([
       { text: 'took a loan', cityId: null },
     ])

--- a/src/components/journal-model.ts
+++ b/src/components/journal-model.ts
@@ -6,6 +6,7 @@
 // message template appears, the fallback keeps it fully visible as an
 // 'info' item rather than dropping anything.
 import { cities } from '~/data/board'
+import { describeCardId } from '~/data/cards'
 import type { LogEntry, LogEntryType, Player } from '~/store/gameStore'
 
 export interface PlayerRef {
@@ -298,12 +299,22 @@ export function decorateMain(main: string, kind: JournalKind): MainSpan[] {
 }
 
 // Whole-word city/merchant ids → their display names ("stoke" →
-// "Stoke-on-Trent"). Longest id first so no prefix can shadow a longer one;
-// card ids like "stafford_1" stay untouched (the underscore breaks \b).
+// "Stoke-on-Trent"). Longest id first so no prefix can shadow a longer one.
 const CITY_ID_RE = new RegExp(
   `\\b(${Object.keys(cities)
     .sort((a, b) => b.length - a.length)
     .join('|')})\\b`,
+  'g',
+)
+
+// Raw card/slot id tokens like "coventry_1", "iron_4", "wild_location_2" reach
+// the journal whenever an engine log names the card used for an action. Matched
+// alongside bare city ids so "coventry_1" resolves to "Coventry" (and stays
+// locatable) rather than leaking the raw slot id.
+const CARD_ID_RE = /\b[a-z][a-z_]*_\d+\b/
+// Combined so a single left-to-right pass classifies both forms in order.
+const PLACE_OR_CARD_RE = new RegExp(
+  `${CARD_ID_RE.source}|${CITY_ID_RE.source}`,
   'g',
 )
 
@@ -314,21 +325,37 @@ export interface PlaceSegment {
 }
 
 /**
- * Split raw engine text into plain runs and recognised place names, each
+ * Split raw engine text into plain runs and recognised game-entity names, each
  * place carrying its board id (so the UI can wire hover-to-locate from
  * structured data instead of re-parsing display names). Resolution is by
- * whole-word city ID — the form the engine logs — never by display name.
+ * whole-word city ID — the form the engine logs — plus card/slot ids: a
+ * location-card id ("coventry_1") resolves to its city name AND stays
+ * locatable, while industry/wild card ids ("iron_4", "wild_location_2") resolve
+ * to their human label via the canonical `describeCardId`.
  */
 export function segmentPlaces(text: string): PlaceSegment[] {
   const segments: PlaceSegment[] = []
   let last = 0
-  // Fresh regex per call: matchAll seeds from the source regex's lastIndex.
-  for (const m of text.matchAll(new RegExp(CITY_ID_RE.source, 'g'))) {
+  for (const m of text.matchAll(new RegExp(PLACE_OR_CARD_RE.source, 'g'))) {
     const at = m.index ?? 0
     if (at > last) segments.push({ text: text.slice(last, at), cityId: null })
-    const id = m[0] as keyof typeof cities
-    segments.push({ text: cities[id].name, cityId: id })
-    last = at + m[0].length
+    const token = m[0]
+    if (token.includes('_')) {
+      // A card/slot id: keep the city link when it names a location.
+      const slug = token.replace(/_\d+$/, '')
+      if (slug in cities) {
+        segments.push({
+          text: cities[slug as keyof typeof cities].name,
+          cityId: slug,
+        })
+      } else {
+        segments.push({ text: describeCardId(token) ?? token, cityId: null })
+      }
+    } else {
+      const id = token as keyof typeof cities
+      segments.push({ text: cities[id].name, cityId: id })
+    }
+    last = at + token.length
   }
   if (last < text.length)
     segments.push({ text: text.slice(last), cityId: null })

--- a/src/components/journal-model.ts
+++ b/src/components/journal-model.ts
@@ -6,7 +6,12 @@
 // message template appears, the fallback keeps it fully visible as an
 // 'info' item rather than dropping anything.
 import { cities } from '~/data/board'
-import { describeCardId } from '~/data/cards'
+import {
+  INDUSTRY_DISPLAY_NAMES,
+  describeCardId,
+  industryDisplayName,
+} from '~/data/cards'
+import type { IndustryType } from '~/data/cards'
 import type { LogEntry, LogEntryType, Player } from '~/store/gameStore'
 
 export interface PlayerRef {
@@ -229,6 +234,12 @@ export interface MainSpan {
 const capitalize = (word: string) =>
   word.charAt(0).toUpperCase() + word.slice(1)
 
+// Proper display case for a headline industry token, via the canonical source.
+const properIndustry = (word: string) =>
+  word in INDUSTRY_DISPLAY_NAMES
+    ? industryDisplayName(word as IndustryType)
+    : capitalize(word)
+
 /**
  * Split a headline into styled spans: the WHAT (industry) and WHERE
  * (location, link endpoints, merchant) carry the emphasis, the tile level
@@ -241,7 +252,7 @@ export function decorateMain(main: string, kind: JournalKind): MainSpan[] {
     if (m) {
       const spans: MainSpan[] = [
         { text: m[1]!, role: 'text' },
-        { text: capitalize(m[2]!), role: 'industry' },
+        { text: properIndustry(m[2]!), role: 'industry' },
         { text: ` (${romanLevel(Number(m[3]!))})`, role: 'level' },
         { text: m[4]!, role: 'text' },
         { text: m[5]!, role: 'place' },
@@ -275,7 +286,7 @@ export function decorateMain(main: string, kind: JournalKind): MainSpan[] {
     if (m) {
       return [
         { text: m[1]!, role: 'text' },
-        { text: capitalize(m[2]!), role: 'industry' },
+        { text: properIndustry(m[2]!), role: 'industry' },
         { text: m[3]!, role: 'text' },
         { text: m[4]!, role: 'place' },
         { text: m[5]!, role: 'text' },
@@ -288,7 +299,7 @@ export function decorateMain(main: string, kind: JournalKind): MainSpan[] {
     if (m) {
       return [
         { text: m[1]!, role: 'text' },
-        { text: capitalize(m[2]!), role: 'industry' },
+        { text: properIndustry(m[2]!), role: 'industry' },
         { text: m[3]!, role: 'text' },
         { text: m[4]!, role: 'place' },
         { text: m[5]!, role: 'text' },
@@ -312,9 +323,15 @@ const CITY_ID_RE = new RegExp(
 // alongside bare city ids so "coventry_1" resolves to "Coventry" (and stays
 // locatable) rather than leaking the raw slot id.
 const CARD_ID_RE = /\b[a-z][a-z_]*_\d+\b/
-// Combined so a single left-to-right pass classifies both forms in order.
+// Bare industry/card-type words ("cotton", "iron", …) so they get the same
+// bold + proper-case highlight as city names, everywhere they appear.
+const INDUSTRY_RE = new RegExp(
+  `\\b(${Object.keys(INDUSTRY_DISPLAY_NAMES).join('|')})\\b`,
+)
+// Combined so a single left-to-right pass classifies every form in order. Card
+// ids first: "iron_4" must not split into the industry word "iron" + "_4".
 const PLACE_OR_CARD_RE = new RegExp(
-  `${CARD_ID_RE.source}|${CITY_ID_RE.source}`,
+  `${CARD_ID_RE.source}|${CITY_ID_RE.source}|${INDUSTRY_RE.source}`,
   'g',
 )
 
@@ -322,16 +339,20 @@ export interface PlaceSegment {
   text: string
   /** Board id when this segment is a city/merchant name; null = plain text. */
   cityId: string | null
+  /** True when this segment is an industry/card-type name (bold, capitalized). */
+  industry?: boolean
 }
 
 /**
  * Split raw engine text into plain runs and recognised game-entity names, each
- * place carrying its board id (so the UI can wire hover-to-locate from
- * structured data instead of re-parsing display names). Resolution is by
- * whole-word city ID — the form the engine logs — plus card/slot ids: a
- * location-card id ("coventry_1") resolves to its city name AND stays
- * locatable, while industry/wild card ids ("iron_4", "wild_location_2") resolve
- * to their human label via the canonical `describeCardId`.
+ * carrying enough to style it: city/merchant names keep their board id (so the
+ * UI can wire hover-to-locate from structured data), and industry/card-type
+ * names are flagged so the UI can bold + proper-case them the same way. All
+ * resolution is by the form the engine logs — whole-word city id, whole-word
+ * industry type, or card/slot id: a location-card id ("coventry_1") resolves to
+ * its city name AND stays locatable, while industry/wild card ids ("iron_4",
+ * "wild_location_2") resolve to their human label via `describeCardId` (then
+ * re-segmented so the industry word inside gets the same treatment).
  */
 export function segmentPlaces(text: string): PlaceSegment[] {
   const segments: PlaceSegment[] = []
@@ -349,8 +370,16 @@ export function segmentPlaces(text: string): PlaceSegment[] {
           cityId: slug,
         })
       } else {
-        segments.push({ text: describeCardId(token) ?? token, cityId: null })
+        // Industry/wild card id → resolve to its label, then re-segment so any
+        // industry word inside ("iron industry") gets the same highlight.
+        segments.push(...segmentPlaces(describeCardId(token) ?? token))
       }
+    } else if (token in INDUSTRY_DISPLAY_NAMES) {
+      segments.push({
+        text: industryDisplayName(token as IndustryType),
+        cityId: null,
+        industry: true,
+      })
     } else {
       const id = token as keyof typeof cities
       segments.push({ text: cities[id].name, cityId: id })

--- a/src/components/journal.tsx
+++ b/src/components/journal.tsx
@@ -67,9 +67,10 @@ function emphasizeAmounts(text: string): React.ReactNode[] {
 }
 
 /**
- * Raw engine text with each recognised place rendered as a hover-to-locate
- * CityName (display name + dotted underline + map spotlight). Replaces the
- * plain prettifyPlaces() at render time — same words, now interactive.
+ * Raw engine text with each recognised game entity styled: city/merchant names
+ * as hover-to-locate CityName (display name + dotted underline + map spotlight),
+ * and industry/card-type names as the same bold parchment highlight cities get.
+ * Replaces the plain prettifyPlaces() at render time — same words, now styled.
  */
 function Places({
   text,
@@ -85,6 +86,10 @@ function Places({
           <CityName key={i} cityId={seg.cityId}>
             {seg.text}
           </CityName>
+        ) : seg.industry ? (
+          <b key={i} className="bb2-jind">
+            {seg.text}
+          </b>
         ) : (
           <span key={i}>
             {emphasize ? emphasizeAmounts(seg.text) : seg.text}

--- a/src/data/cards.test.ts
+++ b/src/data/cards.test.ts
@@ -1,5 +1,30 @@
 import { describe, expect, test } from 'vitest'
-import { describeCardId } from './cards'
+import {
+  INDUSTRY_DISPLAY_NAMES,
+  describeCardId,
+  industryDisplayName,
+} from './cards'
+
+describe('industryDisplayName', () => {
+  test('every industry type has a proper-case display name', () => {
+    expect(industryDisplayName('cotton')).toBe('Cotton')
+    expect(industryDisplayName('manufacturer')).toBe('Manufacturer')
+    expect(industryDisplayName('iron')).toBe('Iron')
+    // The canonical set is exactly the six game industries.
+    expect(Object.keys(INDUSTRY_DISPLAY_NAMES).sort()).toEqual([
+      'brewery',
+      'coal',
+      'cotton',
+      'iron',
+      'manufacturer',
+      'pottery',
+    ])
+    // Proper display case, not a raw uppercase.
+    for (const name of Object.values(INDUSTRY_DISPLAY_NAMES)) {
+      expect(name).toMatch(/^[A-Z][a-z]+$/)
+    }
+  })
+})
 
 describe('describeCardId', () => {
   test('location-card slot ids resolve to the city display name', () => {

--- a/src/data/cards.test.ts
+++ b/src/data/cards.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+import { describeCardId } from './cards'
+
+describe('describeCardId', () => {
+  test('location-card slot ids resolve to the city display name', () => {
+    // The reported bug: "coventry_1" leaked raw into the journal.
+    expect(describeCardId('coventry_1')).toBe('Coventry')
+    expect(describeCardId('stafford_1')).toBe('Stafford')
+    // Ids whose display name differs from the slug.
+    expect(describeCardId('stoke_2')).toBe('Stoke-on-Trent')
+    expect(describeCardId('burton_1')).toBe('Burton upon Trent')
+  })
+
+  test('industry-card slot ids describe the industry', () => {
+    expect(describeCardId('iron_4')).toBe('iron industry')
+    expect(describeCardId('pottery_2')).toBe('pottery industry')
+    expect(describeCardId('cotton_manufacturer_6')).toBe(
+      'cotton/manufacturer industry',
+    )
+  })
+
+  test('wild-card slot ids read as plain wild labels', () => {
+    expect(describeCardId('wild_location_2')).toBe('wild location')
+    expect(describeCardId('wild_industry_1')).toBe('wild industry')
+  })
+
+  test('unrecognised tokens return null (caller keeps them verbatim)', () => {
+    expect(describeCardId('coventry')).toBeNull()
+    expect(describeCardId('not_a_card')).toBeNull()
+    expect(describeCardId('£30')).toBeNull()
+  })
+})

--- a/src/data/cards.ts
+++ b/src/data/cards.ts
@@ -270,6 +270,23 @@ const industries: Record<string, IndustryDefinition> = {
   },
 }
 
+// The canonical set of industry/card-type names and their proper display case.
+// One source of truth so player-facing surfaces (the journal bolds + capitalizes
+// these the same way it does city names) never hand-roll `.toUpperCase()`.
+export const INDUSTRY_DISPLAY_NAMES: Record<IndustryType, string> = {
+  cotton: 'Cotton',
+  coal: 'Coal',
+  iron: 'Iron',
+  manufacturer: 'Manufacturer',
+  pottery: 'Pottery',
+  brewery: 'Brewery',
+}
+
+/** Proper display name for an industry type ("cotton" -> "Cotton"). */
+export function industryDisplayName(type: IndustryType): string {
+  return INDUSTRY_DISPLAY_NAMES[type]
+}
+
 // Human label for a raw card/slot id — "coventry_1" -> "Coventry",
 // "cotton_manufacturer_6" -> "cotton/manufacturer industry",
 // "wild_location_2" -> "wild location". A presentation-only fallback so raw

--- a/src/data/cards.ts
+++ b/src/data/cards.ts
@@ -1,4 +1,4 @@
-import { type CityId } from './board'
+import { type CityId, cities } from './board'
 
 export type IndustryType =
   | 'cotton'
@@ -268,6 +268,25 @@ const industries: Record<string, IndustryDefinition> = {
     threePlayers: 5,
     fourPlayers: 5,
   },
+}
+
+// Human label for a raw card/slot id — "coventry_1" -> "Coventry",
+// "cotton_manufacturer_6" -> "cotton/manufacturer industry",
+// "wild_location_2" -> "wild location". A presentation-only fallback so raw
+// slot ids can never leak into player-facing text; it reuses the SAME `cities`
+// and `industries` sources getCardDescription draws on, so there is one
+// canonical id->name mapping. Returns null for anything it doesn't recognise
+// (callers keep the raw token verbatim rather than guess).
+export function describeCardId(id: string): string | null {
+  const wild = /^wild_(location|industry)_\d+$/.exec(id)
+  if (wild) return `wild ${wild[1]}`
+  const m = /^(.+)_\d+$/.exec(id)
+  if (!m) return null
+  const slug = m[1]!
+  if (slug in cities) return cities[slug as keyof typeof cities].name
+  const industry = industries[slug]
+  if (industry) return `${industry.industries.join('/')} industry`
+  return null
 }
 
 // Function to create cards based on player count

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -845,7 +845,7 @@ export const gameStore = setup({
         logs: [
           ...context.logs,
           createLogEntry(
-            `${currentPlayer.name} took a loan (£${GAME_CONSTANTS.LOAN_AMOUNT}, -${GAME_CONSTANTS.LOAN_INCOME_PENALTY} income) using ${context.selectedCard.id}`,
+            `${currentPlayer.name} took a loan (£${GAME_CONSTANTS.LOAN_AMOUNT}, -${GAME_CONSTANTS.LOAN_INCOME_PENALTY} income) using ${getCardDescription(context.selectedCard)}`,
             'action',
           ),
         ],


### PR DESCRIPTION
## Problem

Raw internal card/slot ids were leaking into the player-facing **journal** — the captain reported a loan line reading *"took a loan £30 −3 INCOME using **coventry_1**"* where it should read **Coventry**. Round 2: industry / card-type names still rendered lowercase + unstyled while city names were bold + capitalized.

## Round 1 — raw ids → human names

1. **Engine** — the `Loan` action logged `context.selectedCard.id` directly; every other action already logs `getCardDescription(card)`. Loan is now consistent.
2. **Render layer** — `segmentPlaces` / `prettifyPlaces` (journal-model) only matched *bare* city ids and left `<city>_<n>` slot ids raw. A new canonical **`describeCardId`** (src/data/cards.ts) now resolves every card-id family, reusing the same `cities` / `industries` sources. Integrated with #39's hover-to-locate so a **location-card ref stays locatable** (`coventry_1` → **Coventry**, still spotlights the map).

## Round 2 — capitalize + bold industry/card-type names, matching cities

- New canonical **`INDUSTRY_DISPLAY_NAMES` / `industryDisplayName`** (src/data/cards.ts) — proper display case, no ad-hoc `toUpperCase()`.
- `segmentPlaces` now recognizes bare industry-type words and flags them `industry: true`; the render layer styles them with the **same `bb2-jind` bold span city names use** — one highlight path for all named game entities. Industry/wild card ids resolve then re-segment so `iron_4` → **Iron** industry.
- `decorateMain` headline industry tokens reuse `industryDisplayName` too, so build/sell/flip headlines and detail lines are all consistent.

| Journal text | Now renders (bold+capitalized) |
|---|---|
| `discarded cotton/manufacturer industry` | discarded **Cotton/Manufacturer** industry |
| `sold cotton industry for £6` | sold **Cotton** industry for £6 |
| `discarded pottery industry` | discarded **Pottery** industry |
| `2 iron from iron works` | 2 **Iron** from **Iron** works |

## Tests

- `describeCardId` + `industryDisplayName` unit suites (`src/data/cards.test.ts`).
- `journal-model.test.ts` asserts the capitalized display name (fails on lowercase "cotton"); #39's `segmentPlaces` tests updated for the new industry/location-card segmentation.
- Full CI test scope green: **58 files, 545 passing**. `typecheck` + `lint` clean. Rebased onto latest `origin/main` (#36–#39).

## Verification (`?demo=beerchoice`)

Before (round 1) — raw ids:

![Before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-journal-city-names-images/journal-before.png)

After (round 2) — human names, industry types capitalized + bold like cities:

![After r2](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-journal-city-names-images/journal-after-r2.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
