### PR TITLE
fix(ui): keep the played card visible through the whole action flow + pointer cursor on city names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,18 +440,32 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   buttons (keyboard-activatable when legal); the board svg must NOT get
   `role="img"` back, that flattens them out of the a11y tree.
 - The hand tray (`hand-tray.tsx`) doubles as the card selector for every
-  discard step; which steps select cards is centralized in
-  `getHandSelection()` (`action-dock.tsx`). It returns `{hint, selectedIds,
-  selectable}` for EVERY `playing.action.*` state: on the card-picking steps
-  `selectable:true` (fan is clickable); once a card is committed a catch-all
-  keeps the held `context.selectedCard` in `selectedIds` with a
-  `Holding <name>` hint and `selectable:false` — so the fan keeps the card
-  lifted (persistent `LENS_SELECTED`, display-only) and the pill keeps naming
-  it for the WHOLE flow (put-back is CANCEL in the dock). Both surfaces gate
-  the tray's `canSelect` on `handSel?.selectable`. Derived from machine
-  context, so the indicator survives the MP intent→broadcast→rebuild
-  round-trip. Pinned by `hand-selection.test.ts` + the card-first Network
-  persistence e2e (`card-first.spec.ts`).
+  discard step. `getHandSelection()` (`action-dock.tsx`) returns
+  `{hint, selectedIds}` for EVERY `playing.action.*` state: the card-picking
+  steps name the action; once a card is committed a catch-all keeps the held
+  `context.selectedCard` in `selectedIds` with a `Holding <name>` hint — so the
+  fan keeps the card lifted (persistent `LENS_SELECTED`) and the pill keeps
+  naming it for the WHOLE flow (put-back is CANCEL in the dock). It does NOT
+  decide which cards are clickable — the shell asks the machine per card
+  (`state.can({SELECT_CARD, cardId})`), the single source of truth, so it
+  survives the MP intent→broadcast→rebuild round-trip.
+- CLICK-TO-SWITCH (2026-07-17): clicking a DIFFERENT hand card switches the
+  play. On a pick step that's `cardSelected`'s own SELECT_CARD; mid-action it's
+  a parent-level SELECT_CARD on `playing.action` → `cardSelected` that reuses
+  `clearSelections` (the top-level CANCEL cleanup) then re-holds the new card.
+  Guard `canSwitchHeldCard` gates it: different in-hand card only, and NEVER
+  once a Sell has flipped an industry (`salesMadeThisAction > 0`) — that
+  half-done sale can only be closed. Child pick steps' own SELECT_CARD takes
+  precedence over the parent. The AI never uses it (`enumerateLegalMoves`
+  suppresses SELECT_CARD once a card is held — human ergonomics only). Pinned
+  by `gameStore.cardfirst.test.ts` + `gameStore.sell.test.ts` +
+  `hand-selection.test.ts`, e2e in `card-first.spec.ts` / `hand-tray.spec.ts`.
+- The active-action panel is the turn's primary focus: `.bb2-panel-active`
+  (`theme.css`, brass border + left accent rail + elevation, applied alongside
+  `.bb2-panel` on the dock wrapper in `game.tsx`/`mp-game.tsx`) plus larger
+  dock type. The right column is `lg:w-[416px]` and the hand tray clears it
+  with `lg:right-[428px]` — keep those in sync; both are lg-gated so phone
+  (w-full / right-0) is untouched.
 - HOVER-TO-LOCATE (2026-07-17): hovering/focusing any city NAME (journal,
   source pickers, sale list, dock steps, ledger, card chips) spotlights its
   plate on the map. The name reads as interactive (`.bb2-locate-name` in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,10 +441,22 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   `role="img"` back, that flattens them out of the a11y tree.
 - The hand tray (`hand-tray.tsx`) doubles as the card selector for every
   discard step; which steps select cards is centralized in
-  `getHandSelection()` (`action-dock.tsx`).
+  `getHandSelection()` (`action-dock.tsx`). It returns `{hint, selectedIds,
+  selectable}` for EVERY `playing.action.*` state: on the card-picking steps
+  `selectable:true` (fan is clickable); once a card is committed a catch-all
+  keeps the held `context.selectedCard` in `selectedIds` with a
+  `Holding <name>` hint and `selectable:false` — so the fan keeps the card
+  lifted (persistent `LENS_SELECTED`, display-only) and the pill keeps naming
+  it for the WHOLE flow (put-back is CANCEL in the dock). Both surfaces gate
+  the tray's `canSelect` on `handSel?.selectable`. Derived from machine
+  context, so the indicator survives the MP intent→broadcast→rebuild
+  round-trip. Pinned by `hand-selection.test.ts` + the card-first Network
+  persistence e2e (`card-first.spec.ts`).
 - HOVER-TO-LOCATE (2026-07-17): hovering/focusing any city NAME (journal,
   source pickers, sale list, dock steps, ledger, card chips) spotlights its
-  plate on the map. Shared plumbing is `src/components/locate.tsx` (context +
+  plate on the map. The name reads as interactive (`.bb2-locate-name` in
+  `theme.css`: dotted underline + `cursor:pointer`). Shared plumbing is
+  `src/components/locate.tsx` (context +
   `CityName` + `useLocateCity`); each surface owns the state and feeds
   BoardMap's `locatedCity` prop (`data-located` on the `g[data-city]`, teal
   `LocateMark`, deliberately distinct from the brass legal pulse;

--- a/e2e/card-first.spec.ts
+++ b/e2e/card-first.spec.ts
@@ -93,6 +93,47 @@ test('card-first: build with the held card resumes at the industry step', async 
   await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
 })
 
+test('card-first: clicking another card switches the selection on the pick step', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  const brewery = page.getByTestId('card-brewery_2')
+  const birmingham = page.getByTestId('card-birmingham_1')
+
+  await brewery.click()
+  await expect(page.getByText('Play this card')).toBeVisible()
+  await expect(brewery).toHaveAttribute('data-selected', 'true')
+
+  // Selection follows the last click — the new card is held, the old released.
+  await birmingham.click()
+  await expect(page.getByText('Play this card')).toBeVisible()
+  await expect(birmingham).toHaveAttribute('data-selected', 'true')
+  await expect(brewery).not.toHaveAttribute('data-selected', 'true')
+})
+
+test('card-first: clicking another card mid-action cancels it and re-holds the new one', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  const birmingham = page.getByTestId('card-birmingham_1')
+  const brewery = page.getByTestId('card-brewery_2')
+
+  // Enter a real action flow holding Birmingham.
+  await birmingham.click()
+  await page.getByTestId('action-network').click()
+  await expect(page.getByText(/^Holding /)).toBeVisible()
+  await expect(birmingham).toHaveAttribute('data-selected', 'true')
+
+  // Clicking a DIFFERENT card mid-flow is "cancel this, play that instead":
+  // the network action unwinds and we're back holding the new card.
+  await brewery.click()
+  await expect(page.getByText('Play this card')).toBeVisible()
+  await expect(brewery).toHaveAttribute('data-selected', 'true')
+  await expect(birmingham).not.toHaveAttribute('data-selected', 'true')
+  // Nothing was spent — the switch consumed no action.
+  await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
+})
+
 test('card-first: the held card can be put back (re-tap and Put back)', async ({
   page,
 }) => {

--- a/e2e/card-first.spec.ts
+++ b/e2e/card-first.spec.ts
@@ -47,6 +47,14 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
     page.getByText(/Choose a canal route — \d+ available/),
   ).toBeVisible()
 
+  // The card stays visibly held for the WHOLE action, not just the
+  // cardSelected screen: it keeps its lift in the fan and the "Holding …"
+  // label persists on the route step (the captain's report was that both
+  // vanished the moment an action was pressed).
+  const held = page.getByTestId('card-brewery_2')
+  await expect(held).toHaveAttribute('data-selected', 'true')
+  await expect(page.getByText(/^Holding /)).toBeVisible()
+
   const legalRoute = page.locator('path[data-conn][data-legal="true"]')
   expect(await legalRoute.count()).toBeGreaterThan(0)
   const firstConn = (await legalRoute.first().getAttribute('data-conn'))!
@@ -54,6 +62,9 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
 
   const confirm = page.getByTestId('confirm-action')
   await expect(confirm).toBeEnabled()
+  // Still held through the confirm step, right up until it's spent.
+  await expect(held).toHaveAttribute('data-selected', 'true')
+  await expect(page.getByText(/^Holding /)).toBeVisible()
   await confirm.click()
 
   // The link was laid with the held card and consumed the action (£19 − £3;

--- a/e2e/hand-tray.spec.ts
+++ b/e2e/hand-tray.spec.ts
@@ -231,35 +231,31 @@ test.describe('phone: fit + tap-to-peek', () => {
     await expect(page.locator('[data-selected="true"]')).toHaveCount(0)
   })
 
-  test('a display-only (disabled) card can still be peeked by tap', async ({
+  test('mid-action, another card peeks on the first tap and switches the play on the second', async ({
     page,
   }) => {
     await page.goto('/?demo')
 
-    // Loan: discard a card (peek-tap, then select-tap) → confirm step.
-    // (Eliza can't actually confirm — income is too low for another loan —
-    // but the confirm STEP is reached either way, which is what we need.)
+    // Loan: discard a card (peek-tap, then select-tap) → confirm step, now
+    // holding brewery_2 (Eliza can't actually confirm — income too low — but
+    // the confirm STEP is reached, which is what we need).
     await page.getByTestId('action-loan').tap()
     const discard = page.getByTestId('card-brewery_2')
     await discard.tap()
     await discard.tap()
     await expect(page.getByTestId('confirm-action')).toBeVisible()
 
-    // At the confirm step the hand is display-only: every card's button is
-    // disabled, so peeking rides the seat wrapper, not the button's click.
+    // A DIFFERENT card mid-flow is a switch target: on touch the first tap
+    // peeks it (look before you leap), the second commits the switch —
+    // cancelling the loan and re-holding the new card at the card-select step.
     const other = page.getByTestId('card-birmingham_1')
-    await expect(other).toBeDisabled()
-    // tap() refuses disabled elements (actionability), which is the point:
-    // force it — the browser still dispatches real touch input at the spot.
-    await other.tap({ force: true })
+    await other.tap()
     await expect(other).toHaveAttribute('data-raised', 'true')
+    await other.tap()
+    await expect(page.getByText('Play this card')).toBeVisible()
+    await expect(other).toHaveAttribute('data-selected', 'true')
 
-    // A second tap folds it back down instead of selecting anything.
-    await other.tap({ force: true })
-    await expect(other).not.toHaveAttribute('data-raised', 'true')
-
-    // Unwind: confirm step → card step → idle.
-    await page.getByTestId('cancel-action').tap()
+    // The loan never happened — put the new card back to idle.
     await page.getByTestId('cancel-action').tap()
     await expect(page.getByText('Choose an action')).toBeVisible()
   })

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -20,7 +20,7 @@ import {
   pendingBeerChoice,
   pendingIronChoice,
 } from '~/store/shared/resourceSources'
-import { CardChip } from './cards'
+import { CardChip, cardTitle } from './cards'
 import {
   doubleLinkDisabledReason,
   showsDoubleLinkOption,
@@ -100,6 +100,14 @@ interface ActionDockProps {
 export interface HandSelection {
   hint: string
   selectedIds: string[]
+  /**
+   * Whether the hand accepts a SELECT_CARD right now. True only on the steps
+   * that pick a card (card-first idle, cardSelected, each `selectingCard`,
+   * scout). False once a card is committed and the flow moved on — the fan
+   * then keeps the held card lifted (persistent lens) but nothing is
+   * clickable; putting the card back is CANCEL in the dock.
+   */
+  selectable: boolean
 }
 
 export function getHandSelection(
@@ -111,30 +119,63 @@ export function getHandSelection(
   // neither hint may contain "choose an action" (the idle dock title, pinned
   // by e2e getByText, which substring-matches case-insensitively).
   if (is('playing.action.selectingAction'))
-    return { hint: 'Pick an action — or play a card first', selectedIds: [] }
+    return {
+      hint: 'Pick an action — or play a card first',
+      selectedIds: [],
+      selectable: true,
+    }
   if (is('playing.action.cardSelected')) {
     const held = snapshot.context.selectedCard
     return {
       hint: 'Pick an action for this card — tap it again to put it back',
       selectedIds: held ? [held.id] : [],
+      selectable: true,
     }
   }
   if (is('playing.action.building.selectingCard'))
-    return { hint: 'Build — play a card from your hand', selectedIds: [] }
+    return {
+      hint: 'Build — play a card from your hand',
+      selectedIds: [],
+      selectable: true,
+    }
   if (is('playing.action.networking.selectingCard'))
-    return { hint: 'Network — discard a card', selectedIds: [] }
+    return {
+      hint: 'Network — discard a card',
+      selectedIds: [],
+      selectable: true,
+    }
   if (is('playing.action.developing.selectingCard'))
-    return { hint: 'Develop — discard a card', selectedIds: [] }
+    return {
+      hint: 'Develop — discard a card',
+      selectedIds: [],
+      selectable: true,
+    }
   if (is('playing.action.selling.selectingCard'))
-    return { hint: 'Sell — discard a card', selectedIds: [] }
+    return { hint: 'Sell — discard a card', selectedIds: [], selectable: true }
   if (is('playing.action.takingLoan.selectingCard'))
-    return { hint: 'Loan — discard a card', selectedIds: [] }
+    return { hint: 'Loan — discard a card', selectedIds: [], selectable: true }
   if (is('playing.action.scouting.selectingCards')) {
     const picked = snapshot.context.selectedCardsForScout
     return {
       hint: `Scout — discard three cards (${picked.length}/3)`,
       selectedIds: picked.map((c) => c.id),
+      selectable: true,
     }
+  }
+  // Any deeper step of an action flow: the card is committed but still in
+  // play. Keep it lifted in the fan and named in the pill for the WHOLE flow
+  // (until confirm / cancel / put-back) so the player never loses sight of
+  // what they're spending. Derived from machine context, so it survives the
+  // multiplayer intent → broadcast → rebuild round-trip like every other
+  // selection signal.
+  if (is('playing.action')) {
+    const held = snapshot.context.selectedCard
+    if (held)
+      return {
+        hint: `Holding ${cardTitle(held)}`,
+        selectedIds: [held.id],
+        selectable: false,
+      }
   }
   return null
 }

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -100,14 +100,6 @@ interface ActionDockProps {
 export interface HandSelection {
   hint: string
   selectedIds: string[]
-  /**
-   * Whether the hand accepts a SELECT_CARD right now. True only on the steps
-   * that pick a card (card-first idle, cardSelected, each `selectingCard`,
-   * scout). False once a card is committed and the flow moved on — the fan
-   * then keeps the held card lifted (persistent lens) but nothing is
-   * clickable; putting the card back is CANCEL in the dock.
-   */
-  selectable: boolean
 }
 
 export function getHandSelection(
@@ -118,48 +110,36 @@ export function getHandSelection(
   // actions it can start (the machine's cardSelected state). Wording gotcha:
   // neither hint may contain "choose an action" (the idle dock title, pinned
   // by e2e getByText, which substring-matches case-insensitively).
+  //
+  // Which cards are actually clickable at each step is NOT decided here — the
+  // shell asks the machine (`state.can({SELECT_CARD, cardId})`) per card. That
+  // keeps one source of truth: on a pick step every hand card is selectable;
+  // once a card is committed only a DIFFERENT card is (the mid-flow switch),
+  // and a Sell that already flipped an industry offers none.
   if (is('playing.action.selectingAction'))
-    return {
-      hint: 'Pick an action — or play a card first',
-      selectedIds: [],
-      selectable: true,
-    }
+    return { hint: 'Pick an action — or play a card first', selectedIds: [] }
   if (is('playing.action.cardSelected')) {
     const held = snapshot.context.selectedCard
     return {
       hint: 'Pick an action for this card — tap it again to put it back',
       selectedIds: held ? [held.id] : [],
-      selectable: true,
     }
   }
   if (is('playing.action.building.selectingCard'))
-    return {
-      hint: 'Build — play a card from your hand',
-      selectedIds: [],
-      selectable: true,
-    }
+    return { hint: 'Build — play a card from your hand', selectedIds: [] }
   if (is('playing.action.networking.selectingCard'))
-    return {
-      hint: 'Network — discard a card',
-      selectedIds: [],
-      selectable: true,
-    }
+    return { hint: 'Network — discard a card', selectedIds: [] }
   if (is('playing.action.developing.selectingCard'))
-    return {
-      hint: 'Develop — discard a card',
-      selectedIds: [],
-      selectable: true,
-    }
+    return { hint: 'Develop — discard a card', selectedIds: [] }
   if (is('playing.action.selling.selectingCard'))
-    return { hint: 'Sell — discard a card', selectedIds: [], selectable: true }
+    return { hint: 'Sell — discard a card', selectedIds: [] }
   if (is('playing.action.takingLoan.selectingCard'))
-    return { hint: 'Loan — discard a card', selectedIds: [], selectable: true }
+    return { hint: 'Loan — discard a card', selectedIds: [] }
   if (is('playing.action.scouting.selectingCards')) {
     const picked = snapshot.context.selectedCardsForScout
     return {
       hint: `Scout — discard three cards (${picked.length}/3)`,
       selectedIds: picked.map((c) => c.id),
-      selectable: true,
     }
   }
   // Any deeper step of an action flow: the card is committed but still in
@@ -167,15 +147,12 @@ export function getHandSelection(
   // (until confirm / cancel / put-back) so the player never loses sight of
   // what they're spending. Derived from machine context, so it survives the
   // multiplayer intent → broadcast → rebuild round-trip like every other
-  // selection signal.
+  // selection signal. Clicking a DIFFERENT card here switches the play (the
+  // machine cancels the action and re-holds it, see `canSwitchHeldCard`).
   if (is('playing.action')) {
     const held = snapshot.context.selectedCard
     if (held)
-      return {
-        hint: `Holding ${cardTitle(held)}`,
-        selectedIds: [held.id],
-        selectable: false,
-      }
+      return { hint: `Holding ${cardTitle(held)}`, selectedIds: [held.id] }
   }
   return null
 }
@@ -522,7 +499,7 @@ function StepRail({ steps, active }: { steps: string[]; active: number }) {
             />
           )}
           <span
-            className="text-[10px] font-bold uppercase tracking-[0.14em]"
+            className="text-[11px] font-bold uppercase tracking-[0.14em]"
             style={{
               color:
                 i === active
@@ -558,7 +535,7 @@ function Flow({
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-1.5">
           <span
-            className="bb2-display text-[19px] font-bold leading-none"
+            className="bb2-display text-[22px] font-bold leading-none"
             style={{ color: 'var(--bb-brass-bright)' }}
           >
             {action}
@@ -585,7 +562,7 @@ function Flow({
 function Note({ children }: { children: React.ReactNode }) {
   return (
     <p
-      className="text-[14px] leading-relaxed"
+      className="text-[15px] leading-relaxed"
       style={{ color: 'rgba(231,215,177,.7)' }}
     >
       {children}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -969,8 +969,8 @@ function GameInner({
             </div>
           </div>
 
-          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
-            <div className="bb2-panel flex flex-col gap-3 p-4">
+          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[416px] lg:overflow-y-auto lg:pb-0">
+            <div className="bb2-panel bb2-panel-active flex flex-col gap-3 p-5">
               {!needsReveal && (
                 <ActionDock
                   snapshot={state as GameStoreSnapshot}
@@ -1004,7 +1004,7 @@ function GameInner({
           <HandTray
             hand={currentPlayer.hand}
             canSelect={
-              handSel?.selectable
+              handSel
                 ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
                 : null
             }

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -1004,7 +1004,7 @@ function GameInner({
           <HandTray
             hand={currentPlayer.hand}
             canSelect={
-              handSel
+              handSel?.selectable
                 ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
                 : null
             }

--- a/src/components/hand-selection.test.ts
+++ b/src/components/hand-selection.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'vitest'
+import type { Card, LocationCard } from '../data/cards'
+import type { GameStoreSnapshot } from '../store/gameStore'
+import { getHandSelection } from './action-dock'
+
+// getHandSelection only reads snapshot.matches(path) and two context fields,
+// so a light fake stands in for a driven actor (same approach as the other
+// pure-logic component tests). matches() follows xstate semantics: an
+// ancestor path matches a deeper active state ('playing.action' matches
+// 'playing.action.networking.selectingLink').
+function snap(
+  statePath: string,
+  context: { selectedCard?: Card | null; selectedCardsForScout?: Card[] } = {},
+): GameStoreSnapshot {
+  return {
+    matches: (path: string) =>
+      statePath === path || statePath.startsWith(`${path}.`),
+    context: {
+      selectedCard: context.selectedCard ?? null,
+      selectedCardsForScout: context.selectedCardsForScout ?? [],
+    },
+  } as unknown as GameStoreSnapshot
+}
+
+const wolverhampton: LocationCard = {
+  id: 'loc-wolverhampton-1',
+  type: 'location',
+  location: 'wolverhampton',
+  color: 'other',
+}
+
+describe('getHandSelection — held card persists through the whole flow', () => {
+  test('card-first idle: selectable, nothing held', () => {
+    const sel = getHandSelection(snap('playing.action.selectingAction'))
+    expect(sel).toEqual({
+      hint: 'Pick an action — or play a card first',
+      selectedIds: [],
+      selectable: true,
+    })
+  })
+
+  test('cardSelected: held card highlighted and still selectable (put back)', () => {
+    const sel = getHandSelection(
+      snap('playing.action.cardSelected', { selectedCard: wolverhampton }),
+    )
+    expect(sel?.selectedIds).toEqual(['loc-wolverhampton-1'])
+    expect(sel?.selectable).toBe(true)
+  })
+
+  test('deeper Network step keeps the card lifted and names it, not selectable', () => {
+    const sel = getHandSelection(
+      snap('playing.action.networking.selectingLink', {
+        selectedCard: wolverhampton,
+      }),
+    )
+    expect(sel).toEqual({
+      hint: 'Holding Wolverhampton',
+      selectedIds: ['loc-wolverhampton-1'],
+      selectable: false,
+    })
+  })
+
+  test('the indicator persists across every deeper step of a flow', () => {
+    for (const path of [
+      'playing.action.building.selectingIndustryType',
+      'playing.action.building.selectingLocation',
+      'playing.action.building.confirmingBuild',
+      'playing.action.building.choosingIronSource',
+      'playing.action.networking.selectingLink',
+      'playing.action.networking.confirmingLink',
+      'playing.action.networking.choosingDoubleLinkBeer',
+      'playing.action.developing.selectingTiles',
+      'playing.action.selling.selectingSale',
+      'playing.action.selling.choosingBeerSource',
+    ]) {
+      const sel = getHandSelection(snap(path, { selectedCard: wolverhampton }))
+      expect(sel, path).not.toBeNull()
+      expect(sel?.selectedIds, path).toEqual(['loc-wolverhampton-1'])
+      expect(sel?.selectable, path).toBe(false)
+      expect(sel?.hint, path).toBe('Holding Wolverhampton')
+    }
+  })
+
+  test('an action-first discard step still selects (no card committed yet)', () => {
+    const sel = getHandSelection(
+      snap('playing.action.networking.selectingCard'),
+    )
+    expect(sel?.selectable).toBe(true)
+    expect(sel?.selectedIds).toEqual([])
+  })
+
+  test('outside any action flow → null', () => {
+    expect(getHandSelection(snap('playing.turnComplete'))).toBeNull()
+    expect(getHandSelection(snap('setup'))).toBeNull()
+  })
+})

--- a/src/components/hand-selection.test.ts
+++ b/src/components/hand-selection.test.ts
@@ -30,33 +30,30 @@ const wolverhampton: LocationCard = {
 }
 
 describe('getHandSelection — held card persists through the whole flow', () => {
-  test('card-first idle: selectable, nothing held', () => {
-    const sel = getHandSelection(snap('playing.action.selectingAction'))
-    expect(sel).toEqual({
+  test('card-first idle: nothing held, hand live', () => {
+    expect(getHandSelection(snap('playing.action.selectingAction'))).toEqual({
       hint: 'Pick an action — or play a card first',
       selectedIds: [],
-      selectable: true,
     })
   })
 
-  test('cardSelected: held card highlighted and still selectable (put back)', () => {
+  test('cardSelected: held card highlighted (put back / switch handled by machine)', () => {
     const sel = getHandSelection(
       snap('playing.action.cardSelected', { selectedCard: wolverhampton }),
     )
     expect(sel?.selectedIds).toEqual(['loc-wolverhampton-1'])
-    expect(sel?.selectable).toBe(true)
   })
 
-  test('deeper Network step keeps the card lifted and names it, not selectable', () => {
-    const sel = getHandSelection(
-      snap('playing.action.networking.selectingLink', {
-        selectedCard: wolverhampton,
-      }),
-    )
-    expect(sel).toEqual({
+  test('deeper Network step keeps the card lifted and names it', () => {
+    expect(
+      getHandSelection(
+        snap('playing.action.networking.selectingLink', {
+          selectedCard: wolverhampton,
+        }),
+      ),
+    ).toEqual({
       hint: 'Holding Wolverhampton',
       selectedIds: ['loc-wolverhampton-1'],
-      selectable: false,
     })
   })
 
@@ -76,17 +73,14 @@ describe('getHandSelection — held card persists through the whole flow', () =>
       const sel = getHandSelection(snap(path, { selectedCard: wolverhampton }))
       expect(sel, path).not.toBeNull()
       expect(sel?.selectedIds, path).toEqual(['loc-wolverhampton-1'])
-      expect(sel?.selectable, path).toBe(false)
       expect(sel?.hint, path).toBe('Holding Wolverhampton')
     }
   })
 
-  test('an action-first discard step still selects (no card committed yet)', () => {
-    const sel = getHandSelection(
-      snap('playing.action.networking.selectingCard'),
-    )
-    expect(sel?.selectable).toBe(true)
-    expect(sel?.selectedIds).toEqual([])
+  test('an action-first discard step names the action, nothing held yet', () => {
+    expect(
+      getHandSelection(snap('playing.action.networking.selectingCard')),
+    ).toEqual({ hint: 'Network — discard a card', selectedIds: [] })
   })
 
   test('outside any action flow → null', () => {

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -189,7 +189,7 @@ export function HandTray({
   return (
     <div
       ref={rootRef}
-      className="bb2-handtray pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[392px]"
+      className="bb2-handtray pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[428px]"
       style={
         { '--bb-hint-clear': `${hintClearance(lens)}px` } as React.CSSProperties
       }

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -1217,9 +1217,9 @@ function MpTable({
             </div>
           </div>
 
-          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[380px] lg:overflow-y-auto lg:pb-0">
+          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[416px] lg:overflow-y-auto lg:pb-0">
             <div
-              className={`bb2-panel flex flex-col gap-3 p-4 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
+              className={`bb2-panel bb2-panel-active flex flex-col gap-3 p-5 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
               aria-busy={myTurn && inFlight}
             >
               {myTurn ? (
@@ -1337,7 +1337,7 @@ function MpTable({
         <HandTray
           hand={me.hand}
           canSelect={
-            handSel?.selectable && !inFlight
+            handSel && !inFlight
               ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
               : null
           }

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -1337,7 +1337,7 @@ function MpTable({
         <HandTray
           hand={me.hand}
           canSelect={
-            handSel && !inFlight
+            handSel?.selectable && !inFlight
               ? (cardId) => state.can({ type: 'SELECT_CARD', cardId })
               : null
           }

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -114,6 +114,37 @@
   border-radius: 6px;
 }
 
+/* The active-action panel: the primary focus every turn. It carries stronger
+   brass, a left accent rail and more elevation than a plain .bb2-panel so the
+   eye lands here first and it separates from THE EXCHANGES beneath it. Applied
+   alongside .bb2-panel on the dock's wrapper. */
+.bb2-panel-active {
+  position: relative;
+  border-color: var(--bb-brass);
+  background: linear-gradient(
+    170deg,
+    #2c2417 0%,
+    var(--bb-iron-raised) 55%,
+    var(--bb-iron-panel) 100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 230, 170, 0.1), 0 0 0 1px
+    var(--bb-brass-hairline), 0 14px 36px rgba(0, 0, 0, 0.62);
+}
+.bb2-panel-active::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  border-radius: 6px 0 0 6px;
+  background: linear-gradient(
+    180deg,
+    var(--bb-brass-bright),
+    var(--bb-brass-dim)
+  );
+}
+
 .bb2-panel-title {
   font-family: var(--bb-body);
   font-weight: 600;
@@ -124,6 +155,11 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+/* Inside the active-action panel the section titles read a step larger,
+   part of making that panel feel substantial (captain feedback). */
+.bb2-panel-active .bb2-panel-title {
+  font-size: 13px;
 }
 .bb2-panel-title::after {
   content: "";

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -630,6 +630,8 @@ button.bb2-card {
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
   border-radius: 2px;
+  /* reads as interactive — hovering it spotlights the city on the map */
+  cursor: pointer;
 }
 .bb2-locate-name:hover,
 .bb2-locate-name:focus-visible,

--- a/src/server/ai/legal-moves.ts
+++ b/src/server/ai/legal-moves.ts
@@ -219,7 +219,15 @@ export function enumerateLegalMoves(snapshot: GameStoreSnapshot): LegalMove[] {
   const atActionChoice = snapshot.matches({
     playing: { action: 'selectingAction' },
   } as never)
+  // A card already committed means any SELECT_CARD now is the human-only
+  // mid-flow switch shortcut (cancel this action, hold another card). It is
+  // redundant for the AI — every card it reaches action-first is reachable
+  // without it — and offering it would let the deterministic fallback loop
+  // cancelling and re-holding instead of taking a turn-consuming action.
+  const cardHeld = snapshot.context.selectedCard !== null
   return candidateMoves(snapshot)
-    .filter((c) => !(atActionChoice && c.event.type === 'SELECT_CARD'))
+    .filter(
+      (c) => !((atActionChoice || cardHeld) && c.event.type === 'SELECT_CARD'),
+    )
     .filter((c) => snapshot.can(c.event as never))
 }

--- a/src/store/gameStore.cardfirst.test.ts
+++ b/src/store/gameStore.cardfirst.test.ts
@@ -395,6 +395,109 @@ describe('card-first — remaining actions continue past the card step', () => {
   })
 })
 
+describe('mid-action card switch — click another card to cancel and re-hold', () => {
+  test('clicking a different card deep in a flow unwinds the action and holds the new card', () => {
+    const { actor, playerId } = setupGame([coalCard, ironCard, locationCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_LINK', from: 'coalbrookdale', to: 'shrewsbury' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { networking: 'confirmingLink' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedLink).not.toBeNull()
+    const actionsBefore = snapshot.context.actionsRemaining
+
+    // The engine offers the switch for a DIFFERENT card (drives the fan's
+    // clickability), and refuses re-picking the already-held one.
+    expect(snapshot.can({ type: 'SELECT_CARD', cardId: ironCard.id })).toBe(
+      true,
+    )
+    expect(snapshot.can({ type: 'SELECT_CARD', cardId: coalCard.id })).toBe(
+      false,
+    )
+
+    actor.send({ type: 'SELECT_CARD', cardId: ironCard.id })
+
+    snapshot = actor.getSnapshot()
+    // Landed back in cardSelected holding the NEW card, action fully unwound.
+    expect(snapshot.matches({ playing: { action: 'cardSelected' } })).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(ironCard.id)
+    expect(snapshot.context.selectedLink).toBeNull()
+    // No action or turn was consumed, and the abandoned card stays in hand.
+    expect(snapshot.context.actionsRemaining).toBe(actionsBefore)
+    expect(snapshot.context.currentPlayerIndex).toBe(playerId)
+    expect(
+      snapshot.context.players[playerId]!.hand.some(
+        (c) => c.id === coalCard.id,
+      ),
+    ).toBe(true)
+  })
+
+  test('re-clicking the SAME held card mid-flow is a no-op (put-back is CANCEL)', () => {
+    const { actor } = setupGame([coalCard, ironCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'NETWORK' })
+
+    let snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { networking: 'selectingLink' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.can({ type: 'SELECT_CARD', cardId: coalCard.id })).toBe(
+      false,
+    )
+
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+
+    snapshot = actor.getSnapshot()
+    // Unchanged — still mid-flow holding the same card.
+    expect(
+      snapshot.matches({
+        playing: { action: { networking: 'selectingLink' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+  })
+
+  test('a bogus card id mid-flow is ignored', () => {
+    const { actor } = setupGame([coalCard, ironCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId: 'not_in_hand' })
+
+    const snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { networking: 'selectingLink' } },
+      }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(coalCard.id)
+  })
+
+  test('the switch works from the build site step too', () => {
+    const { actor } = setupGame([coalCard, ironCard])
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    actor.send({ type: 'BUILD' })
+    expect(
+      actor
+        .getSnapshot()
+        .matches({ playing: { action: { building: 'selectingLocation' } } }),
+    ).toBe(true)
+
+    actor.send({ type: 'SELECT_CARD', cardId: ironCard.id })
+
+    const snapshot = actor.getSnapshot()
+    expect(snapshot.matches({ playing: { action: 'cardSelected' } })).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(ironCard.id)
+    expect(snapshot.context.selectedIndustryTile?.type).toBe('iron')
+  })
+})
+
 describe('action-first flow — unchanged by the card-first entry', () => {
   test('BUILD from idle still asks for the card first', () => {
     const { actor } = setupGame([coalCard, locationCard])

--- a/src/store/gameStore.sell.test.ts
+++ b/src/store/gameStore.sell.test.ts
@@ -256,6 +256,60 @@ describe('Game Store - Sell Actions', () => {
     expect(actionsUsed).toBeLessThanOrEqual(1)
   })
 
+  test('mid-sell card switch is refused once an industry has flipped (sales are irreversible)', () => {
+    const { actor } = setupGame()
+
+    buildLinkToGloucester(actor)
+    passCurrentPlayer(actor)
+
+    let snapshot = actor.getSnapshot()
+    const sellerIndex = snapshot.context.currentPlayerIndex
+
+    actor.send({
+      type: 'TEST_SET_MERCHANTS',
+      merchants: [gloucesterMerchant()],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: sellerIndex,
+      industries: [
+        makeIndustry('worcester', cottonTile),
+        makeIndustry('worcester', manufacturerTile),
+      ],
+      money: 20,
+      income: 10,
+    })
+
+    actor.send({ type: 'SELL' })
+    snapshot = actor.getSnapshot()
+    const discardCard = snapshot.context.players[sellerIndex]!.hand[0]!.id
+    const otherCard = snapshot.context.players[sellerIndex]!.hand[1]!.id
+    actor.send({ type: 'SELECT_CARD', cardId: discardCard })
+    // One sale flips the cotton mill — the action is now partially committed.
+    actor.send({
+      type: 'SELECT_SALE',
+      location: 'worcester',
+      industryType: 'cotton',
+      merchant: 'gloucester',
+    })
+
+    snapshot = actor.getSnapshot()
+    expect(snapshot.context.salesMadeThisAction).toBe(1)
+    expect(
+      snapshot.matches({ playing: { action: { selling: 'selectingSale' } } }),
+    ).toBe(true)
+
+    // A flipped sale cannot be abandoned by switching cards — the shortcut is
+    // refused so no half-applied sale can be walked away from.
+    expect(snapshot.can({ type: 'SELECT_CARD', cardId: otherCard })).toBe(false)
+    actor.send({ type: 'SELECT_CARD', cardId: otherCard })
+    snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({ playing: { action: { selling: 'selectingSale' } } }),
+    ).toBe(true)
+    expect(snapshot.context.selectedCard?.id).toBe(discardCard)
+  })
+
   test('sell action - CONFIRM without a completed sale is blocked (guard)', () => {
     const { actor } = setupGame()
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2623,6 +2623,21 @@ export const gameStore = setup({
         context.selectedCard.id === event.cardId
       )
     },
+    // Mid-action "change my mind": clicking a DIFFERENT hand card while an
+    // action is in progress cancels it and re-holds the new card. Only fires
+    // when a card is already committed (`selectedCard` set), the click is a
+    // different card, and nothing has irreversibly committed — a Sell that has
+    // already flipped an industry (`salesMadeThisAction > 0`) cannot be
+    // abandoned, so the switch is refused there and the player must close the
+    // sale. The card-pick steps define their own SELECT_CARD and override this.
+    canSwitchHeldCard: ({ context, event }) => {
+      if (event.type !== 'SELECT_CARD') return false
+      if (context.selectedCard === null) return false
+      if (context.selectedCard.id === event.cardId) return false
+      if (context.salesMadeThisAction > 0) return false
+      const player = getCurrentPlayer(context)
+      return findCardInHand(player, event.cardId) !== null
+    },
     // Card-first BUILD routing — the same split isLocationCard/isIndustryCard
     // make on the SELECT_CARD event, but read from the already-held card.
     isSelectedCardLocationKind: ({ context }) =>
@@ -3199,6 +3214,21 @@ export const gameStore = setup({
       states: {
         action: {
           initial: 'selectingAction',
+          on: {
+            // Clicking a DIFFERENT hand card mid-action is a shortcut for
+            // "cancel this, I want to play that instead": unwind the whole
+            // action (the same `clearSelections` cleanup the top-level CANCELs
+            // use) and land back in cardSelected holding the new card. The
+            // card-pick steps (cardSelected / *.selectingCard / scouting) each
+            // declare their own SELECT_CARD, which takes precedence, so this
+            // only fires from the deeper flow steps. `canSwitchHeldCard`
+            // refuses it once a Sell has irreversibly flipped an industry.
+            SELECT_CARD: {
+              target: '.cardSelected',
+              actions: ['clearSelections', 'selectCard'],
+              guard: 'canSwitchHeldCard',
+            },
+          },
           states: {
             selectingAction: {
               on: {


### PR DESCRIPTION
## What & why

Card-selection UX in the hand-tray / action dock, from three rounds of captain feedback. Rebased on latest `main` (includes #36–#40).

### 1 — The played card persists for the whole action flow
Selecting a card held it and showed *"Holding X"* only on the card-select screen; pressing an action (Network, etc.) made the highlight and label vanish. Now `getHandSelection()` returns the held `context.selectedCard` for **every** `playing.action.*` state, so the fan keeps the card lifted (the persistent `LENS_SELECTED` from #36) and the pill keeps naming it — *Holding …* — until confirm / cancel / put-back.

### 2 — Click another card to switch the play *(round 2)*
- **On a card-pick step:** clicking a different hand card switches the selection (selection follows the last click).
- **Mid-action:** clicking a *different* card is a shortcut for "cancel this, play that instead" — a parent-level `SELECT_CARD` transition on `playing.action` unwinds the action (reusing the same `clearSelections` cleanup the top-level CANCELs use) and re-holds the new card in `cardSelected`. No context is hand-mutated; it's a real machine transition, so it survives the MP round-trip.
- **Safety:** `canSwitchHeldCard` refuses the switch once a Sell has irreversibly flipped an industry (`salesMadeThisAction > 0`) — that half-done sale can only be closed. ⚠️ **Flagged limitation:** mid-sell (after ≥1 flip) you can't card-switch away; that's by design (sales are irreversible) — you close the sale via Confirm. Every other action cancels cleanly at any sub-step.
- Re-tapping the same held card keeps its put-back meaning. The AI never uses the mid-flow switch (human ergonomics only).

### 3 — Active-action panel prominence + bigger fonts + a little width *(round 3)*
The active-action panel read at the same weight as THE EXCHANGES. New `.bb2-panel-active` (brass border, left accent rail, more elevation, lighter top, `p-5`) makes the eye land there first and separates it. Fonts bumped: action title 19→22px, breadcrumb 10→11px, instruction 14→15px, section title 12→13px. Right column 380→416px (hand-tray offset 392→428px) — all `lg`-gated, so the phone layout (w-full / right-0) is untouched.

### 4 — City-name hover cursor
`.bb2-locate-name` now uses `cursor: pointer` so the hover-to-locate affordance (#39) reads as interactive.

## Verification
- Engine (TDD): mid-flow switch + sell-after-flip block pinned in `gameStore.cardfirst.test.ts` / `gameStore.sell.test.ts`; label/persistence in `hand-selection.test.ts`; statechart-shape sweep (`gameStore.graph.test.ts`) still green with the new edges.
- e2e: pick-step switch, mid-flow switch, held-card persistence through route→confirm, touch peek-then-switch (`card-first.spec.ts`, `hand-tray.spec.ts`).
- `pnpm test` (59 files, 556 tests) + lint + typecheck green; MP e2e (`mp-playthrough`, `multiplayer`, `ai-opponent`) pass.
- Browser-verified on desktop and phone (390px).

### Active-action panel — more prominent, bigger fonts (desktop)
![active desktop](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-persist-images-4d0eac0/r2-active-panel-desktop.png)

### Idle dock — the panel stands out from THE EXCHANGES below
![idle](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-persist-images-4d0eac0/r2-idle-prominent-panel.png)

### Held card persists into the Network flow ("HOLDING BIRMINGHAM")
![holding desktop](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-persist-images-4d0eac0/network-route-holding-desktop.png)

### Phone (390px) — layout intact
![phone](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-persist-images-4d0eac0/r2-panel-phone.png)

## Preview
Vercel branch preview (captain's test surface): https://brass-birmingham-git-fm-brass-ca-ab9238-julius-retzers-projects.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)