### PR TITLE
fix(journal): complete + de-duplicate resource-consumption log entries

### DIFF
--- a/src/components/demo/demo-snapshot-beer-choice.ts
+++ b/src/components/demo/demo-snapshot-beer-choice.ts
@@ -2614,7 +2614,7 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.473Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at walsall for £7 (consumed consumed 1 iron from market for £2) using brewery industry",
+        "message": "Isambard built brewery Level 1 at walsall for £7 (consumed 1 iron from market for £2) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.473Z"
       },
@@ -2664,7 +2664,7 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.474Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at stafford for £6 (consumed consumed 1 iron from market for £1) using stafford (other)",
+        "message": "Isambard built brewery Level 1 at stafford for £6 (consumed 1 iron from market for £1) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.475Z"
       },
@@ -2699,12 +2699,12 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.475Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at nuneaton for £6 (consumed consumed 1 iron from market for £1) using nuneaton (other)",
+        "message": "Eliza built brewery Level 1 at nuneaton for £6 (consumed 1 iron from market for £1) using nuneaton (other)",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.475Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at walsall for £9 (consumed consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
+        "message": "Isambard built brewery Level 2 at walsall for £9 (consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.475Z"
       },
@@ -2719,7 +2719,7 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.476Z"
       },
       {
-        "message": "George built pottery Level 1 at stafford for £19 (consumed consumed 1 iron from market for £2) using stafford (other)",
+        "message": "George built pottery Level 1 at stafford for £19 (consumed 1 iron from market for £2) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.476Z"
       },
@@ -2744,7 +2744,7 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.476Z"
       },
       {
-        "message": "Eliza built brewery Level 2 at uttoxeter for £10 (consumed consumed 1 iron from market for £3) using uttoxeter (other)",
+        "message": "Eliza built brewery Level 2 at uttoxeter for £10 (consumed 1 iron from market for £3) using uttoxeter (other)",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.476Z"
       },
@@ -2764,7 +2764,7 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.477Z"
       },
       {
-        "message": "George built brewery Level 1 at stone for £8 (consumed consumed 1 iron from market for £3) using stone (other)",
+        "message": "George built brewery Level 1 at stone for £8 (consumed 1 iron from market for £3) using stone (other)",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.477Z"
       },
@@ -2859,7 +2859,7 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.481Z"
       },
       {
-        "message": "Eliza built pottery Level 1 at stoke for £21 (consumed consumed 1 iron from market for £4) using stoke (other)",
+        "message": "Eliza built pottery Level 1 at stoke for £21 (consumed 1 iron from market for £4) using stoke (other)",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.481Z"
       },
@@ -2869,7 +2869,7 @@ export const demoSnapshotBeerChoice: unknown = {
         "timestamp": "2026-07-16T20:57:56.481Z"
       },
       {
-        "message": "Isambard built pottery Level 1 at coventry for £21 (consumed consumed 1 iron from market for £4) using coventry (other)",
+        "message": "Isambard built pottery Level 1 at coventry for £21 (consumed 1 iron from market for £4) using coventry (other)",
         "type": "action",
         "timestamp": "2026-07-16T20:57:56.481Z"
       },

--- a/src/components/demo/demo-snapshot-double-beer.ts
+++ b/src/components/demo/demo-snapshot-double-beer.ts
@@ -2563,7 +2563,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.224Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed consumed 1 iron from market for £2) using nuneaton (other)",
+        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed 1 iron from market for £2) using nuneaton (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.224Z"
       },
@@ -2658,7 +2658,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.225Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at stafford for £6 (consumed consumed 1 iron from market for £1) using stafford (other)",
+        "message": "Isambard built brewery Level 1 at stafford for £6 (consumed 1 iron from market for £1) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.225Z"
       },
@@ -2678,7 +2678,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.225Z"
       },
       {
-        "message": "George built brewery Level 1 at coalbrookdale for £6 (consumed consumed 1 iron from market for £1) using coalbrookdale (other)",
+        "message": "George built brewery Level 1 at coalbrookdale for £6 (consumed 1 iron from market for £1) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.226Z"
       },
@@ -2703,22 +2703,22 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.226Z"
       },
       {
-        "message": "George built coal Level 3 at wolverhampton for £10 (consumed consumed 1 iron from market for £2) (overbuilt own level 2) using wolverhampton (other)",
+        "message": "George built coal Level 3 at wolverhampton for £10 (consumed 1 iron from market for £2) (overbuilt own level 2) using wolverhampton (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.226Z"
       },
       {
-        "message": "George built coal Level 3 at cannock for £10 (consumed consumed 1 iron from market for £2) using cannock (other)",
+        "message": "George built coal Level 3 at cannock for £10 (consumed 1 iron from market for £2) using cannock (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.226Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at uttoxeter for £8 (consumed consumed 1 iron from market for £3) using uttoxeter (other)",
+        "message": "Eliza built brewery Level 1 at uttoxeter for £8 (consumed 1 iron from market for £3) using uttoxeter (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.226Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at walsall for £8 (consumed consumed 1 iron from market for £3) using walsall (other)",
+        "message": "Eliza built brewery Level 1 at walsall for £8 (consumed 1 iron from market for £3) using walsall (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.227Z"
       },
@@ -2773,7 +2773,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.227Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at nuneaton for £9 (consumed consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
+        "message": "Isambard built brewery Level 2 at nuneaton for £9 (consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.227Z"
       },
@@ -2788,7 +2788,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.227Z"
       },
       {
-        "message": "Eliza built brewery Level 2 at walsall for £9 (consumed consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
+        "message": "Eliza built brewery Level 2 at walsall for £9 (consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.227Z"
       },
