### PR TITLE
feat(ui): highlight a player's network when hovering their name

### DIFF
--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -213,6 +213,13 @@ export interface BoardMapProps {
    */
   focusCity?: string | null
   /**
+   * Hover-a-name spotlight: the id of the player whose network is hovered in
+   * the top rail right now (null = off). Their built links and industry tiles
+   * light up in their colour; everything else recedes so you can read who owns
+   * what at a glance. Purely presentational — reuses the your-network band.
+   */
+  highlightPlayerId?: string | null
+  /**
    * Game-end scoring overlay: VP earned per city and per route by ONE player
    * (null = off). Annotated places get a brass VP roundel; everything else
    * recedes, so the score reads off the board. Links are destroyed by era
@@ -244,6 +251,7 @@ export function BoardMap({
   hoverCities = null,
   locatedCity = null,
   focusCity = null,
+  highlightPlayerId = null,
   vpAnnotations = null,
   vpColor = null,
 }: BoardMapProps) {
@@ -490,6 +498,17 @@ export function BoardMap({
     return map
   }, [players])
 
+  // Hover-a-name spotlight: the hovered player's colour + the cities where
+  // they hold a tile. Links are matched per-route against builtLinks below.
+  const highlight = useMemo(() => {
+    if (!highlightPlayerId) return null
+    const p = players.find((pl) => pl.id === highlightPlayerId)
+    if (!p) return null
+    const cities = new Set<string>()
+    for (const ind of p.industries) cities.add(ind.location)
+    return { color: PLAYER_FILL[p.color], cities }
+  }, [highlightPlayerId, players])
+
   const merchantsByCity = useMemo(() => {
     const map = new Map<CityId, Merchant[]>()
     for (const m of merchants) {
@@ -696,12 +715,28 @@ export function BoardMap({
                 : types.includes('canal')
                   ? 'canal'
                   : 'rail'
+            const isHighlighted =
+              highlight !== null && built?.player.id === highlightPlayerId
             const dimmed =
               (pickingLink && !isLegal && !isSelected) ||
-              (vpAnnotations !== null && linkVp === undefined)
+              (vpAnnotations !== null && linkVp === undefined) ||
+              (highlight !== null && !isHighlighted)
 
             return (
               <g key={key} opacity={dimmed ? 0.3 : 1}>
+                {/* hover-a-name spotlight: a colour halo under the owner's
+                    route so their network reads at a glance */}
+                {isHighlighted && highlight && (
+                  <path
+                    d={d}
+                    fill="none"
+                    stroke={highlight.color}
+                    strokeOpacity="0.55"
+                    strokeWidth="12"
+                    strokeLinecap="round"
+                    pointerEvents="none"
+                  />
+                )}
                 {!activeThisEra && !built ? (
                   // ghost — corridor exists but not in this era
                   <path
@@ -894,7 +929,8 @@ export function BoardMap({
               entries={merchantsByCity.get(id) ?? []}
               dimmed={
                 pickingCity ||
-                (vpAnnotations !== null && !vpAnnotations.cities.has(id))
+                (vpAnnotations !== null && !vpAnnotations.cities.has(id)) ||
+                highlight !== null
               }
               inNetwork={networkCities?.has(id) ?? false}
               networkColor={networkColor}
@@ -919,10 +955,13 @@ export function BoardMap({
                 isSelected={selectedCity === id}
                 dimmed={
                   (pickingCity && !isLegal && selectedCity !== id) ||
-                  (vpAnnotations !== null && !vpAnnotations.cities.has(id))
+                  (vpAnnotations !== null && !vpAnnotations.cities.has(id)) ||
+                  (highlight !== null && !highlight.cities.has(id))
                 }
                 inNetwork={networkCities?.has(id) ?? false}
                 networkColor={networkColor}
+                highlighted={highlight?.cities.has(id) ?? false}
+                highlightColor={highlight?.color ?? null}
                 hoverHint={hoverCities?.has(id) ?? false}
                 located={locatedCity === id}
                 vp={vpAnnotations?.cities.get(id)}
@@ -1175,6 +1214,8 @@ function CityPlate({
   onClick,
   inNetwork = false,
   networkColor = null,
+  highlighted = false,
+  highlightColor = null,
   hoverHint = false,
   located = false,
   vp = undefined,
@@ -1189,6 +1230,9 @@ function CityPlate({
   onClick: () => void
   inNetwork?: boolean
   networkColor?: string | null
+  /** Hover-a-name spotlight: this plate holds a tile of the hovered player. */
+  highlighted?: boolean
+  highlightColor?: string | null
   hoverHint?: boolean
   located?: boolean
   /** Game-end: VP the shown player earned here (undefined = none). */
@@ -1280,6 +1324,22 @@ function CityPlate({
           stroke={networkColor}
           strokeOpacity="0.75"
           strokeWidth="2"
+          pointerEvents="none"
+        />
+      )}
+      {/* hover-a-name spotlight — same band, in the hovered player's colour */}
+      {highlighted && highlightColor && (
+        <rect
+          x="-7"
+          y="-7"
+          width={plateW + 14}
+          height={plateH + 14}
+          rx={isFarm ? 18 : 12}
+          fill={highlightColor}
+          fillOpacity="0.16"
+          stroke={highlightColor}
+          strokeOpacity="0.9"
+          strokeWidth="2.4"
           pointerEvents="none"
         />
       )}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -404,6 +404,9 @@ function GameInner({
   )
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
+  // Hover-a-name spotlight: the player whose rail mat is hovered/focused right
+  // now — the board lights up their network (links + tiles) and recedes the rest.
+  const [hoveredPlayerId, setHoveredPlayerId] = useState<string | null>(null)
   // Hover-to-locate: which city's NAME (journal, pickers, ledger…) is under
   // the cursor/focus right now — its plate gets the map's surveyor's mark.
   const locateState = useLocateCityState()
@@ -963,6 +966,7 @@ function GameInner({
           turnOrder={ctx.turnOrder}
           playerSpending={ctx.playerSpending}
           onOpenLedger={(id) => setLedgerFor(id)}
+          onHoverPlayer={setHoveredPlayerId}
         />
 
         {/* ---------- main: board + dock ---------- */}
@@ -993,6 +997,7 @@ function GameInner({
                 }
                 locatedCity={locateState.locatedCity}
                 focusCity={needsReveal ? null : focusCityFor(hoveredCard)}
+                highlightPlayerId={needsReveal ? null : hoveredPlayerId}
               />
             </div>
           </div>

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -905,6 +905,9 @@ function MpTable({
 }) {
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
+  // Hover-a-name spotlight: the player whose rail mat is hovered/focused right
+  // now — the board lights up their network (links + tiles) and recedes the rest.
+  const [hoveredPlayerId, setHoveredPlayerId] = useState<string | null>(null)
   // Hover-to-locate: which city's NAME (journal, pickers, ledger…) is under
   // the cursor/focus right now — its plate gets the map's surveyor's mark.
   const locateState = useLocateCityState()
@@ -1349,6 +1352,7 @@ function MpTable({
           turnOrder={ctx.turnOrder}
           playerSpending={ctx.playerSpending}
           onOpenLedger={(id) => setLedgerFor(id)}
+          onHoverPlayer={setHoveredPlayerId}
         />
 
         <div className="flex min-h-0 flex-col gap-3 px-3 pb-3 lg:flex-1 lg:flex-row">
@@ -1370,6 +1374,7 @@ function MpTable({
                 hoverCities={hoverCities}
                 locatedCity={locateState.locatedCity}
                 focusCity={focusCityFor(hoveredCard)}
+                highlightPlayerId={hoveredPlayerId}
               />
             </div>
           </div>

--- a/src/components/player-rail.tsx
+++ b/src/components/player-rail.tsx
@@ -42,12 +42,15 @@ export function PlayerRail({
   turnOrder,
   playerSpending,
   onOpenLedger,
+  onHoverPlayer,
 }: {
   players: Player[]
   currentPlayerId: string | undefined
   turnOrder: GameState['turnOrder']
   playerSpending: GameState['playerSpending']
   onOpenLedger?: (playerId: string) => void
+  /** Hovering/focusing a mat spotlights that player's network on the board. */
+  onHoverPlayer?: (playerId: string | null) => void
 }) {
   const ordered = [...players].sort(
     (a, b) => turnOrder.indexOf(a.id) - turnOrder.indexOf(b.id),
@@ -69,7 +72,16 @@ export function PlayerRail({
             className="bb2-mat min-w-[290px] text-left lg:min-w-0"
             data-testid={`mat-${p.id}`}
             data-current={isCurrent}
-            onClick={() => onOpenLedger?.(p.id)}
+            onClick={() => {
+              // Clear the spotlight so a tap (which fires mouseenter but no
+              // matching mouseleave on touch) can't wedge the board highlighted.
+              onHoverPlayer?.(null)
+              onOpenLedger?.(p.id)
+            }}
+            onMouseEnter={() => onHoverPlayer?.(p.id)}
+            onMouseLeave={() => onHoverPlayer?.(null)}
+            onFocus={() => onHoverPlayer?.(p.id)}
+            onBlur={() => onHoverPlayer?.(null)}
             title={`Open ${p.name}'s ledger`}
           >
             <div


### PR DESCRIPTION
## What

Hovering (or focusing) a player's mat in the top rail spotlights that player's built links and industry tiles on the board and de-emphasizes everything else — so at a glance you can see who owns what.

## How

- `PlayerRail` mats get hover/focus handlers (`onHoverPlayer`) that report the hovered player id up to the surface.
- `BoardMap` gains a `highlightPlayerId` prop. When set, it derives that player's tiled cities + colour and:
  - draws a colour halo under each of that player's built links,
  - shows the existing "your network" band (in the player's colour) on each city holding one of their tiles,
  - dims every other route, plate, and merchant.
- Reuses the player colours already on the owner ribbons and the your-network band treatment — no new visual language.

## Notes

- Purely presentational: no engine / state-machine changes, no journal entries.
- Hover/focus driven (desktop playtest surface). A tap on a mat clears the spotlight before opening the ledger, so touch play can't wedge the board in a highlighted state.
- Independent of the existing city-hover and your-network highlighting (separate props), so they don't interfere.
- Wired on both the hotseat (`game.tsx`) and multiplayer (`mp-game.tsx`) surfaces.

## Verification

- `pnpm test` (607 passed, 4 skipped), `pnpm lint`, `pnpm typecheck` — all green.
- Browser-checked against the `?demo` fixture: hovering a name with a built link shows a colour halo on that link + bands on their tiles with the rest of the board dimmed; unhover restores the normal board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

Hovering **Isambard** in the top rail on the `?demo` fixture — his built links and industry tiles get a teal spotlight while the rest of the board dims:

![Hovering a player name highlights their network](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-62-images/pr62-hover.png)
