### PR TITLE
fix(engine): blank merchant tiles never respawn beer on era reset

### DIFF
--- a/src/store/gameStore.era.test.ts
+++ b/src/store/gameStore.era.test.ts
@@ -236,34 +236,30 @@ describe('Game Store - Era and Scoring', () => {
     // NOTE: This would require checking industryTilesOnMat if implemented
   })
 
-  test('canal to rail era transition resets merchant beer', () => {
+  test('canal to rail era transition resets merchant beer only beside non-blank tiles', () => {
     const { actor } = setup()
 
-    // Set up merchants with consumed beer (hasBeer: false)
     let s = actor.getSnapshot()
     const initialMerchants = s.context.merchants || []
 
-    // Simulate merchant beer consumption during Canal era
-    if (initialMerchants.length > 0) {
-      // Modify merchant beer status to simulate consumption
-      const modifiedMerchants = initialMerchants.map((merchant) => ({
-        ...merchant,
-        hasBeer: false, // Simulate consumed beer
-      }))
+    // The 2p setup deals two BLANK merchant tiles (industryIcons: []) —
+    // those spaces have no beer barrel space, so they must NEVER hold beer.
+    const blankCount = initialMerchants.filter(
+      (m) => m.industryIcons.length === 0,
+    ).length
+    expect(blankCount).toBeGreaterThan(0)
 
-      // NOTE: This would require a test helper to modify merchant state
-      // For now, we'll test the transition logic
-    }
-
-    // Trigger canal era end
+    // Trigger canal era end (canal -> rail transition runs the beer reset)
     actor.send({ type: 'TRIGGER_CANAL_ERA_END' })
     s = actor.getSnapshot()
 
     const finalMerchants = s.context.merchants || []
 
-    // After era transition, all merchants should have beer restored
+    // Rulebook (p.9 setup / era reset): "Place 1 beer barrel on each empty
+    // beer barrel space beside a (non-blank) Merchant tile." Blank tiles get
+    // NO beer; non-blank tiles get exactly one.
     finalMerchants.forEach((merchant) => {
-      expect(merchant.hasBeer).toBe(true)
+      expect(merchant.hasBeer).toBe(merchant.industryIcons.length > 0)
     })
 
     // Verify log message about merchant beer reset

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2498,10 +2498,12 @@ export const gameStore = setup({
         }
       }
 
-      // Reset merchant beer - place 1 beer on each merchant space (per rules)
+      // Reset merchant beer - place 1 beer on each beer barrel space beside a
+      // (non-blank) Merchant tile (rules p.9). Blank tiles have no barrel
+      // space, so they never hold beer — same gate as setup (`goods.length`).
       const updatedMerchants = context.merchants.map((merchant) => ({
         ...merchant,
-        hasBeer: true,
+        hasBeer: merchant.industryIcons.length > 0,
       }))
       logMessages.push('Merchant beer reset for Rail Era')
 


### PR DESCRIPTION
## What

The canal→rail merchant-beer reset in `gameStore.ts` set `hasBeer: true` on **every** merchant unconditionally — including **blank** merchant tiles. Blank tiles (`industryIcons: []`) have no beer-barrel space and must never hold beer.

## Rule

The canonical-game comparison report (§4, deviation 2) flagged this. The report text is not checked into the repo, so the expected behavior is derived directly from the rulebook doc `ai-docs/brass-birmingham-rules.mdc`:

> Reset Merchant Beer — Place 1 beer barrel on each empty beer barrel space beside a **(non-blank)** Merchant tile. *(p.9 / setup step)*

Setup (`createMerchantsForPlayerCount`) already gated correctly on `goods.length > 0`; the era reset diverged. Root cause: one line missing the blank check.

## Fix

`hasBeer: true` → `hasBeer: merchant.industryIcons.length > 0` in the rail-era transition — the same gate setup uses.

## Test

`gameStore.era.test.ts` "canal to rail era transition resets merchant beer" **encoded the bug** — it asserted *all* merchants get beer. Reworked to assert per-merchant `hasBeer === (industryIcons.length > 0)`, and that the 2p deal actually contains blank tiles. Fails on the old code (blank got `true`), passes on the fix.

Full suite: 582 passed / 4 skipped. `e2e/iron-source.spec.ts:21` pre-existing failure ignored (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)