@@ -2798,7 +2798,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.227Z"
       },
       {
-        "message": "George built brewery Level 1 at burton for £8 (consumed consumed 1 iron from market for £3) using burton (other)",
+        "message": "George built brewery Level 1 at burton for £8 (consumed 1 iron from market for £3) using burton (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.228Z"
       },
@@ -2823,7 +2823,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.228Z"
       },
       {
-        "message": "George built brewery Level 2 at coalbrookdale for £10 (consumed consumed 1 iron from market for £3) (overbuilt own level 1) using brewery industry",
+        "message": "George built brewery Level 2 at coalbrookdale for £10 (consumed 1 iron from market for £3) (overbuilt own level 1) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.228Z"
       },
@@ -2843,7 +2843,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.230Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at stafford for £11 (consumed consumed 1 iron from market for £4) (overbuilt own level 1) using stafford (other)",
+        "message": "Isambard built brewery Level 2 at stafford for £11 (consumed 1 iron from market for £4) (overbuilt own level 1) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.230Z"
       },
@@ -3143,7 +3143,7 @@ export const demoSnapshotDoubleBeer: unknown = {
         "timestamp": "2026-07-16T21:36:28.233Z"
       },
       {
-        "message": "Isambard built brewery Level 3 at nuneaton for £13 (consumed consumed 1 iron from market for £4) (overbuilt own level 2) using brewery industry",
+        "message": "Isambard built brewery Level 3 at nuneaton for £13 (consumed 1 iron from market for £4) (overbuilt own level 2) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-16T21:36:28.537Z"
       },

--- a/src/components/demo/demo-snapshot-era-end.ts
+++ b/src/components/demo/demo-snapshot-era-end.ts
@@ -2370,12 +2370,12 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.694Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed consumed 1 iron from market for £2) using nuneaton (other)",
+        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed 1 iron from market for £2) using nuneaton (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.694Z"
       },
       {
-        "message": "George built brewery Level 1 at coalbrookdale for £7 (consumed consumed 1 iron from market for £2) using coalbrookdale (other)",
+        "message": "George built brewery Level 1 at coalbrookdale for £7 (consumed 1 iron from market for £2) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.694Z"
       },
@@ -2450,7 +2450,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.695Z"
       },
       {
-        "message": "Isambard built pottery Level 1 at coventry for £20 (consumed consumed 1 iron from market for £3) using coventry (other)",
+        "message": "Isambard built pottery Level 1 at coventry for £20 (consumed 1 iron from market for £3) using coventry (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.696Z"
       },
@@ -2520,7 +2520,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.698Z"
       },
       {
-        "message": "Eliza built pottery Level 1 at coventry for £18 (consumed consumed 1 iron from market for £1) using coventry (other)",
+        "message": "Eliza built pottery Level 1 at coventry for £18 (consumed 1 iron from market for £1) using coventry (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.698Z"
       },
@@ -2530,7 +2530,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.699Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed consumed 1 iron from market for £2) using brewery industry",
+        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed 1 iron from market for £2) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.699Z"
       },
@@ -2555,12 +2555,12 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.699Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at nuneaton for £9 (consumed consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
+        "message": "Isambard built brewery Level 2 at nuneaton for £9 (consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.699Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at burton for £10 (consumed consumed 1 iron from market for £3) using burton (other)",
+        "message": "Isambard built brewery Level 2 at burton for £10 (consumed 1 iron from market for £3) using burton (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.700Z"
       },
@@ -2610,7 +2610,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.701Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at walsall for £8 (consumed consumed 1 iron from market for £3) using walsall (other)",
+        "message": "Eliza built brewery Level 1 at walsall for £8 (consumed 1 iron from market for £3) using walsall (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.701Z"
       },
@@ -2625,7 +2625,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.702Z"
       },
       {
-        "message": "George built coal Level 3 at coventry for £12 (consumed consumed 1 iron from market for £4) using coventry (other)",
+        "message": "George built coal Level 3 at coventry for £12 (consumed 1 iron from market for £4) using coventry (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.702Z"
       },
@@ -2635,7 +2635,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.703Z"
       },
       {
-        "message": "Isambard built brewery Level 3 at burton for £13 (consumed consumed 1 iron from market for £4) (overbuilt own level 2) using brewery industry",
+        "message": "Isambard built brewery Level 3 at burton for £13 (consumed 1 iron from market for £4) (overbuilt own level 2) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.703Z"
       },
@@ -2695,7 +2695,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.704Z"
       },
       {
-        "message": "George built brewery Level 1 at stafford for £10 (consumed consumed 1 iron from market for £5) using stafford (other)",
+        "message": "George built brewery Level 1 at stafford for £10 (consumed 1 iron from market for £5) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.705Z"
       },
@@ -2760,7 +2760,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.705Z"
       },
       {
-        "message": "George built coal Level 3 at wolverhampton for £13 (consumed consumed 1 iron from market for £5) using wolverhampton (other)",
+        "message": "George built coal Level 3 at wolverhampton for £13 (consumed 1 iron from market for £5) using wolverhampton (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.706Z"
       },
@@ -2820,7 +2820,7 @@ export const demoSnapshotEraEnd: unknown = {
         "timestamp": "2026-07-15T00:08:26.707Z"
       },
       {
-        "message": "George built coal Level 4 at cannock for £16 (consumed consumed 1 iron from general supply for £6) using cannock (other)",
+        "message": "George built coal Level 4 at cannock for £16 (consumed 1 iron from general supply for £6) using cannock (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.707Z"
       },

