### PR TITLE
feat(ui): auto-pan the map to a hovered location card's off-viewport city

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -485,8 +485,17 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   `LocateMark`, deliberately distinct from the brass legal pulse;
   reduced-motion drops the ping). Journal names resolve via `segmentPlaces`
   (journal-model.ts) — by raw city ID, never display-name matching. The state
-  is ONE `cityId|null` on purpose so brass-card-map-sync (pan-into-view for
-  hovered cards) can reuse it.
+  is ONE `cityId|null` on purpose.
+- CARD-MAP-SYNC (2026-07-21): hovering a LOCATION card in the hand tray
+  auto-pans the map (slight zoom-out, animated, debounced) when its city is
+  off-viewport — BoardMap's `focusCity` prop, fed by `focusCityFor`
+  (`hover-highlight.ts`) on both surfaces. DELIBERATE: separate from
+  `locatedCity` (name hover must never move the map); industry/wild cards
+  never pan; no snap-back on hover end; user gestures + board pick steps
+  suppress it. Decision logic is pure in `board/pan-into-view.ts`
+  (trigger/settle hysteresis — pinned by `pan-into-view.test.ts`); the
+  animated application (rAF + reduced-motion instant jump) lives in
+  `board-map.tsx`.
 
 ## AI opponents (added 2026-07-15)
 

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -439,9 +439,14 @@ export function BoardMap({
   const pickingLink = legalLinks !== null
 
   useEffect(() => {
+    // Never yank the map while the player is aiming a board pick — and kill
+    // an animation already in flight when the picker opens under it (checked
+    // before focusCity: the hover may already have ended by then).
+    if (pickingCity || pickingLink) {
+      stopAutoPan()
+      return
+    }
     if (!focusCity) return
-    // Never yank the map while the player is aiming a board pick.
-    if (pickingCity || pickingLink) return
     const pos = cityPos[focusCity as CityId]
     if (!pos) return
     const timer = setTimeout(() => {

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -17,6 +17,12 @@ import { type Merchant, type Player } from '~/store/gameStore'
 import { GAME_ICONS } from '../gameicons-data'
 import { IndustryFragment } from '../icons'
 import { VIEW_H, VIEW_W, cityPos, linkKey, routeBow } from './board-data'
+import {
+  FOCUS_PAN_ANIMATION_MS,
+  FOCUS_PAN_DEBOUNCE_MS,
+  easeInOutCubic,
+  planPanToCity,
+} from './pan-into-view'
 
 /* ---------------- palette (mirrors theme.css) ---------------- */
 
@@ -199,6 +205,14 @@ export interface BoardMapProps {
    */
   locatedCity?: string | null
   /**
+   * Card-hover map sync: the city a hovered hand card names (location cards
+   * only). When it sits outside the current viewport the map pans — with a
+   * slight zoom-out — to bring it into view (debounced; suppressed while a
+   * gesture or a board pick step is active). The map stays where it panned
+   * when the hover ends. Decision logic in `pan-into-view.ts`.
+   */
+  focusCity?: string | null
+  /**
    * Game-end scoring overlay: VP earned per city and per route by ONE player
    * (null = off). Annotated places get a brass VP roundel; everything else
    * recedes, so the score reads off the board. Links are destroyed by era
@@ -229,6 +243,7 @@ export function BoardMap({
   networkColor = null,
   hoverCities = null,
   locatedCity = null,
+  focusCity = null,
   vpAnnotations = null,
   vpColor = null,
 }: BoardMapProps) {
@@ -248,6 +263,7 @@ export function BoardMap({
     if (!svg) return
     const onWheel = (e: WheelEvent) => {
       e.preventDefault()
+      stopAutoPan()
       setVb((v) => {
         const rect = svg.getBoundingClientRect()
         const fx = (e.clientX - rect.left) / rect.width
@@ -296,6 +312,7 @@ export function BoardMap({
 
   const onPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.pointerType === 'mouse' && e.button !== 0) return
+    stopAutoPan()
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
     if (pointers.current.size === 2) {
       // second finger down — switch from pan to pinch (no click expected
@@ -362,13 +379,86 @@ export function BoardMap({
   }
   const wasDrag = () => drag.current?.moved ?? false
 
-  const zoomBy = (scale: number) =>
-    setVb((v) => {
+  const zoomBy = (scale: number) => {
+    stopAutoPan()
+    return setVb((v) => {
       const w = Math.min(Math.max(v.w * scale, VIEW_W / 6), VIEW_W * 1.3)
       const h = (w / VIEW_W) * VIEW_H
       return { x: v.x + (v.w - w) / 2, y: v.y + (v.h - h) / 2, w, h }
     })
-  const resetView = () => setVb({ x: 0, y: 0, w: VIEW_W, h: VIEW_H })
+  }
+  const resetView = () => {
+    stopAutoPan()
+    setVb({ x: 0, y: 0, w: VIEW_W, h: VIEW_H })
+  }
+
+  /* ---- card-hover map sync (auto-pan to a hovered card's city) ---- */
+
+  // Latest vb without retriggering the focus effect on every user pan.
+  const vbRef = useRef(vb)
+  vbRef.current = vb
+  const autoPanFrame = useRef<number | null>(null)
+
+  function stopAutoPan() {
+    if (autoPanFrame.current !== null) {
+      cancelAnimationFrame(autoPanFrame.current)
+      autoPanFrame.current = null
+    }
+  }
+
+  const animateVbTo = (target: {
+    x: number
+    y: number
+    w: number
+    h: number
+  }) => {
+    stopAutoPan()
+    // Reduced motion: land instantly instead of animating (the locate mark
+    // drops its ping under the same preference).
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      setVb(target)
+      return
+    }
+    const from = vbRef.current
+    const start = performance.now()
+    const step = (now: number) => {
+      const t = Math.min((now - start) / FOCUS_PAN_ANIMATION_MS, 1)
+      const k = easeInOutCubic(t)
+      setVb({
+        x: from.x + (target.x - from.x) * k,
+        y: from.y + (target.y - from.y) * k,
+        w: from.w + (target.w - from.w) * k,
+        h: from.h + (target.h - from.h) * k,
+      })
+      autoPanFrame.current = t < 1 ? requestAnimationFrame(step) : null
+    }
+    autoPanFrame.current = requestAnimationFrame(step)
+  }
+
+  const pickingCity = legalCities !== null
+  const pickingLink = legalLinks !== null
+
+  useEffect(() => {
+    if (!focusCity) return
+    // Never yank the map while the player is aiming a board pick.
+    if (pickingCity || pickingLink) return
+    const pos = cityPos[focusCity as CityId]
+    if (!pos) return
+    const timer = setTimeout(() => {
+      // A gesture in progress wins over the auto-pan.
+      if (pointers.current.size > 0) return
+      const target = planPanToCity(vbRef.current, pos, {
+        w: VIEW_W,
+        h: VIEW_H,
+      })
+      if (target) animateVbTo(target)
+    }, FOCUS_PAN_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+    // animateVbTo is stable in behaviour (refs + setState); listing it would
+    // retrigger the debounce on every render.
+  }, [focusCity, pickingCity, pickingLink])
+
+  useEffect(() => stopAutoPan, [])
 
   /* ---- derived game data ---- */
 
@@ -411,9 +501,6 @@ export function BoardMap({
       linkKey(l.to, l.from),
     ]),
   )
-
-  const pickingCity = legalCities !== null
-  const pickingLink = legalLinks !== null
 
   /* ---------------- render ---------------- */
 

--- a/src/components/board/pan-into-view.test.ts
+++ b/src/components/board/pan-into-view.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type ViewBox,
+  easeInOutCubic,
+  isComfortablyVisible,
+  planPanToCity,
+} from './pan-into-view'
+
+const BOUNDS = { w: 1600, h: 1150 }
+const FULL: ViewBox = { x: 0, y: 0, w: 1600, h: 1150 }
+
+/** A zoomed-in view of the top-left quadrant. */
+const ZOOMED: ViewBox = { x: 0, y: 0, w: 800, h: 575 }
+
+function assertComfortable(vb: ViewBox, pt: { x: number; y: number }) {
+  expect(isComfortablyVisible(vb, pt)).toBe(true)
+}
+
+describe('isComfortablyVisible', () => {
+  it('a centred city is visible', () => {
+    expect(isComfortablyVisible(ZOOMED, { x: 400, y: 287 })).toBe(true)
+  })
+
+  it('a city outside the viewBox is not visible', () => {
+    expect(isComfortablyVisible(ZOOMED, { x: 1200, y: 900 })).toBe(false)
+  })
+
+  it('a city just inside the edge margin counts as off-view', () => {
+    // margin = 8% of 800 = 64 → x=30 is inside the box but within the margin
+    expect(isComfortablyVisible(ZOOMED, { x: 30, y: 287 })).toBe(false)
+  })
+
+  it('every city is visible at the full-board view', () => {
+    assertComfortable(FULL, { x: 800, y: 575 })
+    assertComfortable(FULL, { x: 150, y: 150 })
+    assertComfortable(FULL, { x: 1450, y: 1000 })
+  })
+})
+
+describe('planPanToCity', () => {
+  it('returns null when the city is already comfortably visible (no move)', () => {
+    expect(planPanToCity(ZOOMED, { x: 400, y: 287 }, BOUNDS)).toBeNull()
+  })
+
+  it('returns null at the default full-board view — nothing can be off it', () => {
+    expect(planPanToCity(FULL, { x: 1450, y: 1000 }, BOUNDS)).toBeNull()
+  })
+
+  it('pans and slightly zooms out to reach an off-view city', () => {
+    const target = planPanToCity(ZOOMED, { x: 1200, y: 900 }, BOUNDS)
+    expect(target).not.toBeNull()
+    // slight zoom-out: wider than before, but NOT reset to full board
+    expect(target!.w).toBeGreaterThan(ZOOMED.w)
+    expect(target!.w).toBeLessThan(BOUNDS.w)
+    // aspect ratio preserved
+    expect(target!.h / target!.w).toBeCloseTo(ZOOMED.h / ZOOMED.w, 5)
+    // the city is comfortably visible in the destination
+    assertComfortable(target!, { x: 1200, y: 900 })
+  })
+
+  it('the destination is stable: re-planning from it is a no-op (hysteresis)', () => {
+    const pt = { x: 1200, y: 900 }
+    const target = planPanToCity(ZOOMED, pt, BOUNDS)
+    expect(target).not.toBeNull()
+    expect(planPanToCity(target!, pt, BOUNDS)).toBeNull()
+  })
+
+  it('never zooms out past the full-board width', () => {
+    const wide: ViewBox = { x: 0, y: 0, w: 1400, h: 1006.25 }
+    const target = planPanToCity(wide, { x: 1550, y: 1100 }, BOUNDS)
+    expect(target).not.toBeNull()
+    expect(target!.w).toBeLessThanOrEqual(BOUNDS.w)
+  })
+
+  it('a view panned away at 1:1 zoom pans back without zooming in', () => {
+    const pannedAway: ViewBox = { x: 1600, y: 0, w: 1600, h: 1150 }
+    const target = planPanToCity(pannedAway, { x: 200, y: 200 }, BOUNDS)
+    expect(target).not.toBeNull()
+    expect(target!.w).toBe(1600) // no zoom change either way
+    assertComfortable(target!, { x: 200, y: 200 })
+  })
+
+  it('pans the minimum distance: only the offending axis moves', () => {
+    // city is off to the right but vertically centred — y should barely move
+    const vb: ViewBox = { x: 0, y: 0, w: 800, h: 575 }
+    const pt = { x: 1100, y: 287 }
+    const target = planPanToCity(vb, pt, BOUNDS)
+    expect(target).not.toBeNull()
+    // the zoom-out recentre shifts y by (h' - h)/2 at most; no pan beyond that
+    const recentreShift = (target!.h - vb.h) / 2
+    expect(Math.abs(target!.y - (vb.y - recentreShift))).toBeLessThan(0.001)
+    assertComfortable(target!, pt)
+  })
+})
+
+describe('easeInOutCubic', () => {
+  it('anchors at 0 and 1, midpoint at 0.5, monotonic', () => {
+    expect(easeInOutCubic(0)).toBe(0)
+    expect(easeInOutCubic(1)).toBe(1)
+    expect(easeInOutCubic(0.5)).toBeCloseTo(0.5, 5)
+    let prev = 0
+    for (let t = 0; t <= 1.0001; t += 0.05) {
+      const v = easeInOutCubic(Math.min(t, 1))
+      expect(v).toBeGreaterThanOrEqual(prev)
+      prev = v
+    }
+  })
+})

--- a/src/components/board/pan-into-view.test.ts
+++ b/src/components/board/pan-into-view.test.ts
@@ -46,6 +46,27 @@ describe('planPanToCity', () => {
     expect(planPanToCity(FULL, { x: 1450, y: 1000 }, BOUNDS)).toBeNull()
   })
 
+  it('a board-EDGE city at the full-board view is a no-move, not an overshoot', () => {
+    // Warrington-like: inside the board but within the trigger margin. The
+    // bounds clamp collapses the plan back to the current view → null,
+    // instead of panning past the board edge into void.
+    expect(planPanToCity(FULL, { x: 545, y: 78 }, BOUNDS)).toBeNull()
+    expect(planPanToCity(FULL, { x: 40, y: 1120 }, BOUNDS)).toBeNull()
+  })
+
+  it('never pans past the board edge when reaching an edge city zoomed in', () => {
+    // Coalbrookdale-like far-west city from a zoomed east view: the settle
+    // margin would put x at ~-70; the clamp pins it at the board edge.
+    const east: ViewBox = { x: 614, y: 193, w: 830, h: 597 }
+    const target = planPanToCity(east, { x: 158, y: 615 }, BOUNDS)
+    expect(target).not.toBeNull()
+    expect(target!.x).toBeGreaterThanOrEqual(0)
+    expect(target!.y).toBeGreaterThanOrEqual(0)
+    expect(target!.x + target!.w).toBeLessThanOrEqual(BOUNDS.w + 0.001)
+    expect(target!.y + target!.h).toBeLessThanOrEqual(BOUNDS.h + 0.001)
+    assertComfortable(target!, { x: 158, y: 615 })
+  })
+
   it('pans and slightly zooms out to reach an off-view city', () => {
     const target = planPanToCity(ZOOMED, { x: 1200, y: 900 }, BOUNDS)
     expect(target).not.toBeNull()
@@ -82,8 +103,8 @@ describe('planPanToCity', () => {
 
   it('pans the minimum distance: only the offending axis moves', () => {
     // city is off to the right but vertically centred — y should barely move
-    const vb: ViewBox = { x: 0, y: 0, w: 800, h: 575 }
-    const pt = { x: 1100, y: 287 }
+    const vb: ViewBox = { x: 100, y: 200, w: 800, h: 575 }
+    const pt = { x: 1200, y: 487 }
     const target = planPanToCity(vb, pt, BOUNDS)
     expect(target).not.toBeNull()
     // the zoom-out recentre shifts y by (h' - h)/2 at most; no pan beyond that

--- a/src/components/board/pan-into-view.ts
+++ b/src/components/board/pan-into-view.ts
@@ -82,5 +82,29 @@ export function planPanToCity(
   if (pt.y < y + my) y = pt.y - my
   else if (pt.y > y + h - my) y = pt.y - h + my
 
+  // Never pan past the board edge into void: a city that LIVES inside the
+  // settle margin (board-edge cities) is served by the nearest in-bounds
+  // view, not by overshooting. When the view is wider than the board the
+  // valid range inverts — the board then floats with void on both sides.
+  x = clampAxis(x, w, bounds.w)
+  y = clampAxis(y, h, bounds.h)
+
+  // Clamping can collapse the plan to where we already are (an edge city
+  // hovered at the full-board view) — that is "no move", not a pan.
+  if (
+    Math.abs(x - vb.x) < 0.5 &&
+    Math.abs(y - vb.y) < 0.5 &&
+    Math.abs(w - vb.w) < 0.5
+  ) {
+    return null
+  }
+
   return { x, y, w, h }
+}
+
+/** Clamp a viewBox origin so the view stays over the board. */
+function clampAxis(v: number, size: number, boundSize: number): number {
+  const lo = Math.min(0, boundSize - size)
+  const hi = Math.max(0, boundSize - size)
+  return Math.min(Math.max(v, lo), hi)
 }

--- a/src/components/board/pan-into-view.ts
+++ b/src/components/board/pan-into-view.ts
@@ -1,0 +1,86 @@
+// Card-hover map sync: when the player hovers a hand card whose city sits
+// outside the current map viewport, the map pans (and zooms out slightly)
+// to bring that city into view. This module is the PURE decision half —
+// given the current SVG viewBox and the city's board position it answers
+// "should the map move, and to where?" so the trigger logic is unit-testable
+// without a DOM. The animated application lives in `board-map.tsx`.
+//
+// Hysteresis by design: a city counts as "already visible" inside a slim
+// TRIGGER margin, but when we do move, the city is placed inside a deeper
+// SETTLE margin — so the destination never sits on the trigger boundary and
+// a re-hover of the same card is a no-op.
+
+export interface ViewBox {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface Point {
+  x: number
+  y: number
+}
+
+/** Fraction of the viewport treated as edge — inside it a city is "off view". */
+const TRIGGER_MARGIN_FRAC = 0.08
+/** Where a panned-to city lands, measured from the viewport edge. */
+const SETTLE_MARGIN_FRAC = 0.22
+/** Slight zoom-out applied when panning, so arrival keeps some context. */
+const ZOOM_OUT_FACTOR = 1.25
+
+/** Debounce before a hovered card may move the map (rapid tray sweeps). */
+export const FOCUS_PAN_DEBOUNCE_MS = 220
+/** Duration of the animated pan. */
+export const FOCUS_PAN_ANIMATION_MS = 450
+
+/** Ease-in-out cubic — gentle start and stop for the animated pan. */
+export function easeInOutCubic(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2
+}
+
+/** True when `pt` sits comfortably inside `vb` (outside the edge margin). */
+export function isComfortablyVisible(vb: ViewBox, pt: Point): boolean {
+  const mx = vb.w * TRIGGER_MARGIN_FRAC
+  const my = vb.h * TRIGGER_MARGIN_FRAC
+  return (
+    pt.x >= vb.x + mx &&
+    pt.x <= vb.x + vb.w - mx &&
+    pt.y >= vb.y + my &&
+    pt.y <= vb.y + vb.h - my
+  )
+}
+
+/**
+ * Plan the viewBox that brings `pt` comfortably into view, or `null` when no
+ * move is needed (already visible). The plan:
+ *  - zooms out slightly (never past the full-board size `bounds`, and never
+ *    zooms IN — an already-wide view only pans),
+ *  - then pans the MINIMUM distance that lands the city inside the settle
+ *    margin — it does not recentre, so the view stays near where the player
+ *    left it.
+ */
+export function planPanToCity(
+  vb: ViewBox,
+  pt: Point,
+  bounds: { w: number; h: number },
+): ViewBox | null {
+  if (isComfortablyVisible(vb, pt)) return null
+
+  // Slight zoom-out about the viewport centre, clamped to full-board width.
+  const w = vb.w < bounds.w ? Math.min(vb.w * ZOOM_OUT_FACTOR, bounds.w) : vb.w
+  const h = (w / vb.w) * vb.h
+  let x = vb.x - (w - vb.w) / 2
+  let y = vb.y - (h - vb.h) / 2
+
+  // Minimal pan: shift each axis only as far as needed to place the city
+  // inside the settle margin.
+  const mx = w * SETTLE_MARGIN_FRAC
+  const my = h * SETTLE_MARGIN_FRAC
+  if (pt.x < x + mx) x = pt.x - mx
+  else if (pt.x > x + w - mx) x = pt.x - w + mx
+  if (pt.y < y + my) y = pt.y - my
+  else if (pt.y > y + h - my) y = pt.y - h + my
+
+  return { x, y, w, h }
+}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -46,7 +46,7 @@ import { demoSnapshotIronChoice } from './demo/demo-snapshot-iron-choice'
 import { demoSnapshotSell } from './demo/demo-snapshot-sell'
 import { demoSnapshotWilds } from './demo/demo-snapshot-wilds'
 import { HandTray } from './hand-tray'
-import { computeHoverCities } from './hover-highlight'
+import { computeHoverCities, focusCityFor } from './hover-highlight'
 import { LocateCityProvider, useLocateCityState } from './locate'
 import { pendingBeerChoice } from '~/store/shared/resourceSources'
 import { GameOverScreen, PassGate, RoundCurtain } from './overlays'
@@ -965,6 +965,7 @@ function GameInner({
                   needsReveal ? null : (beerCandidateCities ?? hoverCities)
                 }
                 locatedCity={locateState.locatedCity}
+                focusCity={needsReveal ? null : focusCityFor(hoveredCard)}
               />
             </div>
           </div>

--- a/src/components/hover-highlight.test.ts
+++ b/src/components/hover-highlight.test.ts
@@ -6,7 +6,7 @@ import type {
   WildIndustryCard,
   WildLocationCard,
 } from '../data/cards'
-import { computeHoverCities } from './hover-highlight'
+import { computeHoverCities, focusCityFor } from './hover-highlight'
 
 const locationCard = (location: CityId): LocationCard => ({
   id: `loc-${location}`,
@@ -82,5 +82,20 @@ describe('computeHoverCities', () => {
     const anywhere = computeHoverCities(industryCard('pottery'), null)!
     const viaEmpty = computeHoverCities(industryCard('pottery'), new Set())!
     expect(anywhere).toEqual(viaEmpty)
+  })
+})
+
+describe('focusCityFor (card-hover map sync)', () => {
+  test('location card names its printed city as the pan target', () => {
+    expect(focusCityFor(locationCard('derby'))).toBe('derby')
+  })
+
+  test('industry, wild and no card never pan the map', () => {
+    const wildLoc: WildLocationCard = { id: 'wl', type: 'wild_location' }
+    const wildInd: WildIndustryCard = { id: 'wi', type: 'wild_industry' }
+    expect(focusCityFor(industryCard('coal'))).toBeNull()
+    expect(focusCityFor(wildLoc)).toBeNull()
+    expect(focusCityFor(wildInd)).toBeNull()
+    expect(focusCityFor(null)).toBeNull()
   })
 })

--- a/src/components/hover-highlight.ts
+++ b/src/components/hover-highlight.ts
@@ -16,6 +16,16 @@ import type { Card } from '../data/cards'
  * player's `networkCities`. Returns `null` when there is nothing to preview
  * (no card hovered, or a wild card that could go anywhere).
  */
+/**
+ * The single city the map should auto-pan to while `hoveredCard` is hovered
+ * (card-hover map sync), or `null` for no pan. Only LOCATION cards name one
+ * unambiguous city; industry cards spotlight a whole set (panning would have
+ * no single destination) and wild cards could go anywhere — both stay put.
+ */
+export function focusCityFor(hoveredCard: Card | null): string | null {
+  return hoveredCard?.type === 'location' ? hoveredCard.location : null
+}
+
 export function computeHoverCities(
   hoveredCard: Card | null,
   networkCities: ReadonlySet<CityId> | null,

--- a/src/components/locate.tsx
+++ b/src/components/locate.tsx
@@ -7,9 +7,10 @@
 // owns the `locatedCity` state (so it can feed the map directly) and provides
 // it through this context; name-bearing UI reads only the setter.
 //
-// The state is deliberately a plain "one city id or null" value so the
-// queued brass-card-map-sync task (pan-into-view for hovered cards) can
-// reuse it unchanged.
+// The state is deliberately a plain "one city id or null" value. Note:
+// card-map-sync (auto-pan to a hovered card's city) landed as a SEPARATE
+// BoardMap prop (`focusCity`, fed from the hovered card) on purpose —
+// name-hover highlights must never move the map, card hover may.
 import {
   type Dispatch,
   type ReactNode,

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -24,7 +24,7 @@ import { ActionDock, SELLABLE, getHandSelection } from '../action-dock'
 import { linkKey } from '../board/board-data'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
 import { HandTray } from '../hand-tray'
-import { computeHoverCities } from '../hover-highlight'
+import { computeHoverCities, focusCityFor } from '../hover-highlight'
 import { LocateCityProvider, useLocateCityState } from '../locate'
 import { GameOverScreen, RoundCurtain } from '../overlays'
 import { OpenMatButton, PlayerLedger } from '../player-ledger'
@@ -1363,6 +1363,7 @@ function MpTable({
                 networkColor={me ? PLAYER_FILL[me.color] : null}
                 hoverCities={hoverCities}
                 locatedCity={locateState.locatedCity}
+                focusCity={focusCityFor(hoveredCard)}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary

Captain's UX idea: when the map is zoomed in and the player hovers a hand-tray card whose city is off-viewport, the map smoothly pans (with a slight zoom-out) to bring that city into view. Builds on the landed hover-highlight feature — the pan target derives from the same hovered card that drives the `hoverCities` spotlight, so the teal ring and the pan compose instead of duplicating wiring.

## What changed

- **`src/components/board/pan-into-view.ts`** (new, pure): the whole trigger/target decision — should the map move, and to where. Trigger margin 8% ("mostly outside counts as off-view"), settle margin 22% (hysteresis: the destination never sits on the trigger boundary, so re-hovering the same card is a no-op), zoom-out ×1.25 clamped below full-board width (never resets the zoom, never zooms IN), minimal pan (only the offending axis moves — the view stays near where the player left it). 12 unit tests, no DOM needed.
- **`board-map.tsx`**: new `focusCity` prop + the animated application: 220ms debounce (rapid tray sweeps don't thrash the map), 450ms ease-in-out rAF animation, instant jump under `prefers-reduced-motion`.
- **`hover-highlight.ts`**: shared `focusCityFor(card)` — per-card semantics in ONE place, wired identically on both surfaces (`game.tsx` hotseat + `mp-game.tsx` networked).

## Decisions for captain review

- **No snap-back on hover end** (per task): the map stays where it panned. Reverting would be jarring and would fight the player's next look at the city.
- **Card semantics**: only LOCATION cards pan — they name one unambiguous city. Industry cards spotlight a whole *set* of candidate cities (no single pan destination) and wild cards can go anywhere; both keep the existing highlight behavior and never move the map.
- **Gesture/wizard safety**: any user wheel / drag / pinch / zoom-button input cancels an in-flight auto-pan immediately; a gesture in progress at debounce expiry suppresses it; and the auto-pan is disabled entirely while a board pick step is active (`legalCities`/`legalLinks` non-null) so the map never yanks while the player is aiming a city/route click.
- **Separate from `locatedCity`**: name-hover (journal, pickers, ledger) still only highlights — moving the map on every journal name hover would be chaos. Card hover is the only pan trigger.

## Manual repro (desktop width)

1. `pnpm dev` → `http://localhost:3000/?demo`
2. Mouse-wheel zoom into the north-east of the board (Derby/Burton region) until Coalbrookdale is off-screen.
3. Hover the **Coalbrookdale** location card in the hand tray → after ~220ms the map animates west with a slight zoom-out; Coalbrookdale arrives comfortably in view with its teal hover ring.
4. Move the mouse off the card → the map stays put (no snap-back).
5. Re-hover the same card → no movement (hysteresis).
6. Hover an industry or wild card → highlight only, no pan.

### Before (zoomed NE, Coalbrookdale card hovered but city off-screen — old behavior had no pan)
![before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-map-sync-images/card-map-sync-before.png)

### After (map auto-panned + slightly zoomed out; Coalbrookdale spotlit, card raised)
![after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-card-map-sync-images/card-map-sync-after.png)

## Testing

- `pnpm test`: 563 passed (includes new `pan-into-view.test.ts` ×12 and `focusCityFor` cases in `hover-highlight.test.ts`).
- `pnpm lint` + `pnpm typecheck`: clean.
- Playwright: 44 passed; `iron-source.spec.ts:21` is the known pre-existing failure (tracked separately); `multiplayer.spec.ts` failed once on DB contention and passed clean on isolated rerun.
- Manual browser verification of pan, no-snap-back, and hysteresis on the `?demo` fixture (screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hovering a location card now automatically pans and zooms the map to that city when it is off-screen.
  * Map movement is delayed and smoothly animated, while respecting reduced-motion preferences.
  * Industry and wild cards do not trigger map movement.
  * User interactions and active selections take priority and stop automatic map movement.
  * Hovering a city name continues to highlight it without moving the map.

* **Tests**
  * Added coverage for map visibility, panning, animation, and card-hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->