### PR TITLE
Disable automatic TTL sweep of stale games (keep for analytics)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
 # ANTHROPIC_BASE_URL and is called over the OpenAI-compatible wire.
 # BB_AI_MOCK=1 replaces the model with a deterministic mock (tests/e2e).
 
+# Stale-game TTL sweep — DISABLED by default. We currently keep every game
+# (finished, abandoned, lobbies) so snapshots + intent logs stay around for
+# analytics. Set BB_ENABLE_TTL_SWEEP=1 to re-enable the lazy 7-day sweep in
+# `sweepStaleGames`.
+# BB_ENABLE_TTL_SWEEP=1
+
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -741,9 +741,12 @@ When updating this file, preserve this bar for all agents and keep entries conci
   route handlers, EventSource auto-reconnects across dev restarts.
   WebSockets would need a custom server. Store = the `games` table (Drizzle,
   Neon/Postgres), one row per game keyed by token: jsonb `snapshot`/`seats`/
-  `messages`/`ai`, atomic upsert, 7-day TTL sweep (a DELETE) — so game state
+  `messages`/`ai`, atomic upsert — so game state
   and chat SURVIVE a redeploy (`.bb-games/` files, or any ephemeral-disk file,
-  did not). `saveGame` is version-guarded (upsert applies only when the stored
+  did not). The 7-day TTL sweep (`sweepStaleGames`, a DELETE) is DISABLED by
+  default (2026-07-22): we keep every game for analytics. It is a no-op unless
+  `BB_ENABLE_TTL_SWEEP=1`; the lazy call sites in `game.ts`
+  (`createGame`/`listLobbies`) stay wired so flipping the flag re-enables it. `saveGame` is version-guarded (upsert applies only when the stored
   `version` is lower; a stale writer throws 'Concurrent write').
 - REALTIME SYNC IS DB-AS-BUS (2026-07-15, decision doc
   `brass-realtime-arch-d6`): the `games.version` column IS the event bus —
@@ -926,8 +929,9 @@ When updating this file, preserve this bar for all agents and keep entries conci
   `applyView`/`applyChatDelta` in `mp-game.tsx`; full history stays in the
   table (swept when the game is), the view only ever ships the tail.
   Migration 0001 backfills the old jsonb `games.messages` (now vestigial —
-  kept only so the backfill stays re-runnable; drop once pre-migration games
-  age out under the 7-day TTL). Chat is public to seated players; there is no
+  kept only so the backfill stays re-runnable; drop it explicitly once
+  pre-migration games are gone — the TTL sweep no longer ages them out by
+  default, see the store note above). Chat is public to seated players; there is no
   seat-private channel. POST /api/mp/chat auths like act; spectators get no
   chat in `viewFor`. Turn notifications derive from SSE frames via
   `mp/turnNotify.ts` (`didBecomeMyTurn` — never fires on the first frame);

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -356,8 +356,10 @@ export async function createGame(
   return { token, seatId: 0, seatSecret: secret }
 }
 
