### PR TITLE
Deal official starting discard pile at setup + draw-deck counter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,15 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   ties keep relative order). Do not rotate `currentPlayerIndex` directly.
 - Hands refill at END of turn (entry of the `nextPlayer` state), not per
   action. A player whose hand is empty takes fewer actions
-  (`canContinueTurn` guard) and is skipped between turns.
+  (`canContinueTurn` guard) and is skipped between turns. `refillPlayerHand`
+  logs the one-off "Draw deck exhausted" system line on the >0 → 0 transition
+  (once per era); `journal-model.ts` renders it as a divider.
+- SETUP SEEDS THE DISCARD PILE (rules l.402, added 2026-07-22): after dealing
+  8-card hands, `initializeGame` deals 1 more card PER PLAYER into the single
+  shared `discardPile`, so post-setup draw deck = 22/27/28 for 2/3/4 players
+  (not 24/30/32). Tests that assumed an empty starting discard must account
+  for the N seeded cards. Setup only — the rail-era reset still deals 8 to
+  hand with no extra discard. Pinned by `gameStore.setupdiscard.test.ts`.
 - Actions must NEVER throw inside `assign` (it kills the actor and, on the
   server, strands the persisted snapshot). Use the `lastError`/
   `errorContext` pattern; a failed execution returns without consuming the

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -930,6 +930,9 @@ function GameInner({
           <span className="bb2-chip" data-testid="round-chip">
             Round {ctx.round}
           </span>
+          <span className="bb2-chip" data-testid="deck-chip">
+            Deck {ctx.drawPile.length}
+          </span>
           <span className="bb2-chip">
             Actions
             <span className="flex items-center gap-1">

--- a/src/components/journal-model.test.ts
+++ b/src/components/journal-model.test.ts
@@ -271,6 +271,17 @@ describe('system entries and dividers', () => {
     expect(item.kind).toBe('system')
     expect(item.divider).toBeUndefined()
   })
+
+  test('draw-deck exhaustion becomes its own divider', () => {
+    const item = parse(
+      'Draw deck exhausted — hands shrink each round from here',
+      'system',
+    )
+    expect(item.kind).toBe('system')
+    expect(item.divider).toBe(
+      'Draw deck exhausted — hands shrink each round from here',
+    )
+  })
 })
 
 describe('errors and fallbacks', () => {

--- a/src/components/journal-model.ts
+++ b/src/components/journal-model.ts
@@ -198,6 +198,11 @@ function parseSystemEntry(message: string): JournalItem | null {
   if (ERA_DIVIDERS.some((re) => re.test(message))) {
     return { ...base, kind: 'era', divider: message }
   }
+  // Deck exhaustion is a one-off turning point (hands start shrinking), so it
+  // reads as its own divider rather than a numbered action row.
+  if (/^Draw deck exhausted\b/.test(message)) {
+    return { ...base, kind: 'system', divider: message }
+  }
   return null
 }
 

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -1295,6 +1295,9 @@ function MpTable({
           <span className="bb2-chip" data-testid="round-chip">
             Round {ctx.round}
           </span>
+          <span className="bb2-chip" data-testid="deck-chip">
+            Deck {ctx.drawPile.length}
+          </span>
           <span className="bb2-chip">
             Actions
             <span className="flex items-center gap-1">

--- a/src/store/gameStore.build.test.ts
+++ b/src/store/gameStore.build.test.ts
@@ -119,8 +119,10 @@ describe('Game Store - Build Actions', () => {
     expect(builtIndustry).toBeDefined()
     expect(builtIndustry!.type).toBe('coal')
     expect(builtIndustry!.location).toBe('dudley')
-    expect(snapshot.context.discardPile.length).toBe(1)
-    expect(snapshot.context.discardPile[0]!.id).toBe('coal_test')
+    // Setup seeds a face-down starting discard (1 per player, rules l.402), so
+    // the played card lands on top of those 2.
+    expect(snapshot.context.discardPile.length).toBe(3)
+    expect(snapshot.context.discardPile.at(-1)!.id).toBe('coal_test')
   })
 
   test('build industry - player state updates', () => {

--- a/src/store/gameStore.gameloop.test.ts
+++ b/src/store/gameStore.gameloop.test.ts
@@ -130,7 +130,11 @@ describe('Game loop - automatic era end and game over', () => {
 
     // Give P1 a visible income level (start is level 0 since the income
     // track audit) so the era-end collection can be asserted.
-    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 0, income: 10 } as any)
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: 0,
+      income: 10,
+    } as any)
     const moneyBefore = (actor.getSnapshot() as any).context.players[0].money
 
     // Complete the final canal round
@@ -143,8 +147,28 @@ describe('Game loop - automatic era end and game over', () => {
     const p0 = s.context.players.find((p: any) => p.id === '1')
     expect(p0.money).toBe(moneyBefore + 10)
 
+    // Force rail-era exhaustion the same way, so the game ends in one more
+    // round with no income collected on that (final) round. The setup discard
+    // deal (rules l.402) reshuffles into the rail deck, so we must empty it
+    // explicitly rather than relying on the canal round having drained it.
+    actor.send({ type: 'TEST_SET_DRAW_PILE', drawPile: [] } as any)
+    s = actor.getSnapshot() as any
+    const railHand0 = s.context.players[0].hand
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: 0,
+      hand: [railHand0[0]],
+    } as any)
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: 1,
+      hand: [railHand0[1] ?? railHand0[0]],
+    } as any)
+
     // Now drive to game end and confirm no income is paid for the final round
-    const moneyBeforeFinal = s.context.players.map((p: any) => p.money)
+    const moneyBeforeFinal = (actor.getSnapshot() as any).context.players.map(
+      (p: any) => p.money,
+    )
     let guard = 0
     while (!actor.getSnapshot().matches('gameOver') && guard < 20) {
       const snap = actor.getSnapshot() as any

--- a/src/store/gameStore.integration.test.ts
+++ b/src/store/gameStore.integration.test.ts
@@ -703,8 +703,9 @@ describe('Brass Birmingham - Full Game Integration', () => {
 
     const snap = actor.getSnapshot() as any
     expect(snap.context.players).toHaveLength(4)
-    // 4-player deck: 64 cards - 32 dealt into hands leaves 32 to draw
-    expect(snap.context.drawPile).toHaveLength(64 - 4 * 8)
+    // 4-player deck: 64 cards − 32 dealt into hands − 4 into the starting
+    // discard piles (rules l.402) leaves 28 to draw
+    expect(snap.context.drawPile).toHaveLength(64 - 4 * 8 - 4)
 
     const actions = playFullGame(actor, greedyPolicy)
     const c = expectCompletedGame(actor, actions, 4)

--- a/src/store/gameStore.setup.test.ts
+++ b/src/store/gameStore.setup.test.ts
@@ -121,7 +121,9 @@ describe('Game Store - Basic Setup', () => {
     const snapshot = actor.getSnapshot()
 
     expect(snapshot.context.drawPile.length).toBeGreaterThan(0)
-    expect(snapshot.context.discardPile).toHaveLength(0)
+    // Official setup deals 1 face-down card per player as their starting
+    // discard pile (rules l.402); our shared pile holds one per player.
+    expect(snapshot.context.discardPile).toHaveLength(2)
     expect(snapshot.context.wildLocationPile.length).toBeGreaterThan(0)
     expect(snapshot.context.wildIndustryPile.length).toBeGreaterThan(0)
   })

--- a/src/store/gameStore.setupdiscard.test.ts
+++ b/src/store/gameStore.setupdiscard.test.ts
@@ -1,0 +1,141 @@
+// Official setup deals each player a face-down starting Discard Pile
+// (rules l.401-402): 8 cards to hand PLUS 1 to discard. We model one shared
+// discard pile, so this is N cards dealt into it, bringing the post-setup draw
+// deck to the official 22/27/28 for 2/3/4 players. These tests pin the counts
+// and the downstream effect the fix was for: with the official deck, a 3-player
+// no-scout game hits deck-death on a round boundary, so hands stay even.
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import { gameStore } from './gameStore'
+
+let activeActors: ReturnType<typeof createActor>[] = []
+
+afterEach(() => {
+  activeActors.forEach((actor) => {
+    try {
+      actor.stop()
+    } catch {}
+  })
+  activeActors = []
+})
+
+const COLORS = ['red', 'blue', 'green', 'yellow'] as const
+const CHARACTERS = [
+  'Richard Arkwright',
+  'Eliza Tinsley',
+  'Isambard Kingdom Brunel',
+  'George Stephenson',
+] as const
+
+const makePlayers = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({
+    id: String(i + 1),
+    name: `P${i + 1}`,
+    color: COLORS[i]!,
+    character: CHARACTERS[i]!,
+    money: 17,
+    victoryPoints: 0,
+    income: 10,
+    industryTilesOnMat: {} as any,
+  }))
+
+const startGame = (count: number) => {
+  const actor = createActor(gameStore)
+  activeActors.push(actor)
+  actor.start()
+  actor.send({ type: 'START_GAME', players: makePlayers(count) })
+  return actor
+}
+
+// Pass one action with the current player's first card. Only valid when it is
+// that player's action step and they hold a card.
+const passOneAction = (actor: ReturnType<typeof createActor>) => {
+  const s = actor.getSnapshot() as any
+  const player = s.context.players[s.context.currentPlayerIndex]
+  actor.send({ type: 'PASS' } as any)
+  actor.send({ type: 'SELECT_CARD', cardId: player.hand[0].id } as any)
+  actor.send({ type: 'CONFIRM' } as any)
+}
+
+describe('Setup — starting discard pile (rules l.402)', () => {
+  test.each([
+    [2, 22],
+    [3, 27],
+    [4, 28],
+  ])(
+    '%i-player setup: N cards in discard, official draw deck remains',
+    (count, expectedDraw) => {
+      const s = startGame(count).getSnapshot() as any
+
+      // Each player got a full 8-card hand.
+      s.context.players.forEach((p: any) => expect(p.hand).toHaveLength(8))
+      // One face-down card per player seeded the shared discard pile.
+      expect(s.context.discardPile).toHaveLength(count)
+      // Official post-setup draw deck.
+      expect(s.context.drawPile).toHaveLength(expectedDraw)
+      // No cards created or lost: 8*N in hands + N in discard + deck.
+      expect(
+        8 * count + s.context.discardPile.length + s.context.drawPile.length,
+      ).toBe(8 * count + count + expectedDraw)
+    },
+  )
+})
+
+describe('Setup discard → even deck-death for a 3-player no-scout game', () => {
+  test('first post-exhaustion round starts with even hands, exhaustion logs once', () => {
+    const actor = startGame(3)
+
+    // Record deck size + hand sizes at the start of each round as pass-only
+    // play burns the deck. Stop once every hand has emptied (or as a safety
+    // cap) — we never Scout, so nothing leaves the draw deck early.
+    const roundStarts: { round: number; deck: number; hands: number[] }[] = []
+    const snapshotRoundStart = () => {
+      const s = actor.getSnapshot() as any
+      roundStarts.push({
+        round: s.context.round,
+        deck: s.context.drawPile.length,
+        hands: s.context.players.map((p: any) => p.hand.length),
+      })
+    }
+
+    snapshotRoundStart()
+    let lastRound = 1
+    let guard = 0
+    while (guard++ < 3000) {
+      const s = actor.getSnapshot() as any
+      if (s.context.era !== 'canal') break
+      if (!s.matches({ playing: { action: 'selectingAction' } })) break
+      const player = s.context.players[s.context.currentPlayerIndex]
+      if (player.hand.length === 0) break
+      passOneAction(actor)
+      const after = actor.getSnapshot() as any
+      if (after.context.round !== lastRound && after.context.era === 'canal') {
+        lastRound = after.context.round
+        snapshotRoundStart()
+      }
+    }
+
+    // The deck runs out exactly at a round boundary with the official 27-card
+    // deck, so the first round that begins with the deck empty shows even
+    // hands (the divergence the fix addresses).
+    const firstEmpty = roundStarts.find((r) => r.deck === 0)
+    expect(firstEmpty).toBeDefined()
+    const hands = firstEmpty!.hands
+    expect(new Set(hands).size).toBe(1)
+    expect(hands[0]).toBe(8)
+
+    // And the round after it stays even as hands shrink together.
+    const nextRound = roundStarts.find((r) => r.round === firstEmpty!.round + 1)
+    expect(nextRound).toBeDefined()
+    expect(new Set(nextRound!.hands).size).toBe(1)
+    expect(nextRound!.hands[0]).toBe(6)
+
+    // The exhaustion notice fires exactly once for the era, on the >0 → 0
+    // transition — never again while the deck stays empty.
+    const s = actor.getSnapshot() as any
+    const exhaustionLines = s.context.logs.filter((l: any) =>
+      /^Draw deck exhausted/.test(l.message),
+    )
+    expect(exhaustionLines).toHaveLength(1)
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -660,6 +660,18 @@ export const gameStore = setup({
         currentIndex += GAME_CONSTANTS.STARTING_HAND_SIZE
       }
 
+      // Official setup (rules p.11, l.402): after drawing their 8-card hand
+      // each player draws 1 more card face down as their starting Discard
+      // Pile. We keep a single shared discard pile, so the per-player,
+      // face-down distinction has no effect once setup is done — deal one
+      // card per player into it. This brings the post-setup draw deck to the
+      // official 22/27/28 for 2/3/4 players.
+      const startingDiscard = shuffledCards.slice(
+        currentIndex,
+        currentIndex + playerCount,
+      )
+      currentIndex += playerCount
+
       // Initialize players with starting money, income, hands, and industry tiles
       const players: Player[] = event.players.map((playerData, index) => ({
         ...playerData,
@@ -709,7 +721,7 @@ export const gameStore = setup({
         ],
         logs: [createLogEntry('Game started', 'system')],
         drawPile: shuffledCards.slice(currentIndex),
-        discardPile: [],
+        discardPile: startingDiscard,
         wildLocationPile: wildLocationCards,
         wildIndustryPile: wildIndustryCards,
         selectedCard: null,
@@ -1959,6 +1971,13 @@ export const gameStore = setup({
 
       const newCards = drawCards(context, cardsNeeded)
       const updatedHand = [...currentPlayer.hand, ...newCards]
+      const newDrawPile = context.drawPile.slice(cardsNeeded)
+
+      // The deck can only reach empty here (refill is the sole draw within an
+      // era, and it just decreases). This branch runs on the single >0 → 0
+      // transition, so the notice logs exactly once per era; from here hands
+      // shrink each round (rules l.33).
+      const justExhausted = newDrawPile.length === 0
 
       debugLog('refillPlayerHand', context)
       return {
@@ -1967,7 +1986,18 @@ export const gameStore = setup({
           context.currentPlayerIndex,
           { hand: updatedHand },
         ),
-        drawPile: context.drawPile.slice(cardsNeeded),
+        drawPile: newDrawPile,
+        ...(justExhausted
+          ? {
+              logs: [
+                ...context.logs,
+                createLogEntry(
+                  'Draw deck exhausted — hands shrink each round from here',
+                  'system',
+                ),
+              ],
+            }
+          : {}),
       }
     }),
 


### PR DESCRIPTION
## What & why

Two changes that came out of the round-8 hand-size question on the live 3-player game:

### 1. Deal the official starting discard pile at setup (rules fidelity)

Per the rulebook (p.11), at setup each player draws **8 cards to hand plus 1 face-down card as their starting Discard Pile**. Our engine dealt the 8-card hands but skipped that extra card, so the post-setup draw deck was one-per-player too large (24/30/32 instead of the official 22/27/28 for 2/3/4 players).

`initializeGame` now deals 1 card per player from the shuffled deck into the discard pile after the hands. **We model a single shared discard pile**, so the per-player, face-down distinction has no gameplay effect once setup is done — the cards just need to be out of the draw deck, which is what matters for pacing. This is setup-only; the Canal→Rail reset is unchanged (still 8 to hand, no extra discard, matching the rulebook's era-end steps).

Why it matters beyond fidelity: with the official 27-card deck a 3-player no-scout game hits deck exhaustion exactly on a round boundary, so hands stay even — the uneven 6/8/7 spread that prompted the question was an artifact of the extra card, not a refill bug (refill accounting was already correct).

### 2. Surface the draw deck in-game

- **Deck-count chip** in the masthead (hotseat and online), next to the round/actions chips, so shrinking hands late in an era read as expected rather than arbitrary.
- **Journal line** when the deck first empties: *"Draw deck exhausted — hands shrink each round from here."* It fires exactly once per era (on the >0 → 0 transition; refill early-returns once the deck is already empty), and `journal-model.ts` renders it as a divider.

## Compatibility with live games

Purely additive — no state-shape change. `discardPile` and `drawPile` already exist on every snapshot; only `initializeGame` (run at `START_GAME`) changed, so in-flight games are untouched. The deck chip reads `drawPile.length`, which is present on old snapshots (and length-preserving through the MP seat filter, so opponents see the correct public count). The exhaustion line only logs on a future refill, so a live game whose deck is already empty simply never shows it — no crash, no retroactive log.

## Tests

- New `gameStore.setupdiscard.test.ts`: per-player-count deck/discard counts (2p→22, 3p→27, 4p→28, N in discard, card conservation), a scripted 3-player no-scout game asserting even hands at the first post-exhaustion round, and that the exhaustion line logs exactly once per era.
- New `journal-model.test.ts` case for the exhaustion divider.
- Re-pinned the few existing literals that assumed an empty starting discard (`gameStore.setup.test.ts`, `gameStore.build.test.ts`, `gameStore.integration.test.ts`, `gameStore.gameloop.test.ts`).
- Full unit suite, lint, typecheck, and the offline Playwright subset (atlas / coverage / round-curtain, 17 tests) all green. Browser-verified: a fresh 3-player game starts at **Deck 27**.

Demo fixtures were left as-is: they are frozen, internally consistent game states used only for UI journeys, and no test derives setup counts from them — regenerating would churn many pinned e2e literals for no functional gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Screenshots

Fresh 3-player game, round 1 — the masthead now shows **DECK 27**, confirming the official starting discard pile is dealt and the deck count is surfaced in-game:

![Deck counter in a fresh 3-player game](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-57-images/pr57-deck-counter.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Deck indicator showing the current draw-pile size in game and multiplayer views.
  * Games now begin with one face-down discard card per player.
  * Added a clear journal divider when the draw deck is exhausted.
  * Player hands remain evenly sized as the deck runs out.

* **Bug Fixes**
  * Corrected deck and discard-pile handling during setup and deck exhaustion.
  * Updated final-round behavior to prevent incorrect income collection.

* **Tests**
  * Expanded coverage for setup, card conservation, deck exhaustion, and journal updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