--- a/src/components/demo/demo-snapshot-game-end.ts
+++ b/src/components/demo/demo-snapshot-game-end.ts
@@ -2709,7 +2709,7 @@ export const demoSnapshotGameEnd: unknown = {
         "timestamp": "2026-07-16T12:29:24.072Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at walsall for £7 (consumed consumed 1 iron from market for £2) using walsall (other)",
+        "message": "Eliza built brewery Level 1 at walsall for £7 (consumed 1 iron from market for £2) using walsall (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:29:24.072Z"
       },
@@ -2759,7 +2759,7 @@ export const demoSnapshotGameEnd: unknown = {
         "timestamp": "2026-07-16T12:29:24.072Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at stafford for £7 (consumed consumed 1 iron from market for £2) using stafford (other)",
+        "message": "Isambard built brewery Level 1 at stafford for £7 (consumed 1 iron from market for £2) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:29:24.072Z"
       },
@@ -2799,7 +2799,7 @@ export const demoSnapshotGameEnd: unknown = {
         "timestamp": "2026-07-16T12:29:24.072Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at coalbrookdale for £8 (consumed consumed 1 iron from market for £3) using coalbrookdale (other)",
+        "message": "Eliza built brewery Level 1 at coalbrookdale for £8 (consumed 1 iron from market for £3) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:29:24.073Z"
       },
@@ -2814,7 +2814,7 @@ export const demoSnapshotGameEnd: unknown = {
         "timestamp": "2026-07-16T12:29:24.073Z"
       },
       {
-        "message": "George built pottery Level 1 at coventry for £20 (consumed consumed 1 iron from market for £3) using coventry (other)",
+        "message": "George built pottery Level 1 at coventry for £20 (consumed 1 iron from market for £3) using coventry (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:29:24.073Z"
       },
@@ -2909,7 +2909,7 @@ export const demoSnapshotGameEnd: unknown = {
         "timestamp": "2026-07-16T12:29:24.075Z"
       },
       {
-        "message": "Eliza built brewery Level 2 at coalbrookdale for £8 (consumed consumed 1 iron from market for £1) (overbuilt own level 1) using coalbrookdale (other)",
+        "message": "Eliza built brewery Level 2 at coalbrookdale for £8 (consumed 1 iron from market for £1) (overbuilt own level 1) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:29:24.075Z"
       },
@@ -3064,7 +3064,7 @@ export const demoSnapshotGameEnd: unknown = {
         "timestamp": "2026-07-16T12:29:24.079Z"
       },
       {
-        "message": "George built cotton Level 2 at stoke for £15 (consumed consumed 1 coal from connected market for £1) (overbuilt own level 1) using cotton/manufacturer industry",
+        "message": "George built cotton Level 2 at stoke for £15 (consumed 1 coal from connected market for £1) (overbuilt own level 1) using cotton/manufacturer industry",
         "type": "action",
         "timestamp": "2026-07-16T12:29:24.079Z"
       },
@@ -3074,7 +3074,7 @@ export const demoSnapshotGameEnd: unknown = {
         "timestamp": "2026-07-16T12:29:24.080Z"
       },
       {
-        "message": "Isambard built cotton Level 2 at stone for £16 (consumed consumed 1 coal from connected market for £2) (overbuilt own level 1) using stone (other)",
+        "message": "Isambard built cotton Level 2 at stone for £16 (consumed 1 coal from connected market for £2) (overbuilt own level 1) using stone (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:29:24.080Z"
       },

--- a/src/components/demo/demo-snapshot-iron-choice.ts
+++ b/src/components/demo/demo-snapshot-iron-choice.ts
@@ -2775,7 +2775,7 @@ export const demoSnapshotIronChoice: unknown = {
         "timestamp": "2026-07-16T21:36:20.418Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at coalbrookdale for £7 (consumed consumed 1 iron from market for £2) using coalbrookdale (other)",
+        "message": "Eliza built brewery Level 1 at coalbrookdale for £7 (consumed 1 iron from market for £2) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:20.419Z"
       },
@@ -2860,7 +2860,7 @@ export const demoSnapshotIronChoice: unknown = {
         "timestamp": "2026-07-16T21:36:20.422Z"
       },
       {
-        "message": "Eliza built pottery Level 1 at stoke for £19 (consumed consumed 1 iron from market for £2) using stoke (other)",
+        "message": "Eliza built pottery Level 1 at stoke for £19 (consumed 1 iron from market for £2) using stoke (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:20.423Z"
       },
@@ -2870,12 +2870,12 @@ export const demoSnapshotIronChoice: unknown = {
         "timestamp": "2026-07-16T21:36:20.423Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at nuneaton for £8 (consumed consumed 1 iron from market for £3) using nuneaton (other)",
+        "message": "Isambard built brewery Level 1 at nuneaton for £8 (consumed 1 iron from market for £3) using nuneaton (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:20.423Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at burton for £8 (consumed consumed 1 iron from market for £3) using burton (other)",
+        "message": "Isambard built brewery Level 1 at burton for £8 (consumed 1 iron from market for £3) using burton (other)",
         "type": "action",
         "timestamp": "2026-07-16T21:36:20.424Z"
       },

--- a/src/components/demo/demo-snapshot-rail.ts
+++ b/src/components/demo/demo-snapshot-rail.ts
@@ -2566,7 +2566,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.567Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at uttoxeter for £7 (consumed consumed 1 iron from market for £2) using uttoxeter (other)",
+        "message": "Eliza built brewery Level 1 at uttoxeter for £7 (consumed 1 iron from market for £2) using uttoxeter (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.567Z"
       },
@@ -2651,7 +2651,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.569Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at coalbrookdale for £7 (consumed consumed 1 iron from market for £2) using coalbrookdale (other)",
+        "message": "Eliza built brewery Level 1 at coalbrookdale for £7 (consumed 1 iron from market for £2) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.569Z"
       },
