### PR TITLE
fix(ui): explain why pottery cannot be developed instead of hiding it

### DIFF
--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -24,6 +24,7 @@ import {
   pendingIronChoice,
 } from '~/store/shared/resourceSources'
 import { CardChip, cardTitle } from './cards'
+import { blockedIndustries, developableIndustries } from './develop-block'
 import {
   doubleLinkDisabledReason,
   showsDoubleLinkOption,
@@ -183,12 +184,8 @@ function DevelopTilePicker({
   const [counts, setCounts] = useState<Partial<Record<IndustryType, number>>>(
     {},
   )
-  const developable = INDUSTRY_TYPES.filter((t) => {
-    const tiles = currentPlayer.industryTilesOnMat[t] || []
-    return tiles.some(
-      (tw) => tw.quantityAvailable > 0 && isDevelopable(tw.tile),
-    )
-  })
+  const developable = developableIndustries(currentPlayer.industryTilesOnMat)
+  const blocked = blockedIndustries(currentPlayer.industryTilesOnMat)
   const available = (t: IndustryType) =>
     (currentPlayer.industryTilesOnMat[t] || [])
       .filter((tw) => isDevelopable(tw.tile))
@@ -250,6 +247,29 @@ function DevelopTilePicker({
           )
         })}
       </div>
+      {blocked.map(({ type, reason }) => (
+        <div key={type} className="flex flex-col gap-1">
+          <button
+            type="button"
+            className="bb2-option relative flex-col !items-center gap-1.5 py-2.5"
+            data-testid={`develop-blocked-${type}`}
+            disabled
+            title={reason}
+          >
+            <IndustryGlyph type={type} size={20} />
+            <span className="text-[10.5px] font-semibold uppercase tracking-[0.1em]">
+              {type === 'manufacturer' ? 'Goods' : type}
+            </span>
+          </button>
+          <p
+            className="text-[12.5px] leading-snug"
+            data-testid={`develop-blocked-reason-${type}`}
+            style={{ color: '#d68d80' }}
+          >
+            {reason}
+          </p>
+        </div>
+      ))}
       <Confirm disabled={total === 0} onClick={() => onPick(selection)}>
         Scrap {total === 2 ? 'two tiles' : total === 1 ? 'one tile' : 'tiles'}
       </Confirm>

--- a/src/components/develop-block.test.ts
+++ b/src/components/develop-block.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import type { IndustryTileWithQuantity } from '~/data/industryTiles'
+import {
+  POTTERY_LIGHTBULB_REASON,
+  blockedIndustries,
+  developableIndustries,
+  type IndustryMat,
+} from './develop-block'
+
+const tile = (
+  over: Partial<IndustryTileWithQuantity['tile']> & {
+    quantityAvailable?: number
+  },
+): IndustryTileWithQuantity => {
+  const { quantityAvailable = 1, ...tileOver } = over
+  return {
+    quantityAvailable,
+    tile: {
+      type: 'coal',
+      level: 1,
+      hasLightbulbIcon: false,
+      ...tileOver,
+    },
+  } as unknown as IndustryTileWithQuantity
+}
+
+const potteryLightbulb = (quantityAvailable = 1) =>
+  tile({ type: 'pottery', level: 1, hasLightbulbIcon: true, quantityAvailable })
+const potteryPlain = (quantityAvailable = 1) =>
+  tile({
+    type: 'pottery',
+    level: 2,
+    hasLightbulbIcon: false,
+    quantityAvailable,
+  })
+
+const mat = (over: IndustryMat): IndustryMat => ({
+  cotton: [],
+  coal: [],
+  iron: [],
+  manufacturer: [],
+  pottery: [],
+  brewery: [],
+  ...over,
+})
+
+describe('developableIndustries', () => {
+  it('lists an industry with a developable tile on the mat', () => {
+    expect(
+      developableIndustries(mat({ coal: [tile({ type: 'coal' })] })),
+    ).toEqual(['coal'])
+  })
+
+  it('lists pottery while a non-lightbulb tile remains', () => {
+    expect(
+      developableIndustries(
+        mat({ pottery: [potteryLightbulb(), potteryPlain()] }),
+      ),
+    ).toEqual(['pottery'])
+  })
+
+  it('omits an industry whose only tiles are non-developable', () => {
+    expect(
+      developableIndustries(mat({ pottery: [potteryLightbulb()] })),
+    ).toEqual([])
+  })
+
+  it('omits an industry with nothing left on the mat', () => {
+    expect(
+      developableIndustries(
+        mat({ coal: [tile({ type: 'coal', quantityAvailable: 0 })] }),
+      ),
+    ).toEqual([])
+  })
+})
+
+describe('blockedIndustries', () => {
+  it('blocks pottery when only lightbulb tiles remain, with the rulebook reason', () => {
+    expect(blockedIndustries(mat({ pottery: [potteryLightbulb()] }))).toEqual([
+      { type: 'pottery', reason: POTTERY_LIGHTBULB_REASON },
+    ])
+  })
+
+  it('does not block pottery while a developable tile remains', () => {
+    expect(
+      blockedIndustries(mat({ pottery: [potteryLightbulb(), potteryPlain()] })),
+    ).toEqual([])
+  })
+
+  it('does not block an industry the player no longer holds', () => {
+    expect(blockedIndustries(mat({ pottery: [potteryLightbulb(0)] }))).toEqual(
+      [],
+    )
+  })
+
+  it('ignores developable industries', () => {
+    expect(blockedIndustries(mat({ coal: [tile({ type: 'coal' })] }))).toEqual(
+      [],
+    )
+  })
+})

--- a/src/components/develop-block.ts
+++ b/src/components/develop-block.ts
@@ -1,0 +1,70 @@
+// Which industries the Develop tile picker can and cannot offer, in words.
+//
+// The picker used to simply omit any industry with no developable tile, so a
+// player holding a lightbulb Pottery saw it vanish and had no way to learn WHY
+// it could not be scrapped. The picker now lists those industries DISABLED and
+// asks this module what to say — mirroring how `double-link-availability`
+// explains a refused double rail. Legality itself still comes from
+// `isDevelopable` (the same check the engine's Develop action uses); this only
+// EXPLAINS the block.
+import { type IndustryType, industryDisplayName } from '~/data/cards'
+import type { IndustryTileWithQuantity } from '~/data/industryTiles'
+import { isDevelopable } from '~/store/shared/gameUtils'
+
+/** The player's mat, keyed by industry — the shape `Player.industryTilesOnMat`. */
+export type IndustryMat = Partial<
+  Record<IndustryType, IndustryTileWithQuantity[]>
+>
+
+/**
+ * Rulebook p.7, "Potteries and the Lightbulb Icon": the lightbulb Pottery
+ * tiles (levels 1 and 3) may never be developed — they leave the mat only when
+ * built over, and block the higher Pottery levels until they do.
+ */
+export const POTTERY_LIGHTBULB_REASON =
+  'Pottery cannot be developed — the lightbulb tiles are removed only by building over them, which then unlocks the higher Pottery levels (rulebook p.7).'
+
+/** Tiles of this industry still on the mat (quantity remaining). */
+function heldTiles(
+  mat: IndustryMat,
+  type: IndustryType,
+): IndustryTileWithQuantity[] {
+  return (mat[type] || []).filter((t) => t.quantityAvailable > 0)
+}
+
+/** Industries with at least one tile the Develop action may legally remove. */
+export function developableIndustries(mat: IndustryMat): IndustryType[] {
+  return (Object.keys(mat) as IndustryType[]).filter((type) =>
+    heldTiles(mat, type).some((t) => isDevelopable(t.tile)),
+  )
+}
+
+export interface DevelopBlock {
+  type: IndustryType
+  reason: string
+}
+
+/**
+ * Industries the player still holds on the mat but cannot develop right now —
+ * every remaining tile is flagged non-developable. Each carries the sentence to
+ * show under its disabled option. The order follows the mat's own key order so
+ * it is stable across renders.
+ */
+export function blockedIndustries(mat: IndustryMat): DevelopBlock[] {
+  const blocks: DevelopBlock[] = []
+  for (const type of Object.keys(mat) as IndustryType[]) {
+    const held = heldTiles(mat, type)
+    if (held.length === 0) continue
+    if (held.some((t) => isDevelopable(t.tile))) continue
+    const lightbulbPottery = held.some(
+      (t) => t.tile.type === 'pottery' && t.tile.hasLightbulbIcon,
+    )
+    blocks.push({
+      type,
+      reason: lightbulbPottery
+        ? POTTERY_LIGHTBULB_REASON
+        : `${industryDisplayName(type)} cannot be developed.`,
+    })
+  }
+  return blocks
+}


### PR DESCRIPTION
## What

Live-playtest feedback: when a player tries to Develop pottery, nothing explained why it wasn't allowed. The Develop tile picker simply omitted any industry with no developable tile on the mat, so a player left holding a lightbulb Pottery saw the option vanish and had no way to learn why.

## Rule

Rulebook p.7 ("Potteries and the Lightbulb Icon"): the lightbulb Pottery tiles (levels 1 and 3) may never be developed — they leave the mat only when built over, and block the higher Pottery levels until they do.

## Change

- The picker now lists such an industry as a **disabled option with an inline reason**, instead of hiding it — mirroring how the double-rail affordance renders disabled-with-reason rather than disappearing.
- Legality still comes from the same `isDevelopable` check the engine uses, so the message can never disagree with what the engine allows.
- Generic over any non-developable industry, not a pottery-only hardcode.
- The block-and-reason logic lives in a DOM-free `develop-block` module so it's unit-tested directly, following the existing `double-link-availability` / `refusal` split.

## Safety

UI/message-only. No engine state shape or intent payload changes — safe to ship while a live game is running.

## Tests

- New `src/components/develop-block.test.ts` pins the block set and the rulebook reason string, and that a still-developable pottery is not blocked.
- Engine already pins that lightbulb pottery is never removed by Develop (`gameStore.develop.test.ts`).
- Full unit suite, lint, typecheck green. (`e2e/iron-source.spec.ts:21` is a pre-existing unrelated failure.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
