### PR TITLE
test(e2e): harden last count-snapshot flake in coverage.spec.ts

### DIFF
--- a/e2e/coverage.spec.ts
+++ b/e2e/coverage.spec.ts
@@ -59,7 +59,7 @@ test('Network: claim a canal route by clicking it on the map', async ({
 
   // Legal routes are marked on their fat hit-paths; illegal/ghost ones are not.
   const legalRoute = page.locator('path[data-conn][data-legal="true"]')
-  expect(await legalRoute.count()).toBeGreaterThan(0)
+  await expect(legalRoute).not.toHaveCount(0)
   const firstConn = (await legalRoute.first().getAttribute('data-conn'))!
   await clickRoute(page, firstConn)
 


### PR DESCRIPTION
## What

Hardens the one remaining flaky count-snapshot pattern in `e2e/coverage.spec.ts` — a leftover from the PR #26 round-2 e2e hardening.

In the test **'Network: claim a canal route by clicking it on the map'**, a non-auto-waiting snapshot:

```ts
expect(await legalRoute.count()).toBeGreaterThan(0)
```

`count()` evaluates immediately and does not retry, so it can race the SVG route render and flake. Replaced with the auto-waiting assertion:

```ts
await expect(legalRoute).not.toHaveCount(0)
```

Searched the whole file — this was the only count-snapshot occurrence (line 62). The four `isVisible().catch(() => false)` occurrences are legitimate conditional logic (optional curtain, bounded game-end poll loop) and were intentionally left untouched.

## Context

The rest of the intended PR #26 round-2 hardening already landed via **#33** (`bbb411c`): `takeSale`'s explicit `expectBeerChoice` boolean assertion and the asserted double-link `beer` step. This PR is the final focused, low-risk, e2e-only leftover.

## Validation

- `e2e/coverage.spec.ts`: all 11 tests pass (incl. the changed test).
- Full e2e suite: 42 passed. One **pre-existing, unrelated** failure in `e2e/iron-source.spec.ts:21` — its journal-text pin `/…1 iron from iron works…/` is case-sensitive but the journal renders capitalized "1 Iron from Iron works". That file is untouched by this PR (`git diff` shows only `coverage.spec.ts`) and reproduces identically on clean `main`; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)