@@ -2676,7 +2676,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.570Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at walsall for £8 (consumed consumed 1 iron from market for £3) using walsall (other)",
+        "message": "Isambard built brewery Level 1 at walsall for £8 (consumed 1 iron from market for £3) using walsall (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.570Z"
       },
@@ -2756,7 +2756,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.572Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at stafford for £8 (consumed consumed 1 iron from market for £3) using stafford (other)",
+        "message": "Isambard built brewery Level 1 at stafford for £8 (consumed 1 iron from market for £3) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.572Z"
       },
@@ -2766,12 +2766,12 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.572Z"
       },
       {
-        "message": "Eliza built coal Level 3 at redditch for £12 (consumed consumed 1 iron from market for £4) using redditch (other)",
+        "message": "Eliza built coal Level 3 at redditch for £12 (consumed 1 iron from market for £4) using redditch (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.573Z"
       },
       {
-        "message": "Eliza built coal Level 3 at stone for £12 (consumed consumed 1 iron from market for £4) using stone (other)",
+        "message": "Eliza built coal Level 3 at stone for £12 (consumed 1 iron from market for £4) using stone (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.573Z"
       },
@@ -2806,7 +2806,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.574Z"
       },
       {
-        "message": "George built pottery Level 1 at stafford for £22 (consumed consumed 1 iron from market for £5) using stafford (other)",
+        "message": "George built pottery Level 1 at stafford for £22 (consumed 1 iron from market for £5) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.574Z"
       },
@@ -2831,7 +2831,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.576Z"
       },
       {
-        "message": "Eliza built pottery Level 1 at stoke for £22 (consumed consumed 1 iron from market for £5) using stoke (other)",
+        "message": "Eliza built pottery Level 1 at stoke for £22 (consumed 1 iron from market for £5) using stoke (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.576Z"
       },
@@ -2961,12 +2961,12 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.577Z"
       },
       {
-        "message": "Isambard built coal Level 3 at burton for £10 (consumed consumed 1 iron from market for £2) using burton (other)",
+        "message": "Isambard built coal Level 3 at burton for £10 (consumed 1 iron from market for £2) using burton (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.577Z"
       },
       {
-        "message": "Isambard built coal Level 3 at coalbrookdale for £10 (consumed consumed 1 iron from market for £2) (overbuilt own level 1) using coalbrookdale (other)",
+        "message": "Isambard built coal Level 3 at coalbrookdale for £10 (consumed 1 iron from market for £2) (overbuilt own level 1) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.577Z"
       },
@@ -3036,7 +3036,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.578Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at nuneaton for £10 (consumed consumed 1 iron from market for £3) using nuneaton (other)",
+        "message": "Isambard built brewery Level 2 at nuneaton for £10 (consumed 1 iron from market for £3) using nuneaton (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.578Z"
       },
@@ -3191,7 +3191,7 @@ export const demoSnapshotRail: unknown = {
         "timestamp": "2026-07-16T12:33:45.578Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at stafford for £10 (consumed consumed 1 iron from market for £3) using stafford (other)",
+        "message": "Isambard built brewery Level 2 at stafford for £10 (consumed 1 iron from market for £3) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-16T12:33:45.579Z"
       },

--- a/src/components/demo/demo-snapshot-sell.ts
+++ b/src/components/demo/demo-snapshot-sell.ts
@@ -2821,7 +2821,7 @@ export const demoSnapshotSell: unknown = {
         "timestamp": "2026-07-15T00:08:26.674Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at uttoxeter for £7 (consumed consumed 1 iron from market for £2) using uttoxeter (other)",
+        "message": "Isambard built brewery Level 1 at uttoxeter for £7 (consumed 1 iron from market for £2) using uttoxeter (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.675Z"
       },
@@ -2906,7 +2906,7 @@ export const demoSnapshotSell: unknown = {
         "timestamp": "2026-07-15T00:08:26.677Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at burton for £8 (consumed consumed 1 iron from market for £1) using burton (other)",
+        "message": "Isambard built brewery Level 2 at burton for £8 (consumed 1 iron from market for £1) using burton (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.677Z"
       },
@@ -2916,12 +2916,12 @@ export const demoSnapshotSell: unknown = {
         "timestamp": "2026-07-15T00:08:26.677Z"
       },
       {
-        "message": "George built pottery Level 1 at coventry for £18 (consumed consumed 1 iron from market for £1) using pottery industry",
+        "message": "George built pottery Level 1 at coventry for £18 (consumed 1 iron from market for £1) using pottery industry",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.678Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at coalbrookdale for £7 (consumed consumed 1 iron from market for £2) using coalbrookdale (other)",
+        "message": "Eliza built brewery Level 1 at coalbrookdale for £7 (consumed 1 iron from market for £2) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.678Z"
       },
@@ -2961,7 +2961,7 @@ export const demoSnapshotSell: unknown = {
         "timestamp": "2026-07-15T00:08:26.679Z"
       },
       {
-        "message": "Isambard built brewery Level 2 at nuneaton for £9 (consumed consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
+        "message": "Isambard built brewery Level 2 at nuneaton for £9 (consumed 1 iron from market for £2) (overbuilt own level 1) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.679Z"
       },
@@ -2976,7 +2976,7 @@ export const demoSnapshotSell: unknown = {
         "timestamp": "2026-07-15T00:08:26.680Z"
       },
       {
-        "message": "George built brewery Level 1 at stafford for £8 (consumed consumed 1 iron from market for £3) using stafford (other)",
+        "message": "George built brewery Level 1 at stafford for £8 (consumed 1 iron from market for £3) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.680Z"
       },
