### PR TITLE
fix(engine): reject slotless industry placement in the build primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,6 +309,15 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   overbuild) even when another slot is free; enforced in
   `canPlaceOrOverbuildIndustry` + `buildIndustryTile`, pinned by
   `gameStore.canalrule.test.ts`.
+  EXECUTION BACKSTOP (slot-type, fixed 2026-07-21): the placement primitive
+  `buildIndustryTile` now gates on `canPlaceOrOverbuildIndustry` before
+  placing — it previously validated era/overbuild/resources/funds but NOT
+  slot-type compatibility, so a caller reaching it could drop e.g. a Brewery
+  at Birmingham (no brewery slot). The machine guards already reject this; the
+  primitive check is defense-in-depth (a strict no-op for legal builds, which
+  `executeBuildAction` pre-validates identically). The "backstop" that
+  `gameStore.slotguard.test.ts` documented did not actually exist until this;
+  it is now pinned there.
   ONLY THE MAT'S LOWEST TILE IS EVER BUILDABLE (era rule, fixed 2026-07-16):
   rules p.4 step 2 takes the lowest tile, p.7 bars tiles showing the era's
   half-circle — so a barred tile BLOCKS its industry until Develop removes

--- a/src/store/build/buildActions.ts
+++ b/src/store/build/buildActions.ts
@@ -240,10 +240,25 @@ export function buildIndustryTile(
    * from; omit to let the engine pick. */
   ironSources?: IronSource[],
 ): IndustryBuildResult {
+  const location = context.selectedLocation!
+
+  // EXECUTION BACKSTOP: the placement primitive must never drop a tile onto a
+  // city that has no compatible slot (and is not a legal overbuild). The
+  // machine guards + executeBuildAction already reject this, but this is the
+  // last line of defence — without it any unguarded caller (or a future guard
+  // regression) could place e.g. a Brewery at Birmingham, which has no brewery
+  // slot. canPlaceOrOverbuildIndustry covers free-slot, overbuild and the
+  // canal one-tile rule uniformly, so a currently-legal build always passes it.
+  if (!canPlaceOrOverbuildIndustry(context, location, tile.type, tile.level)) {
+    throw new Error(
+      `Cannot build ${tile.type} at ${location}: no compatible slot and not a legal overbuild.`,
+    )
+  }
+
   let updatedPlayersFromResources = context.players
   let updatedCoalMarket = [...context.coalMarket]
   let updatedIronMarket = [...context.ironMarket]
-  
+
   const cost = tile.cost
   let coalCost = 0
   let ironCost = 0

--- a/src/store/gameStore.slotguard.test.ts
+++ b/src/store/gameStore.slotguard.test.ts
@@ -1,12 +1,18 @@
 // Captain bug report 2026-07-15: the Build wizard reached an ENABLED
-// confirm for BREWERY at BIRMINGHAM (no brewery slot). The engine's
-// execution backstop rejected it, but the machine's location-card
-// transition bypassed canSelectIndustryType (guard order), so
-// `can(SELECT_INDUSTRY_TYPE)` said yes and surfaces without the shell's
-// deep probes (multiplayer) showed a live confirm button. These tests pin
-// the fixed guard on every wizard path.
+// confirm for BREWERY at BIRMINGHAM (no brewery slot). The machine's
+// location-card transition bypassed canSelectIndustryType (guard order),
+// so `can(SELECT_INDUSTRY_TYPE)` said yes and surfaced (multiplayer, no
+// deep probes) as a live confirm button. These tests pin the fixed guard
+// on every wizard path.
+//
+// Follow-up 2026-07-21: the "execution backstop" the original comment
+// relied on did NOT exist — buildIndustryTile (the placement primitive)
+// validated era/overbuild/resources/funds but NOT slot-type
+// compatibility, so any caller reaching it would drop a brewery onto
+// Birmingham. It now rejects a slotless placement; pinned below.
 import { describe, expect, it } from 'vitest'
 import { createActor } from 'xstate'
+import { buildIndustryTile } from './build/buildActions'
 import { gameStore } from './gameStore'
 
 const PLAYERS = [
@@ -115,18 +121,87 @@ describe('build wizard slot guard (brewery@Birmingham bug)', () => {
     a.stop()
   })
 
-  it('execution backstop still rejects an illegal build reached by force', () => {
-    // Belt and braces: even if a future guard regression lets the state
-    // through, executeBuildAction must refuse and build nothing.
+  it('wild-location card: brewery is refused at every slotless city', () => {
+    // Wild location can pick ANY city, so it must still be blocked from a
+    // brewery at a city with no brewery slot (Birmingham).
+    const a = startWithHand([{ id: 'wl_1', type: 'wild_location' }])
+    a.send({ type: 'BUILD' } as never)
+    a.send({ type: 'SELECT_CARD', cardId: 'wl_1' } as never)
+    a.send({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'brewery' } as never)
+    expect(snap(a).can({ type: 'SELECT_LOCATION', cityId: 'birmingham' })).toBe(
+      false,
+    )
+    // ...but a real brewery city is reachable.
+    expect(snap(a).can({ type: 'SELECT_LOCATION', cityId: 'burton' })).toBe(
+      true,
+    )
+    a.stop()
+  })
+
+  it('placement primitive REJECTS brewery@Birmingham (the real execution backstop)', () => {
+    // buildIndustryTile is the tile-placement primitive: era, overbuild,
+    // resources and funds were validated, but slot-type compatibility was
+    // NOT — so calling it with a brewery + Birmingham silently placed a
+    // brewery on a city that has no brewery slot. It must throw instead.
+    const a = startWithHand([])
+    const ctx = a.getSnapshot().context as never as {
+      players: Array<{
+        hand: unknown[]
+        industryTilesOnMat: Record<string, Array<{ tile: unknown }>>
+      }>
+    }
+    const player = ctx.players[0]!
+    const breweryTile = player.industryTilesOnMat.brewery![0]!.tile
+    const context = {
+      ...ctx,
+      era: 'canal',
+      selectedLocation: 'birmingham',
+      selectedIndustryTile: breweryTile,
+    } as never
+
+    expect(() =>
+      buildIndustryTile(context, player as never, breweryTile as never, [], []),
+    ).toThrow(/no compatible slot/)
+    a.stop()
+  })
+
+  it('placement primitive still allows a legal Birmingham build (cotton)', () => {
+    const a = startWithHand([])
+    const ctx = a.getSnapshot().context as never as {
+      players: Array<{
+        hand: unknown[]
+        industryTilesOnMat: Record<string, Array<{ tile: unknown }>>
+      }>
+    }
+    const player = ctx.players[0]!
+    const cottonTile = player.industryTilesOnMat.cotton![0]!.tile
+    const context = {
+      ...ctx,
+      era: 'canal',
+      selectedCard: locationCard('birmingham_x', 'birmingham'),
+      selectedLocation: 'birmingham',
+      selectedIndustryTile: cottonTile,
+    } as never
+
+    const result = buildIndustryTile(
+      context,
+      player as never,
+      cottonTile as never,
+      [],
+      [],
+    )
+    expect(
+      result.updatedPlayer.industries.some(
+        (i) => i.type === 'cotton' && i.location === 'birmingham',
+      ),
+    ).toBe(true)
+    a.stop()
+  })
+
+  it('execution backstop: a full CONFIRM of a legal build still succeeds', () => {
     const a = startWithHand([locationCard('birmingham_x', 'birmingham')])
     a.send({ type: 'BUILD' } as never)
     a.send({ type: 'SELECT_CARD', cardId: 'birmingham_x' } as never)
-    // cotton passes the guard; swap the tile via the wild-location route is
-    // not possible here, so assert the CONFIRM validation directly through
-    // a legal-then-illegal sequence: pick cotton, confirm at birmingham
-    // succeeds — then a second brewery attempt at birmingham (fresh actor)
-    // is covered by the first test. Here we only pin that CONFIRM with a
-    // slotless combination surfaces lastError instead of building.
     a.send({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'cotton' } as never)
     a.send({ type: 'CONFIRM' } as never)
     expect(snap(a).context.lastError).toBeNull()


### PR DESCRIPTION
## Bug

A Brewery could be placed at **Birmingham**, which has **no brewery slot** on the board. Screenshot evidence from a real game.

## Diagnosis

The board data is correct — Birmingham's slots allow only `cotton`/`manufacturer`/`iron`. The Build wizard's machine guards (`canSelectIndustryType`, `canSelectLocation`) and `executeBuildAction`'s pre-check (`validateIndustrySlotAvailabilityResult` → `canPlaceOrOverbuildIndustry`) all correctly reject brewery@Birmingham on every card path (location, industry, wild-location, wild-industry — verified).

The hole was the **tile-placement primitive** `buildIndustryTile`: it validated era, overbuild eligibility, resources and funds — but **never slot-type compatibility**. `canCityAccommodateIndustryType` was only used there to decide *free-slot-vs-overbuild*, not as a gate. When no free slot exists and there's no same-type tile to overbuild, `canOverbuildIndustry` returns `{canOverbuild: true}` (its "nothing to overbuild" branch), so the primitive placed the tile anyway.

`slotguard.test.ts` even documented an "execution backstop" that **did not actually exist** — its test 4 only exercised a *legal* build.

## Reproduction (now a committed regression test)

Calling `buildIndustryTile` with a brewery tile + `selectedLocation: 'birmingham'` placed a brewery on Birmingham. It now throws `no compatible slot`.

## Fix

Root cause, all cities/types (not just Birmingham): gate the primitive on `canPlaceOrOverbuildIndustry`, which covers free-slot, legal-overbuild and the canal one-tile rule uniformly. Every currently-legal build already satisfies it (the same check runs in `executeBuildAction` first), so this is a **strict no-op for legal play** and a hard reject for illegal placements — defense-in-depth at the execution layer.

## Tests
- ✅ Primitive rejects brewery@Birmingham (the real backstop)
- ✅ Primitive still builds cotton@Birmingham (valid Birmingham industry)
- ✅ Brewery@Burton still builds end-to-end (valid brewery city)
- ✅ Wild-location brewery refused at slotless cities, allowed at Burton
- ✅ Full CONFIRM of a legal Birmingham build still succeeds
- ✅ Full unit suite: 564 passed / 4 skipped; lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)