### PR TITLE
feat(journal): report turn order and income levels at round end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -720,6 +720,16 @@ When updating this file, preserve this bar for all agents and keep entries conci
   device on). Both seed "already seen" from the booted snapshot so a resume/join
   never replays an old round. The summary is PUBLIC (spends and turn order are
   visible at any table) and passes `filterSnapshotForSeat` unfiltered.
+- END-OF-ROUND JOURNAL (2026-07-22): the same `nextPlayer` round-complete
+  branch also LOGS the transition — one `Turn order set by spending, least
+  first: <name £spent>, …` line, then the per-player income lines, both listed
+  in the NEW turn order (settlement iterates `newTurnOrder`; the players array
+  keeps its index order). Each income line carries the level as an `(income
+  level N)` fragment that `journal-model.ts` lifts into a chip (`chipFor`); both
+  lines are SKIPPED on the game's final round (no income, no next turn). Shapes
+  are additive, so pre-existing journals still render. Pinned by
+  `gameStore.endroundlog.test.ts`; teach `journal-model.ts` + its test about any
+  new round-end line shape in the same commit.
 - UNDO (2026-07-15) is HOTSEAT-ONLY and shell-level: `game.tsx` snapshots the
   machine at turn start (`turnAnchor`) and remounts from it; one action
   undoable while the same player still has an action left. Multiplayer undo