@@ -3106,7 +3106,7 @@ export const demoSnapshotSell: unknown = {
         "timestamp": "2026-07-15T00:08:26.684Z"
       },
       {
-        "message": "Eliza built coal Level 3 at dudley for £9 (consumed consumed 1 iron from market for £1) (overbuilt own level 1) using dudley (other)",
+        "message": "Eliza built coal Level 3 at dudley for £9 (consumed 1 iron from market for £1) (overbuilt own level 1) using dudley (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.684Z"
       },

--- a/src/components/demo/demo-snapshot-wilds.ts
+++ b/src/components/demo/demo-snapshot-wilds.ts
@@ -2572,7 +2572,7 @@ export const demoSnapshotWilds: unknown = {
         "timestamp": "2026-07-15T00:08:26.710Z"
       },
       {
-        "message": "George built brewery Level 1 at walsall for £7 (consumed consumed 1 iron from market for £2) using brewery industry",
+        "message": "George built brewery Level 1 at walsall for £7 (consumed 1 iron from market for £2) using brewery industry",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.710Z"
       },
@@ -2612,7 +2612,7 @@ export const demoSnapshotWilds: unknown = {
         "timestamp": "2026-07-15T00:08:26.711Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed consumed 1 iron from market for £2) using nuneaton (other)",
+        "message": "Isambard built brewery Level 1 at nuneaton for £7 (consumed 1 iron from market for £2) using nuneaton (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.711Z"
       },
@@ -2647,12 +2647,12 @@ export const demoSnapshotWilds: unknown = {
         "timestamp": "2026-07-15T00:08:26.711Z"
       },
       {
-        "message": "George built pottery Level 1 at coventry for £20 (consumed consumed 1 iron from market for £3) using coventry (other)",
+        "message": "George built pottery Level 1 at coventry for £20 (consumed 1 iron from market for £3) using coventry (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.711Z"
       },
       {
-        "message": "George built brewery Level 1 at uttoxeter for £8 (consumed consumed 1 iron from market for £3) using uttoxeter (other)",
+        "message": "George built brewery Level 1 at uttoxeter for £8 (consumed 1 iron from market for £3) using uttoxeter (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.711Z"
       },

--- a/src/components/demo/demo-snapshot.ts
+++ b/src/components/demo/demo-snapshot.ts
@@ -3063,7 +3063,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.532Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at uttoxeter for £7 (consumed consumed 1 iron from market for £2) using uttoxeter (other)",
+        "message": "Isambard built brewery Level 1 at uttoxeter for £7 (consumed 1 iron from market for £2) using uttoxeter (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.532Z"
       },
@@ -3093,7 +3093,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.532Z"
       },
       {
-        "message": "Isambard built brewery Level 1 at coalbrookdale for £7 (consumed consumed 1 iron from market for £2) using coalbrookdale (other)",
+        "message": "Isambard built brewery Level 1 at coalbrookdale for £7 (consumed 1 iron from market for £2) using coalbrookdale (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.532Z"
       },
@@ -3118,7 +3118,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.533Z"
       },
       {
-        "message": "George built brewery Level 1 at stafford for £8 (consumed consumed 1 iron from market for £3) using stafford (other)",
+        "message": "George built brewery Level 1 at stafford for £8 (consumed 1 iron from market for £3) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.533Z"
       },
@@ -3153,7 +3153,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.533Z"
       },
       {
-        "message": "Isambard built pottery Level 1 at stoke for £20 (consumed consumed 1 iron from market for £3) using stoke (other)",
+        "message": "Isambard built pottery Level 1 at stoke for £20 (consumed 1 iron from market for £3) using stoke (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.534Z"
       },
@@ -3198,7 +3198,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.534Z"
       },
       {
-        "message": "George built pottery Level 1 at coventry for £21 (consumed consumed 1 iron from market for £4) using pottery industry",
+        "message": "George built pottery Level 1 at coventry for £21 (consumed 1 iron from market for £4) using pottery industry",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.534Z"
       },
@@ -3208,7 +3208,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.534Z"
       },
       {
-        "message": "Eliza built pottery Level 1 at stafford for £21 (consumed consumed 1 iron from market for £4) using stafford (other)",
+        "message": "Eliza built pottery Level 1 at stafford for £21 (consumed 1 iron from market for £4) using stafford (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.534Z"
       },
@@ -3258,7 +3258,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.535Z"
       },
       {
-        "message": "George built brewery Level 1 at nuneaton for £8 (consumed consumed 1 iron from market for £3) using nuneaton (other)",
+        "message": "George built brewery Level 1 at nuneaton for £8 (consumed 1 iron from market for £3) using nuneaton (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.535Z"
       },
@@ -3298,7 +3298,7 @@ export const demoSnapshot: unknown = {
         "timestamp": "2026-07-15T00:08:26.536Z"
       },
       {
-        "message": "Eliza built brewery Level 1 at burton for £6 (consumed consumed 1 iron from market for £1) using burton (other)",
+        "message": "Eliza built brewery Level 1 at burton for £6 (consumed 1 iron from market for £1) using burton (other)",
         "type": "action",
         "timestamp": "2026-07-15T00:08:26.537Z"
       },

