### PR TITLE
fix(mp): stop the online game header overflowing on phone widths

### DIFF
--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -742,12 +742,12 @@ function SeatsButton({
   )
 }
 
-function ShareLink() {
+function ShareLink({ className }: { className?: string }) {
   const [copied, setCopied] = useState(false)
   return (
     <button
       type="button"
-      className="bb2-chip"
+      className={`bb2-chip ${className ?? ''}`}
       data-testid="share-link"
       style={{ cursor: 'pointer', textTransform: 'none', letterSpacing: 0 }}
       onClick={() => {
@@ -757,7 +757,13 @@ function ShareLink() {
       }}
       title="Copy the invite link"
     >
-      {copied ? 'Link copied!' : window.location.href}
+      {/* The invite URL can be long (token + a deploy-preview host). Let it
+          ellipsis-truncate on phones so it can never force the masthead wider
+          than the viewport; the full URL still shows from lg up (unchanged)
+          and is always copied in full. */}
+      <span className="min-w-0 truncate">
+        {copied ? 'Link copied!' : window.location.href}
+      </span>
     </button>
   )
 }
@@ -1308,7 +1314,7 @@ function MpTable({
           >
             You are {me.name}
           </span>
-          <div className="ml-auto flex items-center gap-3">
+          <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2 lg:flex-nowrap lg:gap-3">
             {inFlight && (
               <span className="bb2-sync-pill" data-testid="mp-syncing">
                 <span className="bb2-sync-dot" />
@@ -1333,7 +1339,7 @@ function MpTable({
             {you === 0 && (
               <SeatsButton token={token} creds={creds} seats={view.seats} />
             )}
-            <ShareLink />
+            <ShareLink className="max-w-[52vw] sm:max-w-[240px] lg:max-w-none" />
           </div>
         </header>
 


### PR DESCRIPTION
## Problem

On phone-width viewports the **online multiplayer** game header overflowed horizontally, laying the whole page out at ~420px on a 360/390px device. The breadcrumb, player rail and the left edge of the action dock were clipped off-screen — a hard blocker for mobile multiplayer.

### Root cause

The masthead's right-hand `.ml-auto` cluster (Turn-alerts + Seats + the invite-link chip) was an **unshrinkable** flex row. `ShareLink` rendered the full `window.location.href` inside a `white-space: nowrap` `.bb2-chip` with no max-width, so its min-content (~404px even for a short localhost token; larger for a deploy-preview host) forced the page wider than the viewport. `flex-wrap` on the header couldn't help — a single child was itself wider than the phone.

## Fix (header-scoped, desktop-safe)

- **ShareLink** truncates its URL with an ellipsis inside a `min-w-0 truncate` span and accepts an optional `className`. The header caps it below `lg` (`max-w-[52vw] sm:max-w-[240px]`) and lifts the cap at `lg` (`lg:max-w-none`) so **desktop still shows the full link, unchanged**. The full URL is always copied.
- The **`.ml-auto` cluster** gains `min-w-0 flex-wrap justify-end` so its buttons/chip wrap and right-align on narrow screens, and stays a single line from `lg` up (`lg:flex-nowrap`).

The player rail's clipped-right appearance in the "before" shot is a deliberate `overflow-x-auto` swipe strip — it does not force page width and is unchanged.

## Verification

- No horizontal overflow at **360 / 390 / 430px** (`documentElement.scrollWidth === visualViewport.width`).
- Breadcrumb + full action dock visible and tappable.
- Desktop (≥1024px) header measured single-line, full URL — visually identical.
- `pnpm lint`, `pnpm typecheck`, component unit tests all green.

## Before / After (360px)

| Before | After |
|---|---|
| ![before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-mp-mobile-header-images/mp-header-before-360.png) | ![after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-mp-mobile-header-images/mp-header-after-360.png) |

## Desktop unchanged (1280px)

![desktop](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-mp-mobile-header-images/mp-header-after-desktop.png)

_Note: `e2e/iron-source.spec.ts:21` has a known pre-existing failure, tracked separately._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiplayer invite-link display on smaller screens by truncating long URLs while preserving full-link copying.
  * Adjusted multiplayer header action layout to better fit available space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->