### PR TITLE
fix(engine): coal crosses mine tiers and judges rail links after placement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,20 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
     same guard. Pinned by `gameStore.sourcechoice.test.ts`,
     `legal-moves.test.ts`, `intent.test.ts`, `e2e/beer-source.spec.ts` +
     `?demo=beerchoice`.
+- COAL "NEAREST MINE" CONSUMPTION (`consumeCoalFromSources` +
+  `findConnectedCoalMines`, `market/marketActions.ts` + `shared/gameUtils.ts`):
+  `findConnectedCoalMines` returns EVERY connected stocked mine ordered
+  nearest-first (not just the closest tier), so a shortfall in the nearest mine
+  rolls to the next-closest — free — and the coal MARKET is charged only once
+  ALL connected mines are exhausted (rules L119-121). Rail-link coal is judged
+  AFTER the link is placed (rules L116/L308): the exec, the `hasSelectedLink`
+  guard, the double-link guard's first coal, and `refusal.ts` all source coal
+  against `withProvisionalLink(context)` (`shared/resourceSources.ts`), anchored
+  over BOTH endpoints `[from, to]` so the pick is orientation-independent
+  (`consumeCoalFromSources`/`findConnectedCoalMines`/`isLocationConnectedToMerchant`
+  accept a `CityId | CityId[]` anchor). Keep guard/exec/double-first-coal/refusal
+  in lockstep. Pinned by `gameStore.coalnearestmine.test.ts`. Equidistant-mine
+  ties are still auto-picked (discovery order) — a tie-choice UI is out of scope.
 - Link scoring: 1 VP per •-• icon on built industry tiles in the two
   adjacent locations, plus `GAME_CONSTANTS.MERCHANT_LINK_ICONS` (2) at
   merchant locations.