--- a/src/components/journal-model.ts
+++ b/src/components/journal-model.ts
@@ -139,6 +139,14 @@ function chipFor(piece: string): JournalChip | null {
   if (income) return { text: `+${income[1]} income`, tone: 'income' }
   const penalty = /^-(\d+) income$/.exec(piece)
   if (penalty) return { text: `−${penalty[1]} income`, tone: 'penalty' }
+  const level = /^income level (-?\d+)$/.exec(piece)
+  if (level) {
+    const n = Number(level[1])
+    return {
+      text: `income level ${n < 0 ? '−' : ''}${Math.abs(n)}`,
+      tone: n < 0 ? 'penalty' : 'income',
+    }
+  }
   if (/^£\d+$/.test(piece)) return { text: piece, tone: 'money' }
   if (/^shortfall: £\d+$/.test(piece)) return { text: piece, tone: 'penalty' }
   if (

--- a/src/store/gameStore.endroundlog.test.ts
+++ b/src/store/gameStore.endroundlog.test.ts
@@ -1,0 +1,214 @@
+// End-of-round journal tests — the round boundary now reports the new turn
+// order (who spent what) and each player's income level alongside the money
+// collected or paid, listed in the order players will act next round.
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import { parseJournalEntry } from '../components/journal-model'
+import type { PlayerRef } from '../components/journal-model'
+import type { LogEntryType } from './gameStore'
+import { gameStore } from './gameStore'
+
+const entry = (message: string, type: LogEntryType) => ({
+  message,
+  type,
+  timestamp: new Date('2026-07-22T12:00:00Z'),
+})
+
+let activeActors: ReturnType<typeof createActor>[] = []
+
+afterEach(() => {
+  activeActors.forEach((actor) => {
+    try {
+      actor.stop()
+    } catch {}
+  })
+  activeActors = []
+})
+
+const player = (id: string) => ({
+  id,
+  name: `P${id}`,
+  color: (['red', 'blue', 'green', 'purple'] as const)[Number(id) - 1]!,
+  character: (
+    [
+      'Richard Arkwright',
+      'Eliza Tinsley',
+      'Isambard Kingdom Brunel',
+      'George Stephenson',
+    ] as const
+  )[Number(id) - 1]!,
+  money: 30,
+  victoryPoints: 0,
+  income: 10,
+  industryTilesOnMat: {} as any,
+})
+
+const setup = (count = 3) => {
+  const actor = createActor(gameStore)
+  activeActors.push(actor)
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: Array.from({ length: count }, (_, i) => player(String(i + 1))),
+  })
+  return { actor }
+}
+
+const pass = (actor: ReturnType<typeof createActor>) => {
+  const s: any = actor.getSnapshot()
+  const p = s.context.players[s.context.currentPlayerIndex]!
+  actor.send({ type: 'PASS' })
+  actor.send({ type: 'SELECT_CARD', cardId: p.hand[0]!.id })
+  actor.send({ type: 'CONFIRM' })
+}
+
+const buildLink = (
+  actor: ReturnType<typeof createActor>,
+  from: string,
+  to: string,
+) => {
+  const s: any = actor.getSnapshot()
+  const p = s.context.players[s.context.currentPlayerIndex]!
+  actor.send({ type: 'NETWORK' })
+  actor.send({ type: 'SELECT_CARD', cardId: p.hand[0]!.id })
+  actor.send({ type: 'SELECT_LINK', from, to })
+  actor.send({ type: 'CONFIRM' })
+}
+
+const messages = (actor: ReturnType<typeof createActor>) =>
+  (actor.getSnapshot() as any).context.logs.map(
+    (l: any) => l.message,
+  ) as string[]
+
+const indexOfMatch = (msgs: string[], re: RegExp) =>
+  msgs.findIndex((m) => re.test(m))
+
+describe('Game Store - end-of-round journal', () => {
+  test('logs the new turn order with each spend, least spender first', () => {
+    const { actor } = setup(3)
+
+    buildLink(actor, 'worcester', 'gloucester') // P1 spends £3
+    pass(actor) // P2 spends £0
+    pass(actor) // P3 spends £0
+
+    // £0 spenders keep their relative order, then the £3 spender.
+    expect((actor.getSnapshot() as any).context.turnOrder).toEqual([
+      '2',
+      '3',
+      '1',
+    ])
+
+    const line = messages(actor).find((m) => /^Turn order/.test(m))
+    expect(line).toBeDefined()
+    expect(line).toBe(
+      'Turn order set by spending, least first: P2 £0, P3 £0, P1 £3',
+    )
+  })
+
+  test('reports each income level and the money settled, in new turn order', () => {
+    const { actor } = setup(3)
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 0, income: 5 }) // P1
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId: 1, income: 12 }) // P2
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: 2,
+      income: -2,
+      money: 30,
+    }) // P3 pays
+
+    buildLink(actor, 'worcester', 'gloucester') // P1 £3
+    pass(actor) // P2 £0
+    pass(actor) // P3 £0
+
+    const msgs = messages(actor)
+
+    // Each line carries the income level as well as the money change.
+    expect(msgs).toContain('P2 collected £12 income (income level 12)')
+    expect(msgs).toContain('P1 collected £5 income (income level 5)')
+    expect(msgs).toContain('P3 paid £2 negative income (income level -2)')
+
+    // Listed in the NEW turn order: P2, then P3, then P1.
+    const iP2 = indexOfMatch(msgs, /^P2 collected/)
+    const iP3 = indexOfMatch(msgs, /^P3 paid/)
+    const iP1 = indexOfMatch(msgs, /^P1 collected/)
+    expect(iP2).toBeGreaterThanOrEqual(0)
+    expect(iP2).toBeLessThan(iP3)
+    expect(iP3).toBeLessThan(iP1)
+
+    // The turn-order line leads the block, above the income lines.
+    const iOrder = indexOfMatch(msgs, /^Turn order/)
+    expect(iOrder).toBeGreaterThanOrEqual(0)
+    expect(iOrder).toBeLessThan(iP2)
+  })
+
+  test('the income-level fragment renders as a chip in the journal', () => {
+    const players: PlayerRef[] = [{ name: 'P2', color: 'blue' }]
+
+    const collected = parseJournalEntry(
+      entry('P2 collected £12 income (income level 12)', 'info'),
+      players,
+    )
+    expect(collected.kind).toBe('income')
+    expect(collected.main).toBe('collected £12 income')
+    expect(collected.chips).toContainEqual({
+      text: 'income level 12',
+      tone: 'income',
+    })
+
+    const paid = parseJournalEntry(
+      entry('P2 paid £2 negative income (income level -2)', 'info'),
+      players,
+    )
+    expect(paid.main).toBe('paid £2 negative income')
+    expect(paid.chips).toContainEqual({
+      text: 'income level −2',
+      tone: 'penalty',
+    })
+  })
+
+  test('a shortfall keeps both the income-level and shortfall chips', () => {
+    const players: PlayerRef[] = [{ name: 'P1', color: 'red' }]
+    const item = parseJournalEntry(
+      entry(
+        'P1 paid £6 negative income (income level -6, shortfall: £3)',
+        'info',
+      ),
+      players,
+    )
+    expect(item.main).toBe('paid £6 negative income')
+    expect(item.chips).toContainEqual({
+      text: 'income level −6',
+      tone: 'penalty',
+    })
+    expect(item.chips).toContainEqual({
+      text: 'shortfall: £3',
+      tone: 'penalty',
+    })
+  })
+
+  test('no income or turn-order block on the final game round', () => {
+    const { actor } = setup(2)
+    // Empty the draw pile and leave each player one card, so this round is the
+    // rail-era end — the game's final round, where no income is collected.
+    actor.send({ type: 'TEST_SET_ERA', era: 'rail' } as any)
+    actor.send({ type: 'TEST_SET_DRAW_PILE', drawPile: [] } as any)
+    const s: any = actor.getSnapshot()
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: 0,
+      hand: [s.context.players[0]!.hand[0]!],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: 1,
+      hand: [s.context.players[1]!.hand[0]!],
+    })
+
+    pass(actor)
+    pass(actor)
+
+    const msgs = messages(actor)
+    expect(msgs.some((m) => /income level/.test(m))).toBe(false)
+    expect(msgs.some((m) => /^Turn order/.test(m))).toBe(false)
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2036,6 +2036,23 @@ export const gameStore = setup({
         const isFinalGameRound =
           context.isFinalRound || (context.era === 'rail' && isEraOver)
 
+        // Announce the turn order the spending just decided (least spender
+        // leads). Skipped on the game's final round — there is no next turn.
+        if (!isFinalGameRound) {
+          const orderLine = newTurnOrder
+            .map((playerId) => {
+              const p = updatedPlayers.find((pl) => pl.id === playerId)
+              return `${p?.name ?? playerId} £${context.playerSpending[playerId] || 0}`
+            })
+            .join(', ')
+          logs.push(
+            createLogEntry(
+              `Turn order set by spending, least first: ${orderLine}`,
+              'info',
+            ),
+          )
+        }
+
         // Money before settlement, so the summary can report the income
         // delta the players actually experienced (a shortfall pays only
         // what it can) rather than the nominal income figure.
@@ -2043,9 +2060,15 @@ export const gameStore = setup({
           updatedPlayers.map((player) => [player.id, player.money]),
         )
 
-        // 2. Collect income (if not final round of the game)
+        // 2. Collect income (if not final round of the game). Settle each
+        // player in the NEW turn order so the journal reads top-to-bottom in
+        // the order players will act next round; the players array itself
+        // keeps its original order (indices are load-bearing elsewhere).
         if (!isFinalGameRound) {
-          updatedPlayers = updatedPlayers.map((player) => {
+          const settledById = new Map<string, Player>()
+          for (const settleId of newTurnOrder) {
+            const player = updatedPlayers.find((p) => p.id === settleId)
+            if (!player) continue
             const updatedPlayer = { ...player }
 
             if (player.income >= 0) {
@@ -2053,7 +2076,7 @@ export const gameStore = setup({
               updatedPlayer.money += player.income
               logs.push(
                 createLogEntry(
-                  `${player.name} collected £${player.income} income`,
+                  `${player.name} collected £${player.income} income (income level ${player.income})`,
                   'info',
                 ),
               )
@@ -2066,7 +2089,7 @@ export const gameStore = setup({
                 updatedPlayer.money -= amountOwed
                 logs.push(
                   createLogEntry(
-                    `${player.name} paid £${amountOwed} negative income`,
+                    `${player.name} paid £${amountOwed} negative income (income level ${player.income})`,
                     'info',
                   ),
                 )
@@ -2147,15 +2170,16 @@ export const gameStore = setup({
 
                 logs.push(
                   createLogEntry(
-                    `${player.name} paid £${amountOwed} negative income (shortfall: £${shortfall})`,
+                    `${player.name} paid £${amountOwed} negative income (income level ${player.income}, shortfall: £${shortfall})`,
                     'info',
                   ),
                 )
               }
             }
 
-            return updatedPlayer
-          })
+            settledById.set(settleId, updatedPlayer)
+          }
+          updatedPlayers = updatedPlayers.map((p) => settledById.get(p.id) ?? p)
         }
 
         const income: Record<string, number> = {}


### PR DESCRIPTION
## What

Live-playtest feedback: the end-of-round journal under-reported the round transition. It now states, in the new turn order:

- **Turn order** — one line naming the next round's order with each player's spend (`Turn order set by spending, least first: P2 £0, P3 £0, P1 £3`). Least spender leads; equal spenders keep their relative order.
- **Income** — each player's income level alongside the money collected or paid (including negative income), e.g. `P2 collected £12 income (income level 12)` / `P3 paid £2 negative income (income level -2)`.

Both blocks are listed in the order players will act next round. They are skipped on the game's final round, where no income is collected.

## How

- `nextPlayer`'s round-complete branch settles income by iterating the new turn order (the `players` array keeps its index order, which is load-bearing elsewhere) and emits the turn-order line ahead of the income lines.
- Income log lines gain an `(income level N)` fragment. `journal-model.ts` lifts it into a chip via `chipFor` (income tone for ≥0, penalty for negative), rendered in the real journal panel.

## Retroactive safety

The message shapes are purely additive — a live game's existing journal renders unchanged, and the shortfall line keeps its previous substring. No stored data shape changed.

## Tests

- New `gameStore.endroundlog.test.ts` drives a scripted 3-player round end and asserts the turn-order line, the per-player income levels, and their ordering; plus the journal-model chip parsing and the final-round suppression.
- Full unit suite, lint, and typecheck are green. Existing journal and income tests are unaffected.

## Verified in the UI

Played a hotseat round to completion; the journal panel shows the `ROUND 1 COMPLETED` divider, `collected £0 income` with an `INCOME LEVEL 0` chip per player, and the turn-order line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * End-of-round journals now show the next turn order, with players ordered by spending.
  * Added income settlement entries for each player, including income levels and collected or owed amounts.
  * Income levels now appear as color-coded journal chips, including distinct handling for penalties and shortfalls.

* **Bug Fixes**
  * Improved settlement ordering so journal entries match the newly determined turn order.
  * Final-round journals no longer include irrelevant turn-order or income entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->