-/** The public list of joinable lobbies, newest first. Sweeps stale games
- *  first (cheap, throttled) so the browser never advertises a dead table. */
+/** The public list of joinable lobbies, newest first. The stale-game sweep is
+ *  retained here as a lazy trigger but is disabled by default (see
+ *  `sweepStaleGames` — we keep all games for analytics); it is a no-op unless
+ *  `BB_ENABLE_TTL_SWEEP=1`. */
 export async function listLobbies(): Promise<LobbySummary[]> {
   await sweepStaleGames()
   return loadOpenLobbies()

--- a/src/server/mp/intentlog.test.ts
+++ b/src/server/mp/intentlog.test.ts
@@ -222,13 +222,22 @@ describe('intent log: atomicity with the version-guarded save', () => {
 
     // Backdate the game past the TTL, then sweep (bypassing the throttle by
     // moving `now` forward; the cutoff stays ~7 days in the past, so other
-    // suites' fresh games are untouched).
+    // suites' fresh games are untouched). The automatic sweep is disabled by
+    // default (analytics retention), so opt this exercise of the reap logic
+    // back in via the flag and restore it afterwards.
     await saveGame({
       ...record,
       version: record.version + 1,
       updatedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
     })
-    await sweepStaleGames(Date.now() + 2 * 60 * 60 * 1000)
+    const priorFlag = process.env.BB_ENABLE_TTL_SWEEP
+    process.env.BB_ENABLE_TTL_SWEEP = '1'
+    try {
+      await sweepStaleGames(Date.now() + 2 * 60 * 60 * 1000)
+    } finally {
+      if (priorFlag === undefined) delete process.env.BB_ENABLE_TTL_SWEEP
+      else process.env.BB_ENABLE_TTL_SWEEP = priorFlag
+    }
 
     expect(await loadGame(host.token)).toBeNull()
     expect(await loadIntentLog(host.token)).toEqual([])

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -505,8 +505,19 @@ export async function saveGame(
 
 let lastSweep = 0
 
-/** Lazily delete stale games; throttled so it costs nothing per-request. */
+/**
+ * Lazily delete stale games; throttled so it costs nothing per-request.
+ *
+ * DISABLED BY DEFAULT: the automatic TTL sweep is gated behind
+ * `BB_ENABLE_TTL_SWEEP=1` and off in every environment unless that is set. We
+ * currently keep all games — finished, abandoned, and lobbies alike — so their
+ * snapshots and intent logs stay available for analytics. The function is left
+ * intact so the sweep can be re-enabled by flipping the flag (or called
+ * directly with the flag set for a one-off manual cleanup) without a code
+ * change. The lazy call sites in `game.ts` become no-ops while the flag is off.
+ */
 export async function sweepStaleGames(now = Date.now()): Promise<void> {
+  if (process.env.BB_ENABLE_TTL_SWEEP !== '1') return
   if (now - lastSweep < 60 * 60 * 1000) return
   lastSweep = now
   // ISO-8601 timestamps sort lexicographically the same as chronologically,

--- a/src/store/gameStore.multiplayer.test.ts
+++ b/src/store/gameStore.multiplayer.test.ts
@@ -33,7 +33,8 @@ vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
 
 // The store is DB-backed (Neon/Postgres); set DATABASE_URL to a dev branch.
 // We provision the schema once per run; rows are left in the dev branch (the
-// TTL sweep and the dev-branch lifecycle clean them up).
+// per-run branch lifecycle cleans them up — the automatic TTL sweep is
+// disabled by default now, see sweepStaleGames).
 beforeAll(async () => {
   await ensureTestSchema()
 })


### PR DESCRIPTION
## What

Disable the automatic 7-day TTL sweep of stale multiplayer games. We want to keep every game — finished, abandoned, and lobbies — so their snapshots and intent logs stay available for analytics.

`sweepStaleGames` (`src/server/mp/store.ts`) is now gated behind a `BB_ENABLE_TTL_SWEEP` env flag and returns early (a no-op) unless it's set to `1`. The lazy call sites in `createGame` and `listLobbies` stay wired, so the sweep can be re-enabled by flipping the flag, or run as a one-off manual cleanup with the flag set — no code change needed. The reap logic itself is untouched.

## Why now (ops note)

We had test/junk games on prod that the sweep would eventually clean, but the sweep also deletes *real* games 7 days after their last activity. Two real games abandoned mid-play (`N_w4X_-J`, `l6tY7XlW`) were already removed by the sweep before this change landed. The two remaining real games on prod (`UMcH5nvr`, a finished game; `orE2U3Ip`, an active one) were last touched on Jul 16 and become sweep-eligible around Jul 23 — so this should merge and deploy before then to avoid losing them to the next `createGame` call.

## Changes

- `store.ts` — `sweepStaleGames` gated on `BB_ENABLE_TTL_SWEEP === '1'`, defaults off; docstring explains the retention rationale and the re-enable path.
- `game.ts` — updated the `listLobbies` docstring (the sweep is now a no-op by default).
- `intentlog.test.ts` — the sweep test opts the flag back in (and restores it) to exercise the reap logic.
- `gameStore.multiplayer.test.ts` — corrected a comment that assumed the sweep still auto-runs.
- `.env.example` / `AGENTS.md` — document the toggle.

## Testing

- `pnpm test` — 596 pass, 4 skipped (63 files), against the local Docker DB.
- `pnpm lint` + `pnpm typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatic cleanup of stale games is now disabled by default.
  - Cleanup can be re-enabled with the `BB_ENABLE_TTL_SWEEP=1` setting.
  - Games and related records are retained by default for snapshots and intent logs.

- **Documentation**
  - Updated configuration and multiplayer persistence documentation to explain retention and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->