--- a/src/store/gameStore.coalnearestmine.test.ts
+++ b/src/store/gameStore.coalnearestmine.test.ts
@@ -1,0 +1,341 @@
+// Regression tests for coal "nearest connected mine" consumption.
+//
+// Rules (ai-docs/brass-birmingham-rules.mdc):
+//   L119-121: "The closest (fewest Link tiles distant) connected unflipped Coal
+//     Mine (owned by any player). If multiple Coal Mines are equally close,
+//     choose one. If a Coal Mine runs out of coal, and you need more, choose the
+//     next closest Coal Mine. Consuming coal in this way is free."
+//   L116/L308: a rail Link or Industry tile "must be connected to a source of
+//     coal (after it is placed)."
+//
+// Two bugs these tests pin (both previously shipped):
+//   A) A shortfall in the nearest mine's cubes must roll to the next-closest
+//      mine (still free) BEFORE the coal market is ever charged — the engine
+//      used to drain only the closest tier then fall to the market.
+//   B) A rail link's coal is judged AFTER the link is placed, over both of its
+//      endpoints — the engine used to judge it before placement, anchored only
+//      at the link's `from`, so a mine reachable only through the new link (or
+//      only from the `to` end) was invisible and the pick flipped with the
+//      from/to orientation the UI happened to send.
+import { afterEach, describe, expect, it, test } from 'vitest'
+import { createActor } from 'xstate'
+import { type GameState, type Player, gameStore } from './gameStore'
+import { consumeCoalFromSources } from './market/marketActions'
+import { findConnectedCoalMines } from './shared/gameUtils'
+
+type Industry = Player['industries'][number]
+
+function coalMine(location: string, cubes: number, flipped = false): Industry {
+  return {
+    type: 'coal',
+    location,
+    flipped,
+    coalCubesOnTile: cubes,
+    ironCubesOnTile: 0,
+    beerBarrelsOnTile: 0,
+    level: 1,
+    tile: { incomeAdvancement: 1 },
+  } as unknown as Industry
+}
+
+function player(
+  id: string,
+  industries: Industry[],
+  links: Array<{ from: string; to: string }>,
+): Player {
+  return {
+    id,
+    name: id,
+    money: 30,
+    income: 0,
+    incomeSpace: 10,
+    victoryPoints: 0,
+    hand: [],
+    industries,
+    links: links.map((l) => ({ ...l, type: 'canal' as const })),
+  } as unknown as Player
+}
+
+function makeContext(players: Player[]): GameState {
+  return {
+    players,
+    currentPlayerIndex: 0,
+    era: 'canal',
+    coalMarket: [
+      { price: 1, cubes: 1, maxCubes: 2 },
+      { price: 2, cubes: 2, maxCubes: 2 },
+      { price: 3, cubes: 2, maxCubes: 2 },
+      { price: 4, cubes: 2, maxCubes: 2 },
+      { price: 5, cubes: 2, maxCubes: 2 },
+      { price: 6, cubes: 2, maxCubes: 2 },
+      { price: 7, cubes: 2, maxCubes: 2 },
+      { price: 8, cubes: 0, maxCubes: Infinity },
+    ],
+    resources: { coal: 30, iron: 10, beer: 15 },
+  } as unknown as GameState
+}
+
+const findMine = (players: Player[], loc: string) =>
+  players
+    .flatMap((p) => p.industries)
+    .find((i) => i.type === 'coal' && i.location === loc)!
+
+const anchor = (loc: string) => loc as never
+
+describe('coal nearest-mine consumption (Bug A: shortfall rolls to next mine)', () => {
+  // Chain: birmingham -(1)- dudley -(1)- wolverhampton ; market via oxford
+  const chain = [
+    { from: 'birmingham', to: 'dudley' },
+    { from: 'dudley', to: 'wolverhampton' },
+    { from: 'birmingham', to: 'oxford' }, // merchant connection
+  ]
+
+  it('baseline: near mine (d1) drained before the far mine, free', () => {
+    const p1 = player('p1', [coalMine('dudley', 2)], chain)
+    const p2 = player('p2', [coalMine('wolverhampton', 2)], [])
+    const r = consumeCoalFromSources(
+      makeContext([p1, p2]),
+      anchor('birmingham'),
+      1,
+    )
+    expect(r.success).toBe(true)
+    expect(r.coalCost).toBe(0)
+    expect(findMine(r.updatedPlayers, 'dudley').coalCubesOnTile).toBe(1)
+    expect(findMine(r.updatedPlayers, 'wolverhampton').coalCubesOnTile).toBe(2)
+  })
+
+  it('shortfall crosses tiers free: near mine (1 cube) then next-closest, never the market', () => {
+    const p1 = player('p1', [coalMine('dudley', 1)], chain)
+    const p2 = player('p2', [coalMine('wolverhampton', 3)], [])
+    const r = consumeCoalFromSources(
+      makeContext([p1, p2]),
+      anchor('birmingham'),
+      2,
+    )
+    expect(r.success).toBe(true)
+    // Both cubes free — the second comes from the next-closest mine (rules
+    // L119-121), NOT the connected coal market.
+    expect(r.coalCost).toBe(0)
+    expect(findMine(r.updatedPlayers, 'dudley').coalCubesOnTile).toBe(0)
+    expect(findMine(r.updatedPlayers, 'wolverhampton').coalCubesOnTile).toBe(2)
+    expect(r.logDetails.some((l) => l.toLowerCase().includes('market'))).toBe(
+      false,
+    )
+  })
+
+  it('shortfall with NO market connection still succeeds via the next-closest mine', () => {
+    const noMerchant = chain.slice(0, 2) // drop the oxford link
+    const p1 = player('p1', [coalMine('dudley', 1)], noMerchant)
+    const p2 = player('p2', [coalMine('wolverhampton', 3)], [])
+    const r = consumeCoalFromSources(
+      makeContext([p1, p2]),
+      anchor('birmingham'),
+      2,
+    )
+    // Previously refused ("Insufficient coal available") because the far mine
+    // was never consulted — a legal action was blocked.
+    expect(r.success).toBe(true)
+    expect(r.coalCost).toBe(0)
+    expect(findMine(r.updatedPlayers, 'wolverhampton').coalCubesOnTile).toBe(2)
+  })
+
+  it('masking: a flipped near mine is skipped and the far stocked mine is used, free', () => {
+    const p1 = player('p1', [coalMine('dudley', 0, true)], chain)
+    const p2 = player('p2', [coalMine('wolverhampton', 2)], [])
+    const r = consumeCoalFromSources(
+      makeContext([p1, p2]),
+      anchor('birmingham'),
+      1,
+    )
+    expect(r.success).toBe(true)
+    expect(r.coalCost).toBe(0)
+    expect(findMine(r.updatedPlayers, 'wolverhampton').coalCubesOnTile).toBe(1)
+  })
+
+  it('only falls to the market once every connected mine is exhausted', () => {
+    // Need 3, both connected mines hold 1 each (total 2); the 3rd is bought.
+    const p1 = player('p1', [coalMine('dudley', 1)], chain)
+    const p2 = player('p2', [coalMine('wolverhampton', 1)], [])
+    const r = consumeCoalFromSources(
+      makeContext([p1, p2]),
+      anchor('birmingham'),
+      3,
+    )
+    expect(r.success).toBe(true)
+    // Two free cubes from the two mines, one paid cube from the £1 market space.
+    expect(r.coalCost).toBe(1)
+    expect(findMine(r.updatedPlayers, 'dudley').coalCubesOnTile).toBe(0)
+    expect(findMine(r.updatedPlayers, 'wolverhampton').coalCubesOnTile).toBe(0)
+  })
+
+  it('equidistant mines: the engine still auto-picks one (tie-choice UI is out of scope)', () => {
+    // Documents current behaviour — a proper player choice for ties is tracked
+    // separately. Two mines both one link from birmingham; discovery order wins.
+    const links = [
+      { from: 'birmingham', to: 'dudley' },
+      { from: 'birmingham', to: 'walsall' },
+    ]
+    const p1 = player('p1', [coalMine('walsall', 2)], links)
+    const p2 = player('p2', [coalMine('dudley', 2)], [])
+    const ctx = makeContext([p1, p2])
+    const mines = findConnectedCoalMines(ctx, anchor('birmingham'), p1)
+    expect(mines.length).toBe(2) // both offered at the same distance
+    const r = consumeCoalFromSources(ctx, anchor('birmingham'), 1)
+    expect(r.success).toBe(true)
+    expect(r.coalCost).toBe(0)
+  })
+})
+
+describe('coal nearest-mine consumption (Bug B: orientation independence)', () => {
+  // The new link birmingham-dudley is on the board (both endpoints anchor coal).
+  // mine1 at coventry is one link from birmingham; mine2 at wolverhampton is one
+  // link from dudley. Over both endpoints each mine is distance 1 — a tie — so
+  // the pick no longer depends on which end the UI called `from`.
+  const build = () => {
+    const links = [
+      { from: 'birmingham', to: 'dudley' }, // the placed link
+      { from: 'birmingham', to: 'coventry' },
+      { from: 'dudley', to: 'wolverhampton' },
+    ]
+    // coventry first in the industry list, so a tie resolves to it.
+    const p = player(
+      'p',
+      [coalMine('coventry', 2), coalMine('wolverhampton', 2)],
+      links,
+    )
+    return makeContext([p])
+  }
+
+  it('anchoring over both endpoints drains the same mine regardless of from/to order', () => {
+    const forward = consumeCoalFromSources(
+      build(),
+      ['birmingham', 'dudley'] as never,
+      1,
+    )
+    const swapped = consumeCoalFromSources(
+      build(),
+      ['dudley', 'birmingham'] as never,
+      1,
+    )
+    for (const r of [forward, swapped]) {
+      expect(r.success).toBe(true)
+      expect(r.coalCost).toBe(0)
+      // coventry (the tie winner) drained, wolverhampton untouched — both ways.
+      expect(findMine(r.updatedPlayers, 'coventry').coalCubesOnTile).toBe(1)
+      expect(findMine(r.updatedPlayers, 'wolverhampton').coalCubesOnTile).toBe(
+        2,
+      )
+    }
+  })
+
+  it('both endpoints see mines reachable from either end', () => {
+    const mines = findConnectedCoalMines(
+      build(),
+      ['birmingham', 'dudley'] as never,
+      {} as Player,
+    )
+    const locations = mines.map((m) => m.location).sort()
+    expect(locations).toEqual(['coventry', 'wolverhampton'])
+  })
+})
+
+describe('coal for a rail link is judged after placement (Bug B, engine level)', () => {
+  let actors: ReturnType<typeof createActor>[] = []
+  afterEach(() => {
+    actors.forEach((a) => {
+      try {
+        a.stop()
+      } catch {}
+    })
+    actors = []
+  })
+
+  const railGame = () => {
+    const actor = createActor(gameStore)
+    actors.push(actor)
+    actor.subscribe({ error: () => {} })
+    actor.start()
+    actor.send({
+      type: 'START_GAME',
+      players: [
+        {
+          id: '1',
+          name: 'Player 1',
+          color: 'red' as const,
+          character: 'Richard Arkwright' as const,
+          money: 100,
+          victoryPoints: 0,
+          income: 10,
+          industryTilesOnMat: {} as never,
+        },
+        {
+          id: '2',
+          name: 'Player 2',
+          color: 'blue' as const,
+          character: 'Eliza Tinsley' as const,
+          money: 100,
+          victoryPoints: 0,
+          income: 10,
+          industryTilesOnMat: {} as never,
+        },
+      ],
+    })
+    actor.send({ type: 'TRIGGER_CANAL_ERA_END' })
+    return actor
+  }
+
+  const nonCoalIndustry = (location: string): Industry =>
+    ({
+      type: 'cotton',
+      location,
+      flipped: false,
+      coalCubesOnTile: 0,
+      ironCubesOnTile: 0,
+      beerBarrelsOnTile: 0,
+      level: 1,
+      tile: { incomeAdvancement: 1 },
+    }) as unknown as Industry
+
+  test('a rail link joins the network to a mine reachable only through it — coal is free', () => {
+    const actor = railGame()
+    const seat = actor.getSnapshot().context.currentPlayerIndex
+
+    // Network before the build: an industry at birmingham (so the build is
+    // legal) plus a link dudley-wolverhampton with a coal mine at wolverhampton.
+    // birmingham cannot reach wolverhampton UNTIL the new birmingham-dudley
+    // link is placed — and there is no merchant connection, so pre-placement
+    // sourcing would refuse a legal action.
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: seat,
+      money: 100,
+      industries: [nonCoalIndustry('birmingham'), coalMine('wolverhampton', 2)],
+      links: [{ from: 'dudley', to: 'wolverhampton', type: 'rail' }] as never,
+    })
+
+    let snap = actor.getSnapshot()
+    const startMoney = snap.context.players[seat]!.money
+    const cardId = snap.context.players[seat]!.hand[0]!.id
+
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId })
+    actor.send({ type: 'SELECT_LINK', from: 'birmingham', to: 'dudley' })
+    actor.send({ type: 'CONFIRM' })
+
+    snap = actor.getSnapshot()
+    const me = snap.context.players[seat]!
+    // The link was actually placed (the action was not refused).
+    expect(
+      me.links.some(
+        (l) =>
+          (l.from === 'birmingham' && l.to === 'dudley') ||
+          (l.from === 'dudley' && l.to === 'birmingham'),
+      ),
+    ).toBe(true)
+    // Coal came free from the now-reachable mine — only the £5 link cost.
+    expect(me.money).toBe(startMoney - 5)
+    expect(
+      findMine(snap.context.players, 'wolverhampton').coalCubesOnTile,
+    ).toBe(1)
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -85,6 +85,7 @@ import {
   pendingBeerChoice,
   pendingIronChoice,
   withProvisionalDoubleLink,
+  withProvisionalLink,
 } from './shared/resourceSources'
 
 export type LogEntryType = 'system' | 'action' | 'info' | 'error'
