### PR TITLE
feat(setup): gate Versus-AI option on real server AI availability

### DIFF
--- a/src/app/api/mp/ai-available/route.test.ts
+++ b/src/app/api/mp/ai-available/route.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { GET } from './route'
+
+const saved = {
+  key: process.env.ANTHROPIC_API_KEY,
+  mock: process.env.BB_AI_MOCK,
+  vercel: process.env.VERCEL_ENV,
+}
+
+function restore(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+afterEach(() => {
+  restore('ANTHROPIC_API_KEY', saved.key)
+  restore('BB_AI_MOCK', saved.mock)
+  restore('VERCEL_ENV', saved.vercel)
+})
+
+async function available(): Promise<boolean> {
+  const body = (await GET().json()) as { available: boolean }
+  return body.available
+}
+
+describe('GET /api/mp/ai-available', () => {
+  it('reports available when a key is present (non-prod)', async () => {
+    delete process.env.VERCEL_ENV
+    delete process.env.BB_AI_MOCK
+    process.env.ANTHROPIC_API_KEY = 'sk-test'
+    expect(await available()).toBe(true)
+  })
+
+  it('reports available in mock mode without a key', async () => {
+    delete process.env.VERCEL_ENV
+    delete process.env.ANTHROPIC_API_KEY
+    process.env.BB_AI_MOCK = '1'
+    expect(await available()).toBe(true)
+  })
+
+  it('reports unavailable with no key and no mock', async () => {
+    delete process.env.VERCEL_ENV
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.BB_AI_MOCK
+    expect(await available()).toBe(false)
+  })
+
+  it('reports unavailable in production even with a key', async () => {
+    process.env.VERCEL_ENV = 'production'
+    process.env.ANTHROPIC_API_KEY = 'sk-test'
+    process.env.BB_AI_MOCK = '1'
+    expect(await available()).toBe(false)
+  })
+
+  it('never leaks the key value in the response', async () => {
+    delete process.env.VERCEL_ENV
+    process.env.ANTHROPIC_API_KEY = 'sk-super-secret'
+    const text = await GET().text()
+    expect(text).not.toContain('sk-super-secret')
+  })
+})

--- a/src/app/api/mp/ai-available/route.ts
+++ b/src/app/api/mp/ai-available/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { aiOpponentsAvailable } from '~/lib/features'
+import { hasAnthropicKey, isMockMode } from '~/server/ai/provider'
+
+export const runtime = 'nodejs'
+
+// Public boolean the charter reads to decide whether to offer "Versus AI".
+// Exposes ONLY the flag — the ANTHROPIC_API_KEY value never leaves the server.
+export function GET() {
+  return NextResponse.json({
+    available: aiOpponentsAvailable({
+      vercelEnv: process.env.VERCEL_ENV,
+      hasKey: hasAnthropicKey(),
+      mock: isMockMode(),
+    }),
+  })
+}

--- a/src/components/setup-screen.tsx
+++ b/src/components/setup-screen.tsx
@@ -4,15 +4,12 @@
 // founding a company against server-driven AI opponents.
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { aiOpponentsEnabled } from '~/lib/features'
 import { AI_TIERS, type AiTierId } from '~/server/ai/types'
 import { type Player } from '~/store/gameStore'
 import { ActivityLine } from './activity-line'
 import { PLAYER_FILL } from './board/board-map'
-
-const AI_ENABLED = aiOpponentsEnabled(process.env.NEXT_PUBLIC_VERCEL_ENV)
 
 const COLORS: Player['color'][] = ['red', 'blue', 'green', 'yellow']
 const CHARACTERS: Player['character'][] = [
@@ -53,6 +50,25 @@ export function SetupScreen({
     'apprentice',
   ])
   const [creating, setCreating] = useState(false)
+  // Whether the server can actually seat AI rivals (needs an LLM key, or the
+  // offline mock, and not production). Default hidden until the server confirms
+  // — the key value never crosses to the client, only this boolean does.
+  const [aiEnabled, setAiEnabled] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    fetch('/api/mp/ai-available')
+      .then((res) => (res.ok ? res.json() : { available: false }))
+      .then((body: { available?: boolean }) => {
+        if (alive) setAiEnabled(!!body.available)
+      })
+      .catch(() => {
+        // Network hiccup fetching the flag → leave AI hidden (safe default).
+      })
+    return () => {
+      alive = false
+    }
+  }, [])
 
   const createOnline = async () => {
     setCreating(true)
@@ -130,7 +146,7 @@ export function SetupScreen({
 
         <div
           className={
-            AI_ENABLED ? 'grid grid-cols-3 gap-2' : 'grid grid-cols-2 gap-2'
+            aiEnabled ? 'grid grid-cols-3 gap-2' : 'grid grid-cols-2 gap-2'
           }
         >
           <button
@@ -155,7 +171,7 @@ export function SetupScreen({
               Play online
             </span>
           </button>
-          {AI_ENABLED && (
+          {aiEnabled && (
             <button
               type="button"
               className="bb2-option justify-center py-2"

--- a/src/lib/features.test.ts
+++ b/src/lib/features.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { aiOpponentsEnabled } from './features'
+import { aiOpponentsAvailable, aiOpponentsEnabled } from './features'
 
 describe('aiOpponentsEnabled', () => {
   it('is disabled in production', () => {
@@ -16,5 +16,39 @@ describe('aiOpponentsEnabled', () => {
 
   it('is enabled when unset (local dev, CI)', () => {
     expect(aiOpponentsEnabled(undefined)).toBe(true)
+  })
+})
+
+describe('aiOpponentsAvailable', () => {
+  it('is available when the feature is enabled and a key is present', () => {
+    expect(
+      aiOpponentsAvailable({ vercelEnv: undefined, hasKey: true, mock: false }),
+    ).toBe(true)
+  })
+
+  it('is available in mock mode without a key', () => {
+    expect(
+      aiOpponentsAvailable({ vercelEnv: undefined, hasKey: false, mock: true }),
+    ).toBe(true)
+  })
+
+  it('is unavailable when neither a key nor mock mode is present', () => {
+    expect(
+      aiOpponentsAvailable({
+        vercelEnv: undefined,
+        hasKey: false,
+        mock: false,
+      }),
+    ).toBe(false)
+  })
+
+  it('is unavailable in production even with a key', () => {
+    expect(
+      aiOpponentsAvailable({
+        vercelEnv: 'production',
+        hasKey: true,
+        mock: true,
+      }),
+    ).toBe(false)
   })
 })

--- a/src/lib/features.ts
+++ b/src/lib/features.ts
@@ -5,3 +5,16 @@
 export function aiOpponentsEnabled(vercelEnv: string | undefined): boolean {
   return vercelEnv !== 'production'
 }
+
+// Whether AI opponents can ACTUALLY be created right now. On top of the
+// production feature gate above, the server needs an LLM key (ANTHROPIC_API_KEY)
+// or the offline mock provider (BB_AI_MOCK=1). Pure so it stays unit-testable
+// and reads no secrets itself — the caller passes booleans derived server-side;
+// the key VALUE never reaches the client, only this flag does.
+export function aiOpponentsAvailable(opts: {
+  vercelEnv: string | undefined
+  hasKey: boolean
+  mock: boolean
+}): boolean {
+  return aiOpponentsEnabled(opts.vercelEnv) && (opts.hasKey || opts.mock)
+}


### PR DESCRIPTION
## What

Hide the "Versus AI" charter option unless the server can actually seat AI rivals. Previously it showed whenever the production feature flag allowed it and only failed at game-creation time when no LLM key was present.

## Approach

- **Pure combinator** `aiOpponentsAvailable({vercelEnv, hasKey, mock})` in `src/lib/features.ts`: available = production feature flag enabled **AND** (`ANTHROPIC_API_KEY` present **OR** `BB_AI_MOCK=1`). Reads no secrets itself — callers pass server-derived booleans.
- **Boolean-only endpoint** `GET /api/mp/ai-available` returns `{ available }`. The `ANTHROPIC_API_KEY` value never crosses to the client — only the flag does.
- **SetupScreen** fetches the flag on mount, defaulting **hidden** until the server confirms. No key on the client, no dead AI UI / validation when unavailable; human-only flows are unchanged.
- **Stale-client rejection** already exists server-side: `createGame` throws a friendly `AI opponents are not available: the server has no ANTHROPIC_API_KEY.` which the create route returns as a clean error.

## Acceptance criteria

- Key unset → option absent from UI, server rejects AI-game creation, everything else unchanged. ✅
- Key set (local dev / mock) → option appears and works as before. ✅
- Test coverage: availability combinator + endpoint (incl. an assertion that the key value never leaks in the response). ✅
- Suite green (`pnpm typecheck`, `pnpm lint`, new tests). ✅

No API key was added/copied/logged anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)