--- a/src/components/journal-model.test.ts
+++ b/src/components/journal-model.test.ts
@@ -62,7 +62,7 @@ describe('actor extraction', () => {
 describe('build entries', () => {
   test('a fully-loaded build keeps the headline and demotes consumption', () => {
     const item = parse(
-      'George built iron Level 1 at dudley for £5 (consumed 1 coal from connected coal mine (free)) (sold 2 iron to market for £6, sold 2 iron to market for £4) (tile flipped, +3 income) (overbuilt own level 1) using coventry (other)',
+      "George built iron Level 1 at dudley for £5 (consumed 1 coal from George's coal mine at dudley (free)) (sold 2 iron to market for £6, sold 2 iron to market for £4) (tile flipped, +3 income) (overbuilt own level 1) using coventry (other)",
     )
     expect(item.kind).toBe('build')
     expect(item.main).toBe('built iron Level 1 at dudley for £5')
@@ -72,7 +72,7 @@ describe('build entries', () => {
       { text: 'overbuilt own level 1', tone: 'neutral' },
     ])
     expect(item.details).toEqual([
-      'consumed 1 coal from connected coal mine (free)',
+      "consumed 1 coal from George's coal mine at dudley (free)",
       'sold 2 iron to market for £6, sold 2 iron to market for £4',
       'using coventry (other)',
     ])
@@ -99,23 +99,25 @@ describe('network entries', () => {
 
   test('a rail link demotes its coal consumption', () => {
     const item = parse(
-      'George built a rail link between dudley and walsall (consumed 1 coal from market for £3)',
+      'George built a rail link between dudley and walsall (consumed 1 coal from connected market for £3)',
     )
     expect(item.kind).toBe('network')
     expect(item.main).toBe('built a rail link between dudley and walsall')
-    expect(item.details).toEqual(['consumed 1 coal from market for £3'])
+    expect(item.details).toEqual([
+      'consumed 1 coal from connected market for £3',
+    ])
   })
 
   test('a double rail keeps the route list and prices inline', () => {
     const item = parse(
-      'George built 2 rail links (dudley-walsall, walsall-tamworth) for £15 + beer + 2 coal (£4) (1 coal from connected coal mine (free), consumed 1 coal from market for £4)',
+      "George built 2 rail links (dudley-walsall, walsall-tamworth) for £15 + 1 beer + 2 coal (£4) (consumed 1 coal from George's coal mine at dudley (free), 1 coal from connected market for £4, 1 beer from own brewery at walsall (free))",
     )
     expect(item.kind).toBe('network')
     expect(item.main).toBe(
-      'built 2 rail links (dudley-walsall, walsall-tamworth) for £15 + beer + 2 coal (£4)',
+      'built 2 rail links (dudley-walsall, walsall-tamworth) for £15 + 1 beer + 2 coal (£4)',
     )
     expect(item.details).toEqual([
-      '1 coal from connected coal mine (free), consumed 1 coal from market for £4',
+      "consumed 1 coal from George's coal mine at dudley (free), 1 coal from connected market for £4, 1 beer from own brewery at walsall (free)",
     ])
   })
 })

--- a/src/store/gameStore.journal.test.ts
+++ b/src/store/gameStore.journal.test.ts
@@ -1,0 +1,234 @@
+// Journal completeness regression suite — the game log is the audit trail for
+// rules verification (the coal next-closest-mine investigation reads it), so
+// these pin three concrete gaps reported from real games:
+//   1. double-link builds must journal the beer consumption AND any brewery flip
+//   2. link/industry coal consumption must NAME the source mine (owner + city)
+//   3. no journal string may contain the duplicated word "consumed consumed"
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import type { CityId } from '../data/board'
+import { gameStore } from './gameStore'
+
+let activeActors: ReturnType<typeof createActor>[] = []
+
+afterEach(() => {
+  activeActors.forEach((actor) => {
+    try {
+      actor.stop()
+    } catch {}
+  })
+  activeActors = []
+})
+
+const setupGame = () => {
+  const actor = createActor(gameStore)
+  activeActors.push(actor)
+  actor.subscribe({ error: () => {} })
+  actor.start()
+
+  const players = [
+    {
+      id: '1',
+      name: 'Player 1',
+      color: 'red' as const,
+      character: 'Richard Arkwright' as const,
+      money: 50,
+      victoryPoints: 0,
+      income: 10,
+      industryTilesOnMat: {} as any,
+    },
+    {
+      id: '2',
+      name: 'Player 2',
+      color: 'blue' as const,
+      character: 'Eliza Tinsley' as const,
+      money: 50,
+      victoryPoints: 0,
+      income: 10,
+      industryTilesOnMat: {} as any,
+    },
+  ]
+
+  actor.send({ type: 'START_GAME', players })
+  return { actor, players }
+}
+
+const coalMineAt = (location: CityId, cubes: number) => ({
+  location,
+  type: 'coal' as const,
+  level: 1,
+  flipped: false,
+  tile: {
+    id: 'coal_1',
+    type: 'coal' as const,
+    level: 1,
+    canBuildInCanalEra: true,
+    canBuildInRailEra: false,
+    incomeAdvancement: 4,
+    victoryPoints: 1,
+    cost: 5,
+    incomeSpaces: 4,
+    linkScoringIcons: 1,
+    coalRequired: 0,
+    ironRequired: 0,
+    beerRequired: 0,
+    beerProduced: 0,
+    coalProduced: 2,
+    ironProduced: 0,
+    hasLightbulbIcon: false,
+    quantity: 2,
+  },
+  coalCubesOnTile: cubes,
+  ironCubesOnTile: 0,
+  beerBarrelsOnTile: 0,
+})
+
+const breweryAt = (location: CityId, barrels: number) => ({
+  location,
+  type: 'brewery' as const,
+  level: 2,
+  flipped: false,
+  tile: {
+    id: 'brewery_2',
+    type: 'brewery' as const,
+    level: 2,
+    canBuildInCanalEra: true,
+    canBuildInRailEra: true,
+    incomeAdvancement: 5,
+    victoryPoints: 5,
+    cost: 7,
+    incomeSpaces: 5,
+    linkScoringIcons: 1,
+    coalRequired: 1,
+    ironRequired: 0,
+    beerRequired: 0,
+    beerProduced: 1,
+    coalProduced: 0,
+    ironProduced: 0,
+    hasLightbulbIcon: false,
+    quantity: 1,
+  },
+  coalCubesOnTile: 0,
+  ironCubesOnTile: 0,
+  beerBarrelsOnTile: barrels,
+})
+
+const lastActionLog = (actor: ReturnType<typeof createActor>) => {
+  const logs = actor.getSnapshot().context.logs
+  return (
+    [...logs].reverse().find((l: any) => l.type === 'action')?.message ?? ''
+  )
+}
+
+describe('journal completeness', () => {
+  test('gap 2: link coal consumption names the source mine (owner + city)', () => {
+    const { actor } = setupGame()
+    actor.send({ type: 'TRIGGER_CANAL_ERA_END' })
+    const playerId = actor.getSnapshot().context.currentPlayerIndex
+
+    // The builder owns a coal mine at birmingham and builds a rail link out of
+    // it — the coal must be drawn (free) from that specific, named mine.
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId,
+      money: 100,
+      industries: [coalMineAt('birmingham', 2)],
+    })
+
+    const card = actor.getSnapshot().context.players[playerId]!.hand[0]!
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+    actor.send({ type: 'SELECT_LINK', from: 'birmingham', to: 'coventry' })
+    actor.send({ type: 'CONFIRM' })
+
+    const log = lastActionLog(actor)
+    expect(log).toContain('built a rail link between birmingham and coventry')
+    // Names the actual mine: owner ("Player 1's") + city ("at birmingham").
+    expect(log).toContain("Player 1's coal mine at birmingham (free)")
+    // The old anonymous phrasing must be gone.
+    expect(log).not.toContain('connected coal mine (free)')
+  })
+
+  test('gap 3: build consuming market resource never duplicates "consumed"', () => {
+    const { actor } = setupGame()
+    const playerId = actor.getSnapshot().context.currentPlayerIndex
+
+    // Brewery L1 needs iron; with no connected iron works it comes from the
+    // market. The build log wraps consumption in "(consumed …)" — the market
+    // detail must NOT also start with "consumed" or it reads "consumed consumed".
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId,
+      hand: [{ id: 'brewery_test', type: 'industry', industries: ['brewery'] }],
+    })
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId, money: 50 })
+
+    actor.send({ type: 'BUILD' })
+    actor.send({ type: 'SELECT_CARD', cardId: 'brewery_test' })
+    actor.send({ type: 'SELECT_INDUSTRY_TYPE', industryType: 'brewery' })
+    actor.send({ type: 'SELECT_LOCATION', cityId: 'burton' })
+    actor.send({ type: 'CONFIRM' })
+
+    const log = lastActionLog(actor)
+    expect(log).toContain('built brewery')
+    expect(log).toContain('consumed 1 iron from market')
+    expect(log).not.toContain('consumed consumed')
+    // Exactly one "consumed" in the whole entry.
+    expect(log.match(/consumed/g)?.length).toBe(1)
+  })
+
+  test('gap 1: double-link build journals beer consumption and brewery flip', () => {
+    const { actor } = setupGame()
+    actor.send({ type: 'TRIGGER_CANAL_ERA_END' })
+    let snapshot = actor.getSnapshot()
+    expect(snapshot.context.era).toBe('rail')
+    const playerId = snapshot.context.currentPlayerIndex
+
+    // One brewery with a SINGLE barrel (so the double-link beer drains it and it
+    // flips) plus a coal mine to feed both rails.
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId,
+      money: 60,
+      industries: [breweryAt('birmingham', 1), coalMineAt('birmingham', 4)],
+    })
+
+    // Establish network so both rails and the brewery are connected.
+    let card = actor.getSnapshot().context.players[playerId]!.hand[0]!
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+    actor.send({ type: 'SELECT_LINK', from: 'birmingham', to: 'coventry' })
+    actor.send({ type: 'CONFIRM' })
+
+    // Double rail link: consumes 2 coal + 1 beer.
+    card = actor.getSnapshot().context.players[playerId]!.hand[0]!
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+    actor.send({ type: 'SELECT_LINK', from: 'coventry', to: 'nuneaton' })
+    actor.send({ type: 'CHOOSE_DOUBLE_LINK_BUILD' })
+    actor.send({
+      type: 'SELECT_SECOND_LINK',
+      from: 'birmingham',
+      to: 'wolverhampton',
+    })
+    actor.send({ type: 'EXECUTE_DOUBLE_NETWORK_ACTION' })
+
+    snapshot = actor.getSnapshot()
+    const doubleLog = [...snapshot.context.logs]
+      .reverse()
+      .find(
+        (l: any) => l.type === 'action' && l.message.includes('2 rail links'),
+      )?.message
+
+    expect(doubleLog).toBeDefined()
+    // The beer source is journaled (was previously only a generic "+ beer").
+    expect(doubleLog).toContain('beer from own brewery at birmingham (free)')
+    // Draining the last barrel flips the brewery — that must be journaled too.
+    expect(doubleLog).toContain("Player 1's brewery at birmingham flipped")
+    // Sanity: the brewery really did flip.
+    const brewery = snapshot.context.players[playerId]!.industries.find(
+      (i: any) => i.type === 'brewery',
+    )!
+    expect(brewery.flipped).toBe(true)
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -1072,7 +1072,7 @@ export const gameStore = setup({
           updatedCoalMarket[i] = coalResult.updatedCoalMarket[i]!
         }
 
-        logMessage += ` (${coalResult.logDetails.join(', ')})`
+        logMessage += ` (consumed ${coalResult.logDetails.join(', ')})`
       }
 
       const totalCost = linkCost + coalCost
@@ -1320,7 +1320,11 @@ export const gameStore = setup({
       // Track money spent
       const currentSpending = context.playerSpending[currentPlayer.id] || 0
 
-      const logMessage = `${currentPlayer.name} built 2 rail links (${context.selectedLink.from}-${context.selectedLink.to}, ${context.selectedSecondLink.from}-${context.selectedSecondLink.to}) for £${linkCost} + beer + 2 coal (£${coalCost}) (${coalLogDetails.join(', ')})`
+      // Journal what was ACTUALLY consumed: the two coal sources (incl. any
+      // mine that flipped) AND the beer source + any brewery that flipped
+      // draining its last barrel — beerResult.logDetails carries both.
+      const consumedDetails = [...coalLogDetails, ...beerResult.logDetails]
+      const logMessage = `${currentPlayer.name} built 2 rail links (${context.selectedLink.from}-${context.selectedLink.to}, ${context.selectedSecondLink.from}-${context.selectedSecondLink.to}) for £${linkCost} + 1 beer + 2 coal (£${coalCost}) (consumed ${consumedDetails.join(', ')})`
 
       debugLog('executeDoubleNetworkAction', context)
       return {

--- a/src/store/market/marketActions.ts
+++ b/src/store/market/marketActions.ts
@@ -70,13 +70,16 @@ export function consumeCoalFromSources(
       }))
 
       coalConsumed += cubesToConsume
-      if (cubesToConsume === 1) {
-        logDetails.push(`1 coal from connected coal mine (free)`)
-      } else {
-        logDetails.push(
-          `${cubesToConsume} coal from connected coal mine (free)`,
-        )
-      }
+      // Name the actual mine the coal came from (owner + city), matching how
+      // beer/iron entries name their source — the coal audit trail needs to
+      // show WHICH mine was drained, not just "a connected mine".
+      const owner = context.players.find((player) =>
+        player.industries.includes(coalMine),
+      )
+      const ownerLabel = owner ? `${owner.name}'s` : 'a'
+      logDetails.push(
+        `${cubesToConsume} coal from ${ownerLabel} coal mine at ${coalMine.location} (free)`,
+      )
     }
   }
 
@@ -97,9 +100,7 @@ export function consumeCoalFromSources(
           level.cubes--
           coalCost += level.price
           coalConsumed++
-          logDetails.push(
-            `consumed 1 coal from connected market for £${level.price}`,
-          )
+          logDetails.push(`1 coal from connected market for £${level.price}`)
           foundCoal = true
           break
         }
@@ -115,7 +116,7 @@ export function consumeCoalFromSources(
           coalCost += GAME_CONSTANTS.COAL_FALLBACK_PRICE
           coalConsumed++
           logDetails.push(
-            `consumed 1 coal from connected market for £${GAME_CONSTANTS.COAL_FALLBACK_PRICE}`,
+            `1 coal from connected market for £${GAME_CONSTANTS.COAL_FALLBACK_PRICE}`,
           )
           foundCoal = true
         }
@@ -240,13 +241,13 @@ export function consumeIronFromSources(
         if (level) {
           level.cubes--
           ironCost += level.price
-          logDetails.push(`consumed 1 iron from market for £${level.price}`)
+          logDetails.push(`1 iron from market for £${level.price}`)
           continue
         }
         // An empty market still sells, at the fallback price, forever
         ironCost += GAME_CONSTANTS.IRON_FALLBACK_PRICE
         logDetails.push(
-          `consumed 1 iron from general supply for £${GAME_CONSTANTS.IRON_FALLBACK_PRICE}`,
+          `1 iron from general supply for £${GAME_CONSTANTS.IRON_FALLBACK_PRICE}`,
         )
       }
       continue


### PR DESCRIPTION
## Why

The game journal is the audit trail for rules verification — the queued **coal next-closest-mine** investigation reads it, so entries must be complete and precise (log what the engine *actually* did, not a re-derivation). Three concrete gaps were reported from real games.

## What changed (`src/store/`)

**Gap 1 — double-link builds drop beer + flip.** `executeDoubleNetworkAction` logged a generic `+ beer` and never journaled the beer source or the brewery that flipped draining its last barrel. Now the entry appends `beerResult.logDetails` (source line + any flip) alongside the coal details.

**Gap 2 — coal source mine unnamed.** `consumeCoalFromSources` said only `1 coal from connected coal mine (free)`. Now it names **owner + city** — `Player 1's coal mine at birmingham (free)` — matching how beer/iron entries name their source, so the audit shows which mine was drained. (Uses the actual owner found in state, not a re-derivation.)

**Gap 3 — `consumed consumed`.** Build entries read `(consumed consumed 1 iron from market …)`: the build log wraps consumption in `(consumed …)` while the market/supply detail lines *also* started with `consumed`. Dropped the redundant prefix from the four market/supply detail strings so every detail is a bare source phrase and the wrapper owns the verb. Single-link builds now wrap coal the same way for consistency with the build pattern.

## Tests

- New `src/store/gameStore.journal.test.ts` pins all three gaps (each asserts the new wording and would fail on old code).
- Updated the `journal-model` parser fixtures to the new engine output; the parser handles the new format unchanged (depth-aware paren splitting).
- Frozen demo snapshots had the `consumed consumed` artifact baked in — deduped it textually in place. Regenerating is non-deterministic (random deck shuffle) and would invalidate every e2e literal pin, so it is deliberately out of scope.

Full unit suite green (585 passed), `pnpm typecheck` + `pnpm lint` clean. Pre-existing `e2e/iron-source.spec.ts:21` failure is tracked separately and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected duplicated “consumed consumed” wording in demo game logs.
  * Improved resource-consumption details for coal, iron, and beer, including specific source locations and market costs.
  * Updated rail and double-rail action logs to accurately show all consumed resources.
* **Tests**
  * Added regression coverage for complete and accurate journal entries across building and network actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->