@@ -393,6 +394,7 @@ type GameEvent =
       money?: number
       income?: number
       industries?: Player['industries']
+      links?: Player['links']
     }
   | {
       type: 'TEST_SET_FINAL_ROUND'
@@ -1042,6 +1044,16 @@ export const gameStore = setup({
         type: context.era,
       }
 
+      // Place the link BEFORE sourcing coal — a rail link's coal must come from
+      // a mine connected "after it is placed" (rules p.7, L116/L308). Anchoring
+      // at both endpoints also makes the mine pick independent of from/to.
+      const playersWithLink = updatePlayerInList(
+        context.players,
+        context.currentPlayerIndex,
+        { ...currentPlayer, links: [...currentPlayer.links, newLink] },
+      )
+      const contextWithLink = { ...context, players: playersWithLink }
+
       let coalCost = 0
       let coalResult: ReturnType<typeof consumeCoalFromSources> | null = null
       const updatedCoalMarket = context.coalMarket.map((level) => ({
@@ -1052,8 +1064,8 @@ export const gameStore = setup({
       // Consume coal if rail era
       if (context.era === 'rail') {
         coalResult = consumeCoalFromSources(
-          context,
-          context.selectedLink.from, // Use the source of the link
+          contextWithLink,
+          [context.selectedLink.from, context.selectedLink.to],
           1,
         )
 
@@ -1084,17 +1096,17 @@ export const gameStore = setup({
         }
       }
 
-      // Get player state after coal consumption, if any
-      const playerAfterCoal =
-        context.era === 'rail' && coalResult
-          ? coalResult.updatedPlayers[context.currentPlayerIndex]!
-          : currentPlayer
+      // Coal consumption already drained mines against the placed link, so the
+      // returned players carry both the new link and the spent cubes.
+      const playersAfterCoal = coalResult
+        ? coalResult.updatedPlayers
+        : playersWithLink
+      const playerAfterCoal = playersAfterCoal[context.currentPlayerIndex]!
 
       const updatedPlayer = {
         ...playerAfterCoal,
         hand: updatedHand,
         money: playerAfterCoal.money - totalCost,
-        links: [...playerAfterCoal.links, newLink],
       }
 
       // Track money spent
@@ -1103,7 +1115,7 @@ export const gameStore = setup({
       debugLog('executeNetworkAction', context)
       return {
         players: updatePlayerInList(
-          coalResult ? coalResult.updatedPlayers : context.players,
+          playersAfterCoal,
           context.currentPlayerIndex,
           updatedPlayer,
         ),
@@ -1209,14 +1221,14 @@ export const gameStore = setup({
         playerWithFirstLink,
       )
 
-      // Consume first coal (closest to first link)
+      // Consume first coal (closest to first link, over both its endpoints)
       const firstCoalResult = consumeCoalFromSources(
         {
           ...context,
           players: updatedPlayersAfterCoal,
           coalMarket: updatedCoalMarket,
         },
-        context.selectedLink.from,
+        [context.selectedLink.from, context.selectedLink.to],
         1,
       )
 
@@ -1254,14 +1266,15 @@ export const gameStore = setup({
         playerWithBothLinks,
       )
 
-      // Consume second coal (closest to second link, considering new network state)
+      // Consume second coal (closest to second link's endpoints, with both
+      // links now on the board)
       const secondCoalResult = consumeCoalFromSources(
         {
           ...context,
           players: updatedPlayersAfterCoal,
           coalMarket: updatedCoalMarket,
         },
-        context.selectedSecondLink.from,
+        [context.selectedSecondLink.from, context.selectedSecondLink.to],
         1,
       )
 
@@ -2346,6 +2359,7 @@ export const gameStore = setup({
           incomeSpace: highestSpaceForLevel(event.income),
         }),
         ...(event.industries !== undefined && { industries: event.industries }),
+        ...(event.links !== undefined && { links: event.links }),
       }
 
       return {
@@ -2740,11 +2754,13 @@ export const gameStore = setup({
           : GAME_CONSTANTS.RAIL_LINK_COST
       let coalCost = 0
 
-      // Check coal availability for rail era links
+      // Check coal availability for rail era links. Judge against the
+      // post-placement network (both endpoints), matching execution — a mine
+      // reachable only through the new link must be seen here too.
       if (context.era === 'rail') {
         const coalResult = consumeCoalFromSources(
-          context,
-          context.selectedLink.from,
+          withProvisionalLink(context),
+          [context.selectedLink.from, context.selectedLink.to],
           1,
         )
         if (!coalResult.success) {
@@ -3064,17 +3080,18 @@ export const gameStore = setup({
         return false
       }
 
-      // Brass has no debt: £15 plus the coal for both links must be payable
+      // Brass has no debt: £15 plus the coal for both links must be payable.
+      // Mirror execution: the FIRST link is on the board before its coal is
+      // sourced, anchored over both its endpoints.
       const firstCoal = consumeCoalFromSources(
-        context,
-        context.selectedLink.from,
+        withProvisionalLink(context),
+        [context.selectedLink.from, context.selectedLink.to],
         1,
       )
       if (!firstCoal.success) {
         return false
       }
-      // Mirror execution: the second link is on the board (and so part of the
-      // player's network) before its coal is sourced
+      // ...and both links are on the board before the second link's coal.
       const playerWithLinks =
         firstCoal.updatedPlayers[context.currentPlayerIndex]!
       const secondCoal = consumeCoalFromSources(
@@ -3087,14 +3104,13 @@ export const gameStore = setup({
               ...playerWithLinks,
               links: [
                 ...playerWithLinks.links,
-                { ...context.selectedLink, type: 'rail' as const },
                 { ...context.selectedSecondLink, type: 'rail' as const },
               ],
             },
           ),
           coalMarket: firstCoal.updatedCoalMarket,
         },
-        context.selectedSecondLink.from,
+        [context.selectedSecondLink.from, context.selectedSecondLink.to],
         1,
       )
       if (!secondCoal.success) {

--- a/src/store/market/marketActions.ts
+++ b/src/store/market/marketActions.ts
@@ -22,7 +22,10 @@ import {
 
 export function consumeCoalFromSources(
   context: GameState,
-  location: CityId,
+  // A single city, or — for a rail link — both of its endpoints. Coal is
+  // sourced from the mine closest to any anchor, and market connection is
+  // judged from any anchor too.
+  location: CityId | CityId[],
   coalRequired: number,
 ): {
   success: boolean
@@ -145,9 +148,12 @@ export function consumeCoalFromSources(
       availableSources.push('coal markets')
     }
 
+    const locationLabel = (
+      Array.isArray(location) ? location : [location]
+    ).join('/')
     if (availableSources.length === 0) {
       logDetails.push(
-        `Coal consumption failed: need ${shortfall} more coal. No coal mines or market connection available from ${location}.`,
+        `Coal consumption failed: need ${shortfall} more coal. No coal mines or market connection available from ${locationLabel}.`,
       )
     } else {
       logDetails.push(
@@ -304,10 +310,12 @@ export function consumeIronFromSources(
   }
 }
 
-// Helper function to check if a location is connected to any merchant
+// Helper function to check if a location is connected to any merchant.
+// `location` may be a single city or, for a rail link, both endpoints —
+// connection from ANY anchor counts.
 export function isLocationConnectedToMerchant(
   context: GameState,
-  location: CityId,
+  location: CityId | CityId[],
 ): { connected: boolean; connectedMerchants: CityId[] } {
   const merchantLocations: CityId[] = [
     'warrington',
@@ -317,15 +325,16 @@ export function isLocationConnectedToMerchant(
     'shrewsbury',
   ]
 
+  const anchors = Array.isArray(location) ? location : [location]
   const connectedMerchants: CityId[] = []
 
   for (const merchantLocation of merchantLocations) {
-    const distance = calculateNetworkDistance(
-      context,
-      location,
-      merchantLocation,
+    const reachable = anchors.some(
+      (anchor) =>
+        calculateNetworkDistance(context, anchor, merchantLocation) !==
+        Infinity,
     )
-    if (distance !== Infinity) {
+    if (reachable) {
       connectedMerchants.push(merchantLocation)
     }
   }

--- a/src/store/refusal.ts
+++ b/src/store/refusal.ts
@@ -43,6 +43,7 @@ import {
   ironSourceKey,
   pendingBeerChoice,
   pendingIronChoice,
+  withProvisionalLink,
 } from './shared/resourceSources'
 
 const money = (amount: number) => `£${amount}`
@@ -125,10 +126,15 @@ const explainSelectedLink = (context: GameState): string | null => {
   const cost = linkCostFor(context)
 
   if (context.era === 'rail') {
-    // Probe coal exactly as hasSelectedLink does — a rail link burns 1 coal.
-    const coal = consumeCoalFromSources(context, link.from as CityId, 1)
+    // Probe coal exactly as hasSelectedLink does — a rail link burns 1 coal,
+    // sourced against the placed link (both endpoints).
+    const coal = consumeCoalFromSources(
+      withProvisionalLink(context),
+      [link.from as CityId, link.to as CityId],
+      1,
+    )
     if (!coal.success) {
-      return `No coal reachable from ${link.from} — a rail link needs 1 coal.`
+      return `No coal reachable from ${link.from}/${link.to} — a rail link needs 1 coal.`
     }
     const total = cost + coal.coalCost
     if (player.money < total) {
@@ -203,9 +209,14 @@ const explainDoubleLink = (context: GameState): string | null => {
       'Two rails needs 1 beer — none is reachable from your network.'
     )
   }
-  const coal = consumeCoalFromSources(context, first.from as CityId, 1)
+  // Mirror the guard: the first link is on the board, coal over both endpoints.
+  const coal = consumeCoalFromSources(
+    withProvisionalLink(context),
+    [first.from as CityId, first.to as CityId],
+    1,
+  )
   if (!coal.success) {
-    return `No coal reachable from ${first.from} — each rail link needs 1 coal.`
+    return `No coal reachable from ${first.from}/${first.to} — each rail link needs 1 coal.`
   }
   const player = getCurrentPlayer(context)
   const cost = GAME_CONSTANTS.RAIL_DOUBLE_LINK_COST

--- a/src/store/shared/gameUtils.ts
+++ b/src/store/shared/gameUtils.ts
@@ -22,7 +22,9 @@ import type { IndustryTile } from '../../data/industryTiles'
  * removed from a Player Mat via Build, never via Develop (rulebook p.7,
  * "Potteries and the Lightbulb Icon").
  */
-export function isDevelopable(tile: Pick<IndustryTile, 'type' | 'hasLightbulbIcon'>): boolean {
+export function isDevelopable(
+  tile: Pick<IndustryTile, 'type' | 'hasLightbulbIcon'>,
+): boolean {
   return tile.type !== 'pottery' || !tile.hasLightbulbIcon
 }
 
@@ -135,12 +137,24 @@ export function calculateNetworkDistance(
 }
 
 // Resource consumption utility functions
+//
+// RULES (p.5, L119-121): coal comes from the closest connected unflipped Coal
+// Mine (any owner), and "if a Coal Mine runs out of coal, and you need more,
+// choose the next closest Coal Mine" — free — before the coal market is ever
+// touched. So this returns EVERY connected stocked mine, ordered nearest-first,
+// and the consumer drains them in that order until the requirement is met.
+//
+// `location` may be a single city or, for a rail link (which touches two
+// locations), both of its endpoints — a mine's distance is then measured from
+// whichever endpoint is closer (min over the anchors). Passing both endpoints
+// makes the pick independent of the link's from/to orientation.
 export function findConnectedCoalMines(
   context: GameState,
-  location: CityId,
-  currentPlayer: Player,
+  location: CityId | CityId[],
+  _currentPlayer: Player,
 ): Player['industries'] {
-  // RULE: Find closest (fewest Link tiles distant) connected unflipped Coal Mines
+  const anchors = Array.isArray(location) ? location : [location]
+
   const allCoalMines = context.players
     .flatMap((player) => player.industries)
     .filter(
@@ -154,7 +168,11 @@ export function findConnectedCoalMines(
   const minesByDistance = new Map<number, Player['industries']>()
 
   for (const mine of allCoalMines) {
-    const distance = calculateNetworkDistance(context, location, mine.location)
+    const distance = Math.min(
+      ...anchors.map((anchor) =>
+        calculateNetworkDistance(context, anchor, mine.location),
+      ),
+    )
     if (distance !== Infinity) {
       // Only include connected mines
       if (!minesByDistance.has(distance)) {
@@ -164,16 +182,11 @@ export function findConnectedCoalMines(
     }
   }
 
-  // Return mines at the closest distance (0 = same location, 1 = one link away, etc.)
+  // Return ALL connected mines, closest distance first (0 = same location,
+  // 1 = one link away, ...). Within a distance tier discovery order is kept,
+  // which is where an equidistant-mine tie is currently auto-resolved.
   const distances = Array.from(minesByDistance.keys()).sort((a, b) => a - b)
-  if (distances.length > 0) {
-    const closestDistance = distances[0]
-    if (closestDistance !== undefined) {
-      return minesByDistance.get(closestDistance) || []
-    }
-  }
-
-  return [] // No connected mines
+  return distances.flatMap((distance) => minesByDistance.get(distance) ?? [])
 }
 
 export function findAvailableIronWorks(

--- a/src/store/shared/resourceSources.ts
+++ b/src/store/shared/resourceSources.ts
@@ -424,6 +424,37 @@ export function beerChoiceForSale(
 }
 
 /**
+ * A copy of `context` with the single selected link provisionally on the
+ * current player's board. A rail link's coal is sourced from a mine connected
+ * "after it is placed" (rules p.7, L116/L308) — so the guard, execution and
+ * refusal explainer all judge coal against this post-placement network, never
+ * the raw pre-placement one (which hides a mine reachable only through the new
+ * link). Returns `context` unchanged when no link is selected.
+ */
+export function withProvisionalLink(context: GameState): GameState {
+  if (!context.selectedLink) return context
+  const me = context.players[context.currentPlayerIndex]
+  if (!me) return context
+  const updated = {
+    ...me,
+    links: [
+      ...me.links,
+      {
+        from: context.selectedLink.from,
+        to: context.selectedLink.to,
+        type: context.era,
+      },
+    ],
+  }
+  return {
+    ...context,
+    players: context.players.map((p, i) =>
+      i === context.currentPlayerIndex ? updated : p,
+    ),
+  }
+}
+
+/**
  * A copy of `context` with both selected rail links provisionally on the
  * current player's board. The rules judge the double link's beer reachability
  * "after placement" (p.9), and execution consumes beer with both rails built —


### PR DESCRIPTION
## What

Fixes two rulebook deviations in coal consumption, both currently shipped.

### Bug A — a shortfall in the nearest mine skipped farther mines

`findConnectedCoalMines` returned only the closest distance tier, and `consumeCoalFromSources` drained that tier then fell straight to the coal market. The rules (p.5) say: *"If a Coal Mine runs out of coal, and you need more, choose the next closest Coal Mine"* — free — and the market is only used *"if you are not connected to an unflipped Coal Mine"*, i.e. after **all** connected mines are exhausted.

Symptoms this caused:
- **Silent wrong charge**: the player paid market price for coal the rules give for free whenever a nearer mine ran short but a farther connected mine still had cubes.
- **Illegal refusal**: with no merchant connection, the same shortfall refused a perfectly legal build/link outright (`"Insufficient coal available"`).

`findConnectedCoalMines` now returns **every** connected stocked mine ordered nearest-first; the consumer drains them in order and only touches the market once they're all empty.

### Bug B — rail-link coal was judged before the link was placed

The single-link execution and its guard sourced coal at `selectedLink.from` on the raw, pre-placement context. The rules judge connectivity *after* the link is placed (p.7). Consequences:
- A mine reachable **only through the new link** (or only from the link's other endpoint) was invisible → wrong market charge or an illegal refusal.
- Which mine counted as "nearest" flipped depending on the from/to orientation the UI happened to send.

Coal is now sourced against a provisional context with the link on the board (`withProvisionalLink`), anchored over **both** endpoints, so the pick is orientation-independent. The single-link exec, the `hasSelectedLink` guard, the double-link guard's first coal, and the `refusal.ts` explainers all share the same post-placement / both-endpoints basis so they stay in lockstep. `consumeCoalFromSources`, `findConnectedCoalMines` and `isLocationConnectedToMerchant` now accept a single city or a pair of anchors.

Equidistant mines are still auto-picked in discovery order — offering the player a choice for ties is intentionally left as a separate change.

## Tests

New `src/store/gameStore.coalnearestmine.test.ts` pins:
- shortfall crosses tiers for free (market untouched while a far mine has coal),
- the no-merchant shortfall now succeeds instead of refusing,
- rail-link coal connectivity judged after placement (engine-level, drives the machine),
- orientation independence (same mine drained either from/to order).

A small test-only field (`links`) was added to `TEST_SET_PLAYER_STATE` so the engine-level test can seed a pre-existing network.

## Fixture impact

Full `pnpm test` (the CI glob) is green — 591 passed. No pinned coal fixture changed: none of the existing scenarios hit the market while a stocked farther mine was reachable, so the correctness change is transparent to them. `typecheck` and `lint` are clean.

_(Pre-existing, unrelated: `src/store/shared/gameUtils.industrySlots.test.ts` fails when that file is run in isolation — it fails identically on the base commit and is outside the CI `pnpm test` glob.)_