### PR TITLE
fix(ui): name the held card in the dock in BOTH entry orders (follow-up to #41)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -449,6 +449,15 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   decide which cards are clickable — the shell asks the machine per card
   (`state.can({SELECT_CARD, cardId})`), the single source of truth, so it
   survives the MP intent→broadcast→rebuild round-trip.
+- HELD-CARD BANNER (2026-07-17): the DOCK also names the held card — a shared
+  `HeldCard` (`Holding <CardChip>`) rendered by the `Flow` wrapper (via a
+  `held` prop on every `<Flow>` / `DevelopTilePicker`) AND the `cardSelected`
+  chooser, so both entry orders (card-first and action-first) show the
+  IDENTICAL "Holding <card>" the instant `context.selectedCard` is set, for the
+  whole flow. Keyed on state + `selectedCard` only, so it's order-independent.
+  Don't reintroduce the old per-step "Playing"/"Card" chips — they duplicated
+  it. `data-testid="held-card"`; pinned by the action-first + card-first dock
+  tests in `card-first.spec.ts`.
 - CLICK-TO-SWITCH (2026-07-17): clicking a DIFFERENT hand card switches the
   play. On a pick step that's `cardSelected`'s own SELECT_CARD; mid-action it's
   a parent-level SELECT_CARD on `playing.action` → `cardSelected` that reuses

--- a/e2e/card-first.spec.ts
+++ b/e2e/card-first.spec.ts
@@ -53,7 +53,9 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   // vanished the moment an action was pressed).
   const held = page.getByTestId('card-brewery_2')
   await expect(held).toHaveAttribute('data-selected', 'true')
-  await expect(page.getByText(/^Holding /)).toBeVisible()
+  await expect(
+    page.locator('.bb2-hand-hint').getByText(/^Holding /),
+  ).toBeVisible()
 
   const legalRoute = page.locator('path[data-conn][data-legal="true"]')
   expect(await legalRoute.count()).toBeGreaterThan(0)
@@ -64,7 +66,9 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   await expect(confirm).toBeEnabled()
   // Still held through the confirm step, right up until it's spent.
   await expect(held).toHaveAttribute('data-selected', 'true')
-  await expect(page.getByText(/^Holding /)).toBeVisible()
+  await expect(
+    page.locator('.bb2-hand-hint').getByText(/^Holding /),
+  ).toBeVisible()
   await confirm.click()
 
   // The link was laid with the held card and consumed the action (£19 − £3;
@@ -91,6 +95,46 @@ test('card-first: build with the held card resumes at the industry step', async 
   await page.getByTestId('cancel-action').click()
   await expect(page.getByText('Choose an action')).toBeVisible()
   await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
+})
+
+test('action-first: the "Holding <card>" banner appears once a card is picked and persists', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+
+  // Action first: choose Network BEFORE a card. On the discard step no card is
+  // held yet, so the dock shows no held-card banner.
+  await page.getByTestId('action-network').click()
+  await expect(page.getByTestId('held-card')).toHaveCount(0)
+
+  // Pick a card during the discard step — the dock now NAMES it, the same
+  // "Holding <card>" wording the card-first order shows.
+  await page.getByTestId('card-birmingham_1').click()
+  const held = page.getByTestId('held-card')
+  await expect(held).toBeVisible()
+  await expect(held).toContainText('Holding')
+  await expect(held).toContainText('Birmingham')
+
+  // …and it persists through the route step and into confirm.
+  const legalRoute = page.locator('path[data-conn][data-legal="true"]')
+  expect(await legalRoute.count()).toBeGreaterThan(0)
+  const firstConn = (await legalRoute.first().getAttribute('data-conn'))!
+  await clickRoute(page, firstConn)
+  await expect(page.getByTestId('confirm-action')).toBeEnabled()
+  await expect(page.getByTestId('held-card')).toContainText('Birmingham')
+})
+
+test('card-first: the same held-card banner shows in the dock and persists', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+
+  // Card first: the banner is up from the chooser onward.
+  await page.getByTestId('card-birmingham_1').click()
+  await expect(page.getByTestId('held-card')).toContainText('Birmingham')
+  await page.getByTestId('action-network').click()
+  // Same banner through the route step — identical to the action-first order.
+  await expect(page.getByTestId('held-card')).toContainText('Birmingham')
 })
 
 test('card-first: clicking another card switches the selection on the pick step', async ({
@@ -121,7 +165,9 @@ test('card-first: clicking another card mid-action cancels it and re-holds the n
   // Enter a real action flow holding Birmingham.
   await birmingham.click()
   await page.getByTestId('action-network').click()
-  await expect(page.getByText(/^Holding /)).toBeVisible()
+  await expect(
+    page.locator('.bb2-hand-hint').getByText(/^Holding /),
+  ).toBeVisible()
   await expect(birmingham).toHaveAttribute('data-selected', 'true')
 
   // Clicking a DIFFERENT card mid-flow is "cancel this, play that instead":

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -5,7 +5,7 @@
 // Card discards are made in the HandTray fan; this dock shows the step rail.
 import { useEffect, useState } from 'react'
 import { type CityId, cities } from '~/data/board'
-import { type IndustryType } from '~/data/cards'
+import { type Card, type IndustryType } from '~/data/cards'
 import {
   type GameEvent,
   type GameStoreSnapshot,
@@ -169,11 +169,13 @@ function DevelopTilePicker({
   onCancel,
   onPick,
   onLowest,
+  held,
 }: {
   currentPlayer: Player
   onCancel: () => void
   onPick: (types: IndustryType[]) => void
   onLowest: () => void
+  held?: Card | null
 }) {
   const [counts, setCounts] = useState<Partial<Record<IndustryType, number>>>(
     {},
@@ -208,6 +210,7 @@ function DevelopTilePicker({
       steps={['Card', 'Tiles', 'Confirm']}
       active={1}
       onCancel={onCancel}
+      held={held}
     >
       <Note>
         Scrap one or <b>two</b> tiles from your mat — each consumes 1 iron. Tap
@@ -517,17 +520,39 @@ function StepRail({ steps, active }: { steps: string[]; active: number }) {
   )
 }
 
+/**
+ * The held-card banner, shown the instant a card is committed and kept for the
+ * whole action flow — the SAME "Holding <card>" wording in the card-first
+ * chooser and every action-first step, so the two entry orders look identical
+ * (captain's rule: the held card is named consistently regardless of order).
+ */
+function HeldCard({ card }: { card: Card | null | undefined }) {
+  if (!card) return null
+  return (
+    <div
+      className="flex items-center gap-2 text-[12px]"
+      style={{ color: 'rgba(231,215,177,.6)' }}
+      data-testid="held-card"
+    >
+      Holding <CardChip card={card} />
+    </div>
+  )
+}
+
 function Flow({
   action,
   steps,
   active,
   onCancel,
+  held,
   children,
 }: {
   action: string
   steps: string[]
   active: number
   onCancel?: () => void
+  /** The card carried through this action — named at the top of every step. */
+  held?: Card | null
   children: React.ReactNode
 }) {
   return (
@@ -553,6 +578,7 @@ function Flow({
           </button>
         )}
       </div>
+      <HeldCard card={held} />
       <hr className="bb2-rule" />
       {children}
     </div>
@@ -850,14 +876,7 @@ export function ActionDock({
         <div className="flex items-start justify-between gap-2">
           <div className="flex flex-col gap-1.5">
             <span className="bb2-panel-title">Play this card</span>
-            {c.selectedCard && (
-              <div
-                className="flex items-center gap-2 text-[12px]"
-                style={{ color: 'rgba(231,215,177,.6)' }}
-              >
-                Holding <CardChip card={c.selectedCard} />
-              </div>
-            )}
+            <HeldCard card={c.selectedCard} />
           </div>
           <button
             type="button"
@@ -903,7 +922,13 @@ export function ActionDock({
   const buildSteps = ['Card', 'Industry', 'Site', 'Confirm']
   if (is('playing.action.building.selectingCard')) {
     return (
-      <Flow action="Build" steps={buildSteps} active={0} onCancel={cancel}>
+      <Flow
+        action="Build"
+        steps={buildSteps}
+        active={0}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <Note>
           Play a card from your hand below. A <b>location card</b> opens that
           city; an <b>industry card</b> builds in your network.
@@ -917,15 +942,13 @@ export function ActionDock({
       (viableIndustries === null || viableIndustries.has(t))
     const anyBlocked = INDUSTRY_TYPES.some((t) => !isViable(t))
     return (
-      <Flow action="Build" steps={buildSteps} active={1} onCancel={cancel}>
-        {c.selectedCard && (
-          <div
-            className="flex items-center gap-2 text-[12px]"
-            style={{ color: 'rgba(231,215,177,.6)' }}
-          >
-            Playing <CardChip card={c.selectedCard} />
-          </div>
-        )}
+      <Flow
+        action="Build"
+        steps={buildSteps}
+        active={1}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <div className="grid grid-cols-3 gap-2">
           {INDUSTRY_TYPES.map((t) => (
             <button
@@ -971,7 +994,13 @@ export function ActionDock({
         can({ type: 'SELECT_LOCATION', cityId: id }),
       ).length
     return (
-      <Flow action="Build" steps={buildSteps} active={2} onCancel={cancel}>
+      <Flow
+        action="Build"
+        steps={buildSteps}
+        active={2}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         {legalCount === 0 ? (
           <Note>
             <b style={{ color: '#d68d80' }}>No city can take this build</b> —
@@ -992,14 +1021,14 @@ export function ActionDock({
   if (is('playing.action.building.confirmingBuild')) {
     const tile = c.selectedIndustryTile
     return (
-      <Flow action="Build" steps={buildSteps} active={3} onCancel={cancel}>
+      <Flow
+        action="Build"
+        steps={buildSteps}
+        active={3}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <div className="flex flex-col gap-2 text-[13px]">
-          {c.selectedCard && (
-            <div className="flex items-center gap-2">
-              <span style={{ color: 'rgba(231,215,177,.55)' }}>Card</span>
-              <CardChip card={c.selectedCard} />
-            </div>
-          )}
           {tile && (
             <div className="flex items-center gap-2">
               <span style={{ color: 'rgba(231,215,177,.55)' }}>Tile</span>
@@ -1070,6 +1099,7 @@ export function ActionDock({
         }
         active={building ? 3 : 2}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         {choice && (
           <IronSourcePicker
@@ -1087,14 +1117,26 @@ export function ActionDock({
   const netSteps = ['Card', 'Route', 'Confirm']
   if (is('playing.action.networking.selectingCard')) {
     return (
-      <Flow action="Network" steps={netSteps} active={0} onCancel={cancel}>
+      <Flow
+        action="Network"
+        steps={netSteps}
+        active={0}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <Note>Discard any card from your hand below to open a route.</Note>
       </Flow>
     )
   }
   if (is('playing.action.networking.selectingLink')) {
     return (
-      <Flow action="Network" steps={netSteps} active={1} onCancel={cancel}>
+      <Flow
+        action="Network"
+        steps={netSteps}
+        active={1}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <Note>
           Choose a {c.era} route on the map.{' '}
           {c.era === 'canal' ? (
@@ -1113,7 +1155,13 @@ export function ActionDock({
   if (is('playing.action.networking.confirmingLink')) {
     const link = c.selectedLink
     return (
-      <Flow action="Network" steps={netSteps} active={2} onCancel={cancel}>
+      <Flow
+        action="Network"
+        steps={netSteps}
+        active={2}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <Note>
           <b style={{ color: 'var(--bb-parchment-bright)' }}>
             <LinkLabel link={link} />
@@ -1145,6 +1193,7 @@ export function ActionDock({
         steps={['Card', 'Route', 'Route II', 'Confirm']}
         active={2}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>Choose the second rail route on the map.</Note>
       </Flow>
@@ -1158,6 +1207,7 @@ export function ActionDock({
         steps={['Card', 'Route', 'Route II', 'Beer', 'Confirm']}
         active={3}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>Which brewery supplies the beer for the second rail?</Note>
         {choice && (
@@ -1178,6 +1228,7 @@ export function ActionDock({
         steps={['Card', 'Route', 'Route II', 'Confirm']}
         active={3}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>
           <b style={{ color: 'var(--bb-parchment-bright)' }}>
@@ -1204,7 +1255,13 @@ export function ActionDock({
   const devSteps = ['Card', 'Tiles', 'Confirm']
   if (is('playing.action.developing.selectingCard')) {
     return (
-      <Flow action="Develop" steps={devSteps} active={0} onCancel={cancel}>
+      <Flow
+        action="Develop"
+        steps={devSteps}
+        active={0}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <Note>Discard any card from your hand below.</Note>
       </Flow>
     )
@@ -1218,12 +1275,19 @@ export function ActionDock({
           send({ type: 'SELECT_TILES_FOR_DEVELOP', industryTypes: types })
         }
         onLowest={() => send({ type: 'CONFIRM' })}
+        held={c.selectedCard}
       />
     )
   }
   if (is('playing.action.developing.confirmingDevelop')) {
     return (
-      <Flow action="Develop" steps={devSteps} active={2} onCancel={cancel}>
+      <Flow
+        action="Develop"
+        steps={devSteps}
+        active={2}
+        onCancel={cancel}
+        held={c.selectedCard}
+      >
         <Note>
           Scrapping:{' '}
           <b style={{ color: 'var(--bb-parchment-bright)' }}>
@@ -1251,6 +1315,7 @@ export function ActionDock({
         steps={['Card', 'Goods']}
         active={0}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>Discard any card from your hand below.</Note>
       </Flow>
@@ -1270,6 +1335,7 @@ export function ActionDock({
         steps={['Card', 'Goods', 'Beer']}
         active={2}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>
           Where does the beer for {industryLabel(sale?.industryType ?? 'goods')}{' '}
@@ -1326,6 +1392,7 @@ export function ActionDock({
         steps={['Card', 'Goods']}
         active={1}
         onCancel={sold === 0 ? cancel : undefined}
+        held={c.selectedCard}
       >
         {sales.length === 0 ? (
           <Note>
@@ -1392,6 +1459,7 @@ export function ActionDock({
         steps={['Three cards', 'Confirm']}
         active={picked.length < 3 ? 0 : 1}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>
           Discard three cards from your hand below to take a wild location and a
@@ -1418,6 +1486,7 @@ export function ActionDock({
         steps={['Card', 'Confirm']}
         active={0}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>Discard any card from your hand below.</Note>
       </Flow>
@@ -1430,6 +1499,7 @@ export function ActionDock({
         steps={['Card', 'Confirm']}
         active={1}
         onCancel={cancel}
+        held={c.selectedCard}
       >
         <Note>
           Draw <b style={{ color: 'var(--bb-brass-bright)' }}>£30</b> against

--- a/src/components/cards.tsx
+++ b/src/components/cards.tsx
@@ -3,10 +3,122 @@
 // Real card faces for the hand — parchment stock, region-coloured bands for
 // location cards, engraved industry glyphs for industry cards, and a dark
 // compass-star face for wilds. Replaces v1's text-button hand.
+import { useLayoutEffect, useRef, useState } from 'react'
 import { type CityId, cities } from '~/data/board'
 import { type Card as GameCard, type IndustryType } from '~/data/cards'
 import { CardsIcon, IndustryFragment, WildIcon } from './icons'
 import { CityName } from './locate'
+
+/**
+ * A card name that shrinks to fit the card's fixed width. Long single-word
+ * names (Wolverhampton, Kidderminster) can't wrap and would otherwise spill
+ * past the 108px card edge; this steps the font down until the widest line
+ * fits. Multi-word names still wrap naturally at their spaces, so they keep
+ * the full size — the shrink only kicks in when a word is itself too wide.
+ * Measured in layout px (transform-independent), so the magnified lens copy
+ * fits identically then scales up with the card.
+ */
+function FitText({
+  text,
+  max,
+  min = 9,
+  className,
+}: {
+  text: string
+  max: number
+  min?: number
+  className?: string
+}) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const [size, setSize] = useState(max)
+
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    let s = max
+    el.style.fontSize = `${s}px`
+    // scrollWidth > clientWidth only when an unbreakable word overflows the
+    // box — wrapping lines never do, so multi-word names are left untouched.
+    while (s > min && el.scrollWidth > el.clientWidth) {
+      s -= 0.5
+      el.style.fontSize = `${s}px`
+    }
+    setSize(s)
+  }, [text, max, min])
+
+  return (
+    <span
+      ref={ref}
+      className={className}
+      style={{ fontSize: `${size}px`, display: 'block', width: '100%' }}
+    >
+      {text}
+    </span>
+  )
+}
+
+/**
+ * A location's engraved emblem: a gabled Midlands mill house — arched door,
+ * lit windows — beside a tall works chimney trailing smoke. Reads as a place
+ * AND keeps the industrial theme, in the same single-ink engraving style as
+ * the rest of the card art.
+ */
+function LocationEmblem() {
+  const ink = 'rgba(74,61,41,.82)'
+  const faint = 'rgba(74,61,41,.5)'
+  return (
+    <svg width="50" height="32" viewBox="0 0 50 32" fill="none" aria-hidden>
+      {/* smoke from the chimney */}
+      <path
+        d="M39 10.5c-1.5-1.6 1.2-2.6-.3-4.3M41.4 10.2c-1.3-1.5 1-2.5-.3-4"
+        stroke={faint}
+        strokeWidth="1.1"
+        strokeLinecap="round"
+      />
+      {/* mill house body + gable roof */}
+      <path
+        d="M9 30V16l11-8 11 8v14"
+        fill="rgba(74,61,41,.05)"
+        stroke={ink}
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {/* eaves line */}
+      <path
+        d="M7.5 16.5h25"
+        stroke={ink}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      {/* arched door */}
+      <path
+        d="M17 30v-4.2a3 3 0 0 1 6 0V30"
+        stroke={ink}
+        strokeWidth="1.2"
+        strokeLinecap="round"
+      />
+      {/* windows */}
+      <path
+        d="M11.8 19.5h3.4v3.2h-3.4zM24.8 19.5h3.4v3.2h-3.4z"
+        fill="rgba(74,61,41,.12)"
+        stroke={faint}
+        strokeWidth="1"
+        strokeLinejoin="round"
+      />
+      {/* works chimney + cap */}
+      <path
+        d="M37 30V13.5h4V30M35.8 13.5h6.4"
+        stroke={ink}
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* ground */}
+      <path d="M4 30h43" stroke={ink} strokeWidth="1.4" strokeLinecap="round" />
+    </svg>
+  )
+}
 
 const REGION_BAND: Record<string, string> = {
   blue: '#45719d',
@@ -115,25 +227,12 @@ export function CardFaceContent({ card }: { card: GameCard }) {
           </span>
         </div>
         <div className="flex flex-1 flex-col items-center justify-center gap-2 px-2 text-center">
-          {/* rooftop engraving */}
-          <svg
-            width="44"
-            height="26"
-            viewBox="0 0 44 26"
-            fill="none"
-            aria-hidden
-          >
-            <path
-              d="M4 24V14l6-5v5M10 24V14m0-5 8-6 8 6M18 24V11m8 13V11m6 13V12l6-4v16M2 24h40"
-              stroke="rgba(74,61,41,.75)"
-              strokeWidth="1.4"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </svg>
-          <span className="bb2-display text-[15px] font-bold leading-[1.05] text-[color:var(--bb-ink)]">
-            {name}
-          </span>
+          <LocationEmblem />
+          <FitText
+            text={name}
+            max={15}
+            className="bb2-display font-bold leading-[1.05] text-[color:var(--bb-ink)]"
+          />
           <Flourish />
         </div>
       </div>
@@ -179,9 +278,11 @@ export function CardFaceContent({ card }: { card: GameCard }) {
             </svg>
           ))}
         </div>
-        <span className="bb2-display text-[13px] font-bold leading-[1.1] text-[color:var(--bb-ink)]">
-          {types.map((t) => INDUSTRY_LABEL[t]).join(' or ')}
-        </span>
+        <FitText
+          text={types.map((t) => INDUSTRY_LABEL[t]).join(' or ')}
+          max={13}
+          className="bb2-display font-bold leading-[1.1] text-[color:var(--bb-ink)]"
+        />
         <Flourish />
       </div>
     </div>

--- a/src/components/hand-selection.test.ts
+++ b/src/components/hand-selection.test.ts
@@ -83,6 +83,24 @@ describe('getHandSelection — held card persists through the whole flow', () =>
     ).toEqual({ hint: 'Network — discard a card', selectedIds: [] })
   })
 
+  test('the held hint is order-independent: a deep step reached action-first reads identically', () => {
+    // getHandSelection keys off the current state + selectedCard only — never
+    // how the state was reached — so action-first and card-first converge to
+    // the same "Holding <name>" the instant a card is committed.
+    const cardFirst = getHandSelection(
+      snap('playing.action.networking.selectingLink', {
+        selectedCard: wolverhampton,
+      }),
+    )
+    const actionFirst = getHandSelection(
+      snap('playing.action.networking.confirmingLink', {
+        selectedCard: wolverhampton,
+      }),
+    )
+    expect(cardFirst?.hint).toBe('Holding Wolverhampton')
+    expect(actionFirst?.hint).toBe('Holding Wolverhampton')
+  })
+
   test('outside any action flow → null', () => {
     expect(getHandSelection(snap('playing.turnComplete'))).toBeNull()
     expect(getHandSelection(snap('setup'))).toBeNull()


### PR DESCRIPTION
Follow-up to #41 (round-4 captain feedback). #41 is already merged; this is the remaining item on the same branch.

## The gap
The persistent "Holding X" indicator was there for the **card-first** order but missing in the **action-first** order: pick **Network** first, then select a card during the discard step, and the **dock (action box)** said nothing about the held card. The tray pill was already order-independent; the dock named the card only on the card-first `cardSelected` chooser, never during the flow steps both orders pass through.

## Fix
- New shared `HeldCard` (`Holding <CardChip>`) rendered by the `Flow` wrapper — a `held` prop threaded onto **every** `<Flow>` and `DevelopTilePicker` — and by the `cardSelected` chooser. So the **identical** "Holding \<card\>" banner appears the instant `context.selectedCard` is set, in **either order**, and stays for the whole flow (route / site / confirm / source pickers). Keyed on `selectedCard` only ⇒ order-independent, survives the MP round-trip.
- Removed the old ad-hoc per-step chips ("Playing \<chip\>" on the build industry step, the "Card \<chip\>" confirm-summary line) — they duplicated it with inconsistent wording. One "Holding \<card\>" everywhere now.
- The tray pill (`getHandSelection`) was already correct in both orders — left as is. `data-testid="held-card"` added for e2e.

## Verification
- e2e (`card-first.spec.ts`): action-first order — banner **absent** before a card is picked, **present and identical** after, **persists** through route→confirm; plus a card-first twin asserting the same banner. Order-independence unit test in `hand-selection.test.ts`.
- `pnpm test` (59 files) + lint + typecheck green.
- Browser-verified both orders: dock shows **"Holding Birmingham"** identically; and across actions (Build shows "Holding Brewery").

### Action-first order — dock now shows "Holding [Birmingham]" (was blank before)
![action-first](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-persist-images-4d0eac0/r4-actionfirst-holding-dock.png)

## Preview
https://brass-birmingham-git-fm-brass-ca-ab9238-julius-retzers-projects.vercel.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent “Holding <card>” banner across hotseat action flows.
  * The held-card banner now appears correctly regardless of whether players choose a card or action first.
  * The banner persists through card selection, routing, development, confirmation, and related steps.

* **Tests**
  * Added coverage for action-first and card-first selection flows.
  * Improved assertions to verify the correct held-card banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also on this branch: card-face polish
- **Fit long card names** — long single-word city names (Wolverhampton, Coalbrookdale, Kidderminster) were spilling past the fixed 108px card edge. New `FitText` shrinks the font only when a word is too wide; multi-word names still wrap at their spaces and keep full size. Applied to location + industry names.
- **Nicer location emblem** — replaced the crude rooftop-skyline engraving with an engraved Midlands mill house + smoking works chimney (on-theme for Brass), same single-ink style. No icon library is installed, so a hand-drawn SVG keeps the engraved aesthetic.

![card emblem + fitted name](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-persist-images-4d0eac0/card-emblem-fitname.png)