### PR TITLE
test(e2e): fix stale iron-source journal pin

### DIFF
--- a/e2e/iron-source.spec.ts
+++ b/e2e/iron-source.spec.ts
@@ -37,10 +37,13 @@ test('the iron picker offers every works but never the market, and the develop c
   await confirm.click()
 
   // The journal renders the tile count as a chip and the iron consumption
-  // as a demoted detail line — same words, restructured.
+  // as a demoted detail line — same words, restructured. Industry names are
+  // proper-cased on render ("Iron works"), so match case-insensitively while
+  // still pinning the source: this must fail if the line vanishes or the iron
+  // is reported as coming from the market instead of the free works.
   await expect(
     page
-      .getByText(/developed removed 1 tile 1 iron from iron works \(free\)/)
+      .getByText(/developed removed 1 tile 1 iron from iron works \(free\)/i)
       .first(),
   ).toBeVisible()
 })


### PR DESCRIPTION
## Problem

`e2e/iron-source.spec.ts:21` failed on clean `main`. The develop-flow assertion pinned the iron-consumption journal line with a case-sensitive substring:

```
/developed removed 1 tile 1 iron from iron works \(free\)/
```

The journal view proper-cases industry names on render, so the actual DOM text is `... developed removed 1 tile 1 Iron from Iron works (free) · ...`. The lowercase pin no longer matched.

## Diagnosis

Not a copy regression. The engine log string stays lowercase (`marketActions.ts` pushes `1 iron from iron works (free)`); the journal *view* capitalizes industry tokens by design — `segmentPlaces`/`industryDisplayName` in `journal-model.ts`, pinned by `journal-model.test.ts:429` (`prettifyPlaces('2 iron from iron works (free)')` → `'2 Iron from Iron works (free)'`). The e2e assertion was simply written against the old lowercase copy.

## Fix

Add the `/i` flag to the regex. This survives the proper-casing without weakening what the test proves: it still fails if the develop line disappears or reports the iron as coming from the market instead of the free works (the whole point of the iron-source fixture).

## Verification

- `e2e/iron-source.spec.ts` — both tests green.
- Full Playwright suite — 46 passed.
- `pnpm lint` + `pnpm typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage for iron sourcing in the journal.
  * Verifies that iron is reported as sourced from iron works for free, rather than from the market.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->