### PR TITLE
fix(engine): let a double rail's second link build off the first link's new network

### DIFF
--- a/src/store/gameStore.network.test.ts
+++ b/src/store/gameStore.network.test.ts
@@ -465,6 +465,136 @@ describe('Game Store - Network Actions', () => {
     expect(snapshot.context.discardPile).toContainEqual(card)
   })
 
+  // Regression (live game y9KEazF6ldi9sQu4FXufhQ, Jules): the SECOND rail of a
+  // double Network action must be allowed to build off the FIRST link's new
+  // network extension. Each link is placed separately, so after the first link
+  // is chosen its far endpoint is part of the network the second link is judged
+  // against (rules p.9 diagram — link B off link A's far end). Previously the
+  // second-link adjacency ignored the staged first link, so a merchant like
+  // Shrewsbury reachable ONLY via the first link's far endpoint was refused.
+  test('double rail - second link may extend off the first link (rules p.9)', () => {
+    const { actor } = setupGame()
+
+    actor.send({ type: 'TRIGGER_CANAL_ERA_END' })
+    let snapshot = actor.getSnapshot()
+    expect(snapshot.context.era).toBe('rail')
+
+    const pid = snapshot.context.currentPlayerIndex
+    // Player anchors the network ONLY at kidderminster (a coal mine, supplies
+    // both links' coal) and owns a brewery for the double link's beer. No links
+    // on the board (rail era just began). coalbrookdale is NOT in the network
+    // except via the first link that is about to be placed.
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: pid,
+      money: 50,
+      links: [],
+      industries: [
+        {
+          location: 'kidderminster',
+          type: 'coal',
+          level: 1,
+          flipped: false,
+          tile: {
+            id: 'coal_1',
+            type: 'coal',
+            level: 1,
+            canBuildInCanalEra: true,
+            canBuildInRailEra: false,
+            incomeAdvancement: 4,
+            victoryPoints: 1,
+            cost: 5,
+            incomeSpaces: 4,
+            linkScoringIcons: 1,
+            coalRequired: 0,
+            ironRequired: 0,
+            beerRequired: 0,
+            beerProduced: 0,
+            coalProduced: 2,
+            ironProduced: 0,
+            hasLightbulbIcon: false,
+            quantity: 2,
+          },
+          coalCubesOnTile: 3,
+          ironCubesOnTile: 0,
+          beerBarrelsOnTile: 0,
+        },
+        {
+          location: 'birmingham',
+          type: 'brewery',
+          level: 2,
+          flipped: false,
+          tile: {
+            id: 'brewery_2',
+            type: 'brewery',
+            level: 2,
+            canBuildInCanalEra: true,
+            canBuildInRailEra: true,
+            incomeAdvancement: 5,
+            victoryPoints: 5,
+            cost: 7,
+            incomeSpaces: 5,
+            linkScoringIcons: 1,
+            coalRequired: 1,
+            ironRequired: 0,
+            beerRequired: 0,
+            beerProduced: 1,
+            coalProduced: 0,
+            ironProduced: 0,
+            hasLightbulbIcon: false,
+            quantity: 1,
+          },
+          coalCubesOnTile: 0,
+          ironCubesOnTile: 0,
+          beerBarrelsOnTile: 2,
+        },
+      ],
+    })
+
+    snapshot = actor.getSnapshot()
+    const card = snapshot.context.players[pid]!.hand[0]!
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+    // First link anchored at kidderminster (in network); coalbrookdale is only
+    // reached BY this link.
+    actor.send({ type: 'SELECT_LINK', from: 'coalbrookdale', to: 'kidderminster' })
+    actor.send({ type: 'CHOOSE_DOUBLE_LINK_BUILD' })
+    snapshot = actor.getSnapshot()
+    expect(
+      snapshot.matches({
+        playing: { action: { networking: 'selectingSecondLink' } },
+      }),
+    ).toBe(true)
+
+    // THE BUG: Shrewsbury connects only to coalbrookdale, which is in the
+    // network solely via the first link just chosen. It must be offered.
+    expect(
+      snapshot.can({
+        type: 'SELECT_SECOND_LINK',
+        from: 'coalbrookdale',
+        to: 'shrewsbury',
+      }),
+    ).toBe(true)
+
+    // And the whole double link must complete: £15 + coal (own mine) + beer.
+    const moneyBefore = snapshot.context.players[pid]!.money
+    actor.send({
+      type: 'SELECT_SECOND_LINK',
+      from: 'coalbrookdale',
+      to: 'shrewsbury',
+    })
+    resolveCoalTies(actor)
+    actor.send({ type: 'EXECUTE_DOUBLE_NETWORK_ACTION' })
+    snapshot = actor.getSnapshot()
+
+    const links = snapshot.context.players[pid]!.links
+    expect(links).toHaveLength(2)
+    expect(
+      links.some((l) => l.to === 'shrewsbury' || l.from === 'shrewsbury'),
+    ).toBe(true)
+    expect(moneyBefore - snapshot.context.players[pid]!.money).toBe(15)
+  })
+
   test('single rail link building - cost £5 + 1 coal', () => {
     const { actor } = setupGame()
 

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -2903,16 +2903,23 @@ export const gameStore = setup({
         return true
       }
 
-      // Special handling for second link in double link building
+      // The second link of a double Network action may build off the FIRST
+      // link's new network extension: each link is placed separately, so the
+      // first link's connected locations are part of the network the second
+      // link is judged against (rules p.9 diagram — link B off link A's far
+      // end). The first link is only staged in context.selectedLink until
+      // execution, so fold it in provisionally when judging the second link's
+      // adjacency. (`withProvisionalLink` is a no-op for a first/single link,
+      // where selectedLink is still null.)
       if (event.type === 'SELECT_SECOND_LINK') {
         if (!context.selectedLink) {
           return false
         }
-
-        // Second link follows same network adjacency rules as regular links
-        // (No special adjacency requirement between the two links)
-        // Continue to regular network adjacency check below
       }
+      const networkPlayer =
+        event.type === 'SELECT_SECOND_LINK'
+          ? getCurrentPlayer(withProvisionalLink(context))
+          : currentPlayer
 
       // Check if link is adjacent to player's network
       // A location is part of your network if:
@@ -2922,12 +2929,12 @@ export const gameStore = setup({
       const playerLocations = new Set<CityId>()
 
       // Add locations with player's industries
-      currentPlayer.industries.forEach((industry) => {
+      networkPlayer.industries.forEach((industry) => {
         playerLocations.add(industry.location)
       })
 
       // Add locations adjacent to player's links (incl. farm breweries)
-      currentPlayer.links.forEach((link) => {
+      networkPlayer.links.forEach((link) => {
         for (const loc of linkConnectedLocations(link.from, link.to)) {
           playerLocations.add(loc)
         }


### PR DESCRIPTION
## Summary

The second rail of a double Network action was wrongly refused when its only route into the player's network ran through the **first** link placed in the same action. Fixing it unblocks a live 3-player game where a player's rail to **Shrewsbury** could not be built.

## The bug

In a double Network action the two rail links are placed separately, so per the rules (p.9, "Understanding Your Networks") the second link may build off the **first link's new network extension**. But `canBuildLink` (`src/store/gameStore.ts`) judged the second link's network adjacency against the player's *committed* `links`, which don't yet include the first link — it's only staged in `context.selectedLink` until `EXECUTE_DOUBLE_NETWORK_ACTION`. So any location reachable only via the first link was dimmed at `SELECT_SECOND_LINK`.

Concretely: with a `coalbrookdale → kidderminster` first link (anchored at the player's kidderminster coal mine), the merchant **Shrewsbury** — whose only connection is `coalbrookdale ↔ shrewsbury` — was refused, even though `coalbrookdale` had just become part of the network. Coal, beer and the £15 cost were all satisfiable; the link simply was never offered.

This is the same "judge before placement" class as #53 (rail-link coal) and the double-link beer check, in the one spot they didn't cover.

## The fix

Judge the second link's adjacency against `withProvisionalLink(context)` — the same post-placement network the sibling coal (#53) and double-link beer checks already use. It's a no-op for a first/single link (`selectedLink` is `null`), so single links and the first link of a double are unchanged.

## Testing

- Added a regression test in `gameStore.network.test.ts` (`double rail - second link may extend off the first link`): asserts the Shrewsbury second link is offered and drives the whole double link to completion (£15 spent, both rails placed). Verified **red** without the fix, **green** with it.
- Full `pnpm test` glob: 608 passing. `pnpm lint` clean.
- The existing double-link test only ever chose a second link adjacent to an *industry*, so this network-extension path was previously uncovered.

Reproduced from a live game (rail era, round 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)