### PR TITLE
feat(ui): list every remaining mat tile individually instead of a ×N count

### DIFF
--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -159,18 +159,23 @@ export function PlayerLedger({
               </svg>
               link-scoring icons
             </span>
-            <span>×N tiles left</span>
           </p>
           <div className="grid grid-cols-2 gap-x-6 gap-y-4 pt-3 sm:grid-cols-3">
             {INDUSTRY_TYPES.map((t) => {
-              const rows = [...(player.industryTilesOnMat[t] ?? [])].sort(
+              const levels = [...(player.industryTilesOnMat[t] ?? [])].sort(
                 (a, b) => a.tile.level - b.tile.level,
+              )
+              // Show every remaining tile as its own token, lowest level
+              // first — the physical mat holds each copy separately, so we
+              // list identical tiles one-for-one instead of collapsing them
+              // into a count. Depleted levels drop out (no tile left to show).
+              const tiles = levels.flatMap((r) =>
+                Array.from({ length: r.quantityAvailable }, () => r.tile),
               )
               // The mat's next tile is simply the lowest one left — never the
               // next era-legal one. A barred tile blocks the industry until
               // Develop removes it, so highlighting past it would promise a
               // build the engine refuses (rules p.4 step 2 / p.7).
-              const nextIdx = rows.findIndex((r) => r.quantityAvailable > 0)
               return (
                 <div key={t} className="flex flex-col gap-1.5">
                   <span
@@ -181,20 +186,19 @@ export function PlayerLedger({
                     {LABEL[t]}
                   </span>
                   <div className="flex flex-col gap-1">
-                    {rows.map((r, i) => {
+                    {tiles.map((tile, i) => {
                       const eraOk =
                         era === 'canal'
-                          ? r.tile.canBuildInCanalEra
-                          : r.tile.canBuildInRailEra
-                      const depleted = r.quantityAvailable === 0
+                          ? tile.canBuildInCanalEra
+                          : tile.canBuildInRailEra
                       // Only the lowest remaining tile is ever in play, and
                       // only if this era allows it — otherwise it is what the
                       // player must Develop away.
-                      const isNext = i === nextIdx && eraOk
-                      const isBlocking = i === nextIdx && !eraOk
+                      const isNext = i === 0 && eraOk
+                      const isBlocking = i === 0 && !eraOk
                       return (
                         <div
-                          key={r.tile.id}
+                          key={`${tile.id}-${i}`}
                           className="flex flex-wrap items-center gap-2 rounded border px-2 py-1.5 text-[13px]"
                           style={{
                             borderColor: isNext
@@ -203,7 +207,7 @@ export function PlayerLedger({
                             boxShadow: isNext
                               ? '0 0 0 1px rgba(230,189,99,.35)'
                               : undefined,
-                            opacity: depleted ? 0.32 : eraOk ? 1 : 0.45,
+                            opacity: eraOk ? 1 : 0.45,
                             background: isNext
                               ? 'rgba(195,149,56,.09)'
                               : 'rgba(255,240,200,.02)',
@@ -213,19 +217,18 @@ export function PlayerLedger({
                             className="bb2-display w-7 text-[13.5px] font-bold"
                             style={{ color: 'var(--bb-brass-bright)' }}
                           >
-                            {ROMAN[r.tile.level] ?? r.tile.level}
+                            {ROMAN[tile.level] ?? tile.level}
                           </span>
                           <span
                             className="tabular-nums"
                             style={{ color: 'var(--bb-parchment-bright)' }}
                           >
-                            £{r.tile.cost}
+                            £{tile.cost}
                           </span>
-                          {(r.tile.coalRequired > 0 ||
-                            r.tile.ironRequired > 0) && (
+                          {(tile.coalRequired > 0 || tile.ironRequired > 0) && (
                             <span className="flex items-center gap-1">
                               {Array.from(
-                                { length: r.tile.coalRequired },
+                                { length: tile.coalRequired },
                                 (_, k) => (
                                   <span
                                     key={`c${k}`}
@@ -239,7 +242,7 @@ export function PlayerLedger({
                                 ),
                               )}
                               {Array.from(
-                                { length: r.tile.ironRequired },
+                                { length: tile.ironRequired },
                                 (_, k) => (
                                   <span
                                     key={`i${k}`}
@@ -260,27 +263,27 @@ export function PlayerLedger({
                             title="victory points when flipped"
                           >
                             <LaurelIcon size={11} />
-                            {r.tile.victoryPoints}
+                            {tile.victoryPoints}
                           </span>
                           <span
                             className="flex items-center gap-0.5 text-[12px]"
                             style={{ color: 'rgba(231,215,177,.6)' }}
                             title="income advance when flipped"
                           >
-                            <IncomeIcon size={11} />+{r.tile.incomeAdvancement}
+                            <IncomeIcon size={11} />+{tile.incomeAdvancement}
                           </span>
                           <span
                             className="flex items-center gap-0.5 text-[12px]"
                             style={{ color: 'rgba(231,215,177,.6)' }}
-                            title={`${r.tile.linkScoringIcons} link-scoring icon(s) on the tile`}
+                            title={`${tile.linkScoringIcons} link-scoring icon(s) on the tile`}
                           >
                             {/* one •—• per printed icon, like the physical
                                 tile face (0 icons → an em-dash) */}
-                            {r.tile.linkScoringIcons === 0 ? (
+                            {tile.linkScoringIcons === 0 ? (
                               <span style={{ opacity: 0.5 }}>—</span>
                             ) : (
                               Array.from(
-                                { length: r.tile.linkScoringIcons },
+                                { length: tile.linkScoringIcons },
                                 (_, k) => (
                                   <svg
                                     key={k}
@@ -314,19 +317,9 @@ export function PlayerLedger({
                               )
                             )}
                           </span>
-                          <span
-                            className="text-[12px] tabular-nums"
-                            style={{
-                              color: depleted
-                                ? 'var(--bb-danger)'
-                                : 'rgba(231,215,177,.6)',
-                            }}
-                          >
-                            ×{r.quantityAvailable}
-                          </span>
                           {isBlocking && (
                             <span
-                              data-testid={`mat-blocked-${r.tile.id}`}
+                              data-testid={`mat-blocked-${tile.id}`}
                               className="w-full text-[11px] italic"
                               style={{ color: 'rgba(231,215,177,.5)' }}
                             >
@@ -338,7 +331,7 @@ export function PlayerLedger({
                         </div>
                       )
                     })}
-                    {rows.length === 0 && (
+                    {tiles.length === 0 && (
                       <span
                         className="text-[12px] italic"
                         style={{ color: 'rgba(231,215,177,.35)' }}

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -64,6 +64,39 @@ export function PlayerLedger({
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onClose])
 
+  // Each industry's remaining tiles, expanded one-per-token, lowest level
+  // first.
+  const stacks = INDUSTRY_TYPES.map((t) => {
+    const levels = [...(player.industryTilesOnMat[t] ?? [])].sort(
+      (a, b) => a.tile.level - b.tile.level,
+    )
+    const tiles = levels.flatMap((r) =>
+      Array.from({ length: r.quantityAvailable }, () => r.tile),
+    )
+    // Next tile out = the lowest one left, via the shared helper so this
+    // highlight can't drift from the build/develop guards.
+    return { type: t, tiles, buildableNext: getBuildableTileInEra(levels, era) }
+  })
+
+  // Pack the stacks into balanced columns (greedy: tallest stack first into
+  // the currently shortest column) so a full fresh mat's tall tracks don't
+  // leave ragged whitespace beside short ones. Each column is then shown
+  // shortest-first — short stacks on top, tall on the bottom.
+  const COLUMN_COUNT = 3
+  const columns = Array.from({ length: COLUMN_COUNT }, () => ({
+    rows: 0,
+    stacks: [] as typeof stacks,
+  }))
+  for (const stack of [...stacks].sort(
+    (a, b) => b.tiles.length - a.tiles.length,
+  )) {
+    const target = columns.reduce((min, c) => (c.rows < min.rows ? c : min))
+    target.stacks.push(stack)
+    target.rows += stack.tiles.length + 1 // +1 for the label row
+  }
+  for (const c of columns)
+    c.stacks.sort((a, b) => a.tiles.length - b.tiles.length)
+
   return (
     <div
       className="bb2-curtain fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 sm:p-8"
@@ -179,262 +212,251 @@ export function PlayerLedger({
                 cannot)
               </span>
             </p>
-            <div className="grid grid-cols-2 gap-x-6 gap-y-4 pt-3 sm:grid-cols-3">
-              {INDUSTRY_TYPES.map((t) => {
-                const levels = [...(player.industryTilesOnMat[t] ?? [])].sort(
-                  (a, b) => a.tile.level - b.tile.level,
-                )
-                // Show every remaining tile as its own token, lowest level
-                // first — the physical mat holds each copy separately, so we
-                // list identical tiles one-for-one instead of collapsing them
-                // into a count. Depleted levels drop out (no tile left to show).
-                const tiles = levels.flatMap((r) =>
-                  Array.from({ length: r.quantityAvailable }, () => r.tile),
-                )
-                // The mat's next tile is simply the lowest one left — never the
-                // next era-legal one. A barred tile blocks the industry until
-                // Develop removes it, so highlighting past it would promise a
-                // build the engine refuses (rules p.4 step 2 / p.7). Route the
-                // decision through the shared helper so this highlight can never
-                // drift from what the build/develop guards actually allow.
-                const buildableNext = getBuildableTileInEra(levels, era)
-                return (
-                  <div key={t} className="flex flex-col gap-1.5">
-                    <span
-                      className="flex items-center gap-1.5 text-[12.5px] font-bold uppercase tracking-[0.14em]"
-                      style={{ color: 'var(--bb-parchment)' }}
-                    >
-                      <IndustryChip type={t} size={14} />
-                      {LABEL[t]}
-                    </span>
-                    <div className="flex flex-col gap-1">
-                      {tiles.map((tile, i) => {
-                        const eraOk = canBuildTileInEra(tile, era)
-                        // Only the lowest remaining tile is ever in play, and
-                        // only if this era allows it — otherwise it is what the
-                        // player must Develop away. `buildableNext` is the shared
-                        // helper's verdict on that lowest tile (null when barred).
-                        const isNext = i === 0 && buildableNext !== null
-                        const isBlocking = i === 0 && buildableNext === null
-                        // Resources a tile YIELDS when built (only one of the
-                        // three is ever non-zero): coal mines → coal, iron
-                        // works → iron, breweries → beer. All sourced from the
-                        // tile definition, never hardcoded.
-                        const producedKind =
-                          tile.coalProduced > 0
-                            ? ('coal' as const)
-                            : tile.ironProduced > 0
-                              ? ('iron' as const)
-                              : tile.beerProduced > 0
-                                ? ('beer' as const)
-                                : null
-                        const producedCount =
-                          tile.coalProduced ||
-                          tile.ironProduced ||
-                          tile.beerProduced
-                        // Lightbulb pottery tiles can only be removed by
-                        // selling, never Developed (rules p.6).
-                        const developable = !tile.hasLightbulbIcon
-                        return (
-                          <div
-                            key={`${tile.id}-${i}`}
-                            className="flex flex-wrap items-center gap-2 rounded border px-2 py-1.5 text-[13px]"
-                            style={{
-                              borderColor: isNext
-                                ? 'var(--bb-brass-bright)'
-                                : 'rgba(231,215,177,.12)',
-                              boxShadow: isNext
-                                ? '0 0 0 1px rgba(230,189,99,.35)'
-                                : undefined,
-                              opacity: eraOk ? 1 : 0.45,
-                              background: isNext
-                                ? 'rgba(195,149,56,.09)'
-                                : 'rgba(255,240,200,.02)',
-                            }}
-                          >
-                            <span
-                              className="bb2-display w-7 text-[13.5px] font-bold"
-                              style={{ color: 'var(--bb-brass-bright)' }}
-                            >
-                              {ROMAN[tile.level] ?? tile.level}
-                            </span>
-                            <span
-                              className="tabular-nums"
-                              style={{ color: 'var(--bb-parchment-bright)' }}
-                            >
-                              £{tile.cost}
-                            </span>
-                            {(tile.coalRequired > 0 ||
-                              tile.ironRequired > 0) && (
-                              <span className="flex items-center gap-1">
-                                {Array.from(
-                                  { length: tile.coalRequired },
-                                  (_, k) => (
-                                    <span
-                                      key={`c${k}`}
-                                      className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
-                                      style={{
-                                        background: '#55504a',
-                                        border: '1px solid #8d867c',
-                                      }}
-                                      title="coal required"
-                                    />
-                                  ),
-                                )}
-                                {Array.from(
-                                  { length: tile.ironRequired },
-                                  (_, k) => (
-                                    <span
-                                      key={`i${k}`}
-                                      className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
-                                      style={{
-                                        background: '#c2632f',
-                                        border: '1px solid #7c3d1c',
-                                      }}
-                                      title="iron required"
-                                    />
-                                  ),
-                                )}
-                              </span>
-                            )}
-                            {producedKind && (
-                              <span
-                                className="flex items-center gap-0.5 text-[12px] tabular-nums"
-                                style={{
-                                  color:
-                                    producedKind === 'coal'
-                                      ? '#b6ae9f'
-                                      : producedKind === 'iron'
-                                        ? '#d07135'
-                                        : '#d3a44a',
-                                }}
-                                title={`produces ${producedCount} ${producedKind} when built`}
-                              >
-                                {producedKind === 'coal' ? (
-                                  <CoalIcon size={12} />
-                                ) : producedKind === 'iron' ? (
-                                  <IronIcon size={12} />
-                                ) : (
-                                  <BeerSteinIcon size={12} />
-                                )}
-                                ×{producedCount}
-                              </span>
-                            )}
-                            {tile.beerRequired > 0 && (
-                              <span
-                                className="flex items-center gap-0.5 text-[12px] tabular-nums"
-                                style={{ color: 'rgba(231,215,177,.6)' }}
-                                title={`${tile.beerRequired} beer needed to sell`}
-                              >
-                                <BeerSteinIcon size={12} />×{tile.beerRequired}
-                              </span>
-                            )}
-                            <span
-                              className="ml-auto flex items-center gap-0.5 text-[12px]"
-                              style={{ color: 'rgba(231,215,177,.6)' }}
-                              title="victory points when flipped"
-                            >
-                              <LaurelIcon size={11} />
-                              {tile.victoryPoints}
-                            </span>
-                            <span
-                              className="flex items-center gap-0.5 text-[12px]"
-                              style={{ color: 'rgba(231,215,177,.6)' }}
-                              title="income advance when flipped"
-                            >
-                              <IncomeIcon size={11} />+{tile.incomeAdvancement}
-                            </span>
-                            <span
-                              className="flex items-center gap-0.5 text-[12px]"
-                              style={{ color: 'rgba(231,215,177,.6)' }}
-                              title={`${tile.linkScoringIcons} link-scoring icon(s) on the tile`}
-                            >
-                              {/* one •—• per printed icon, like the physical
-                                tile face (0 icons → an em-dash) */}
-                              {tile.linkScoringIcons === 0 ? (
-                                <span style={{ opacity: 0.5 }}>—</span>
-                              ) : (
-                                Array.from(
-                                  { length: tile.linkScoringIcons },
-                                  (_, k) => (
-                                    <svg
-                                      key={k}
-                                      width="15"
-                                      height="8"
-                                      viewBox="0 0 15 8"
-                                      aria-hidden
-                                    >
-                                      <circle
-                                        cx="2"
-                                        cy="4"
-                                        r="1.6"
-                                        fill="currentColor"
-                                      />
-                                      <line
-                                        x1="3.6"
-                                        y1="4"
-                                        x2="11"
-                                        y2="4"
-                                        stroke="currentColor"
-                                        strokeWidth="1.4"
-                                      />
-                                      <circle
-                                        cx="12.6"
-                                        cy="4"
-                                        r="1.6"
-                                        fill="currentColor"
-                                      />
-                                    </svg>
-                                  ),
-                                )
-                              )}
-                            </span>
-                            <span
-                              className="flex items-center"
+            {/* height-packed columns (see packing above) so short stacks
+                don't leave a gap beside tall ones the way fixed grid rows did */}
+            <div className="flex flex-col gap-x-6 gap-y-6 pt-3 sm:flex-row sm:items-start">
+              {columns.map((col, ci) => (
+                <div key={ci} className="flex flex-1 flex-col gap-4">
+                  {col.stacks.map(({ type: t, tiles, buildableNext }) => (
+                    <div key={t} className="flex flex-col gap-1.5">
+                      <span
+                        className="flex items-center gap-1.5 text-[12.5px] font-bold uppercase tracking-[0.14em]"
+                        style={{ color: 'var(--bb-parchment)' }}
+                      >
+                        <IndustryChip type={t} size={14} />
+                        {LABEL[t]}
+                      </span>
+                      <div className="flex flex-col gap-1">
+                        {tiles.map((tile, i) => {
+                          const eraOk = canBuildTileInEra(tile, era)
+                          // Only the lowest remaining tile is ever in play, and
+                          // only if this era allows it — otherwise it is what the
+                          // player must Develop away. `buildableNext` is the shared
+                          // helper's verdict on that lowest tile (null when barred).
+                          const isNext = i === 0 && buildableNext !== null
+                          const isBlocking = i === 0 && buildableNext === null
+                          // Resources a tile YIELDS when built (only one of the
+                          // three is ever non-zero): coal mines → coal, iron
+                          // works → iron, breweries → beer. All sourced from the
+                          // tile definition, never hardcoded.
+                          const producedKind =
+                            tile.coalProduced > 0
+                              ? ('coal' as const)
+                              : tile.ironProduced > 0
+                                ? ('iron' as const)
+                                : tile.beerProduced > 0
+                                  ? ('beer' as const)
+                                  : null
+                          const producedCount =
+                            tile.coalProduced ||
+                            tile.ironProduced ||
+                            tile.beerProduced
+                          // Lightbulb pottery tiles can only be removed by
+                          // selling, never Developed (rules p.6).
+                          const developable = !tile.hasLightbulbIcon
+                          return (
+                            <div
+                              key={`${tile.id}-${i}`}
+                              className="flex flex-wrap items-center gap-2 rounded border px-2 py-1.5 text-[13px]"
                               style={{
-                                color: developable
-                                  ? 'rgba(231,215,177,.32)'
-                                  : 'var(--bb-brass-bright)',
+                                borderColor: isNext
+                                  ? 'var(--bb-brass-bright)'
+                                  : 'rgba(231,215,177,.12)',
+                                boxShadow: isNext
+                                  ? '0 0 0 1px rgba(230,189,99,.35)'
+                                  : undefined,
+                                opacity: eraOk ? 1 : 0.45,
+                                background: isNext
+                                  ? 'rgba(195,149,56,.09)'
+                                  : 'rgba(255,240,200,.02)',
                               }}
-                              title={
-                                developable
-                                  ? 'can be developed'
-                                  : 'lightbulb tile — cannot be developed'
-                              }
                             >
-                              <DevelopIcon size={12} />
-                              {!developable && (
-                                <span className="ml-0.5 text-[11px] font-bold leading-none">
-                                  ✕
+                              <span
+                                className="bb2-display w-7 text-[13.5px] font-bold"
+                                style={{ color: 'var(--bb-brass-bright)' }}
+                              >
+                                {ROMAN[tile.level] ?? tile.level}
+                              </span>
+                              <span
+                                className="tabular-nums"
+                                style={{ color: 'var(--bb-parchment-bright)' }}
+                              >
+                                £{tile.cost}
+                              </span>
+                              {(tile.coalRequired > 0 ||
+                                tile.ironRequired > 0) && (
+                                <span className="flex items-center gap-1">
+                                  {Array.from(
+                                    { length: tile.coalRequired },
+                                    (_, k) => (
+                                      <span
+                                        key={`c${k}`}
+                                        className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
+                                        style={{
+                                          background: '#55504a',
+                                          border: '1px solid #8d867c',
+                                        }}
+                                        title="coal required"
+                                      />
+                                    ),
+                                  )}
+                                  {Array.from(
+                                    { length: tile.ironRequired },
+                                    (_, k) => (
+                                      <span
+                                        key={`i${k}`}
+                                        className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
+                                        style={{
+                                          background: '#c2632f',
+                                          border: '1px solid #7c3d1c',
+                                        }}
+                                        title="iron required"
+                                      />
+                                    ),
+                                  )}
                                 </span>
                               )}
-                            </span>
-                            {isBlocking && (
+                              {producedKind && (
+                                <span
+                                  className="flex items-center gap-0.5 text-[12px] tabular-nums"
+                                  style={{
+                                    color:
+                                      producedKind === 'coal'
+                                        ? '#b6ae9f'
+                                        : producedKind === 'iron'
+                                          ? '#d07135'
+                                          : '#d3a44a',
+                                  }}
+                                  title={`produces ${producedCount} ${producedKind} when built`}
+                                >
+                                  {producedKind === 'coal' ? (
+                                    <CoalIcon size={12} />
+                                  ) : producedKind === 'iron' ? (
+                                    <IronIcon size={12} />
+                                  ) : (
+                                    <BeerSteinIcon size={12} />
+                                  )}
+                                  ×{producedCount}
+                                </span>
+                              )}
+                              {tile.beerRequired > 0 && (
+                                <span
+                                  className="flex items-center gap-0.5 text-[12px] tabular-nums"
+                                  style={{ color: 'rgba(231,215,177,.6)' }}
+                                  title={`${tile.beerRequired} beer needed to sell`}
+                                >
+                                  <BeerSteinIcon size={12} />×
+                                  {tile.beerRequired}
+                                </span>
+                              )}
                               <span
-                                data-testid={`mat-blocked-${tile.id}`}
-                                className="w-full text-[11px] italic"
-                                style={{ color: 'rgba(231,215,177,.5)' }}
+                                className="ml-auto flex items-center gap-0.5 text-[12px]"
+                                style={{ color: 'rgba(231,215,177,.6)' }}
+                                title="victory points when flipped"
                               >
-                                {era === 'rail'
-                                  ? 'canal-era tile — Develop to skip'
-                                  : 'rail-era tile — not yet buildable'}
+                                <LaurelIcon size={11} />
+                                {tile.victoryPoints}
                               </span>
-                            )}
-                          </div>
-                        )
-                      })}
-                      {tiles.length === 0 && (
-                        <span
-                          className="text-[12px] italic"
-                          style={{ color: 'rgba(231,215,177,.35)' }}
-                        >
-                          None remaining
-                        </span>
-                      )}
+                              <span
+                                className="flex items-center gap-0.5 text-[12px]"
+                                style={{ color: 'rgba(231,215,177,.6)' }}
+                                title="income advance when flipped"
+                              >
+                                <IncomeIcon size={11} />+
+                                {tile.incomeAdvancement}
+                              </span>
+                              <span
+                                className="flex items-center gap-0.5 text-[12px]"
+                                style={{ color: 'rgba(231,215,177,.6)' }}
+                                title={`${tile.linkScoringIcons} link-scoring icon(s) on the tile`}
+                              >
+                                {/* one •—• per printed icon, like the physical
+                                tile face (0 icons → an em-dash) */}
+                                {tile.linkScoringIcons === 0 ? (
+                                  <span style={{ opacity: 0.5 }}>—</span>
+                                ) : (
+                                  Array.from(
+                                    { length: tile.linkScoringIcons },
+                                    (_, k) => (
+                                      <svg
+                                        key={k}
+                                        width="15"
+                                        height="8"
+                                        viewBox="0 0 15 8"
+                                        aria-hidden
+                                      >
+                                        <circle
+                                          cx="2"
+                                          cy="4"
+                                          r="1.6"
+                                          fill="currentColor"
+                                        />
+                                        <line
+                                          x1="3.6"
+                                          y1="4"
+                                          x2="11"
+                                          y2="4"
+                                          stroke="currentColor"
+                                          strokeWidth="1.4"
+                                        />
+                                        <circle
+                                          cx="12.6"
+                                          cy="4"
+                                          r="1.6"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    ),
+                                  )
+                                )}
+                              </span>
+                              <span
+                                className="flex items-center"
+                                style={{
+                                  color: developable
+                                    ? 'rgba(231,215,177,.32)'
+                                    : 'var(--bb-brass-bright)',
+                                }}
+                                title={
+                                  developable
+                                    ? 'can be developed'
+                                    : 'lightbulb tile — cannot be developed'
+                                }
+                              >
+                                <DevelopIcon size={12} />
+                                {!developable && (
+                                  <span className="ml-0.5 text-[11px] font-bold leading-none">
+                                    ✕
+                                  </span>
+                                )}
+                              </span>
+                              {isBlocking && (
+                                <span
+                                  data-testid={`mat-blocked-${tile.id}`}
+                                  className="w-full text-[11px] italic"
+                                  style={{ color: 'rgba(231,215,177,.5)' }}
+                                >
+                                  {era === 'rail'
+                                    ? 'canal-era tile — Develop to skip'
+                                    : 'rail-era tile — not yet buildable'}
+                                </span>
+                              )}
+                            </div>
+                          )
+                        })}
+                        {tiles.length === 0 && (
+                          <span
+                            className="text-[12px] italic"
+                            style={{ color: 'rgba(231,215,177,.35)' }}
+                          >
+                            None remaining
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  </div>
-                )
-              })}
+                  ))}
+                </div>
+              ))}
             </div>
           </div>
 

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -11,9 +11,13 @@ import { canBuildTileInEra, getBuildableTileInEra } from '~/data/industryTiles'
 import { type Player } from '~/store/gameStore'
 import { PLAYER_FILL } from './board/board-map'
 import {
+  BeerSteinIcon,
   CanalIcon,
+  CoalIcon,
+  DevelopIcon,
   IncomeIcon,
   IndustryChip,
+  IronIcon,
   LaurelIcon,
   MatIcon,
   RailIcon,
@@ -69,7 +73,7 @@ export function PlayerLedger({
       }}
     >
       <div
-        className="bb2-panel bb2-rise w-full max-w-3xl p-5"
+        className="bb2-panel bb2-rise flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden p-5"
         role="dialog"
         aria-label={`${player.name}'s ledger`}
       >
@@ -111,306 +115,393 @@ export function PlayerLedger({
         </div>
         <hr className="bb2-rule" />
 
-        {/* tile mat */}
-        <div className="pt-4">
-          <span className="bb2-panel-title">Tiles on the mat</span>
-          <p
-            className="pt-1.5 text-[12.5px]"
-            style={{ color: 'rgba(231,215,177,.5)' }}
-          >
-            Lowest level builds first — the brass-ringed tile is the next one
-            out of the mat. Greyed tiles cannot be built in the {era} era.
-          </p>
-          <p
-            className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1.5 text-[11.5px]"
-            style={{ color: 'rgba(231,215,177,.45)' }}
-          >
-            <span className="flex items-center gap-1">
-              <span
-                className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
-                style={{ background: '#55504a', border: '1px solid #8d867c' }}
-              />
-              coal to build
-            </span>
-            <span className="flex items-center gap-1">
-              <span
-                className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
-                style={{ background: '#c2632f', border: '1px solid #7c3d1c' }}
-              />
-              iron to build
-            </span>
-            <span className="flex items-center gap-1">
-              <LaurelIcon size={11} /> victory points
-            </span>
-            <span className="flex items-center gap-1">
-              <IncomeIcon size={11} /> income when flipped
-            </span>
-            <span className="flex items-center gap-1">
-              <svg width="15" height="8" viewBox="0 0 15 8" aria-hidden>
-                <circle cx="2" cy="4" r="1.6" fill="currentColor" />
-                <line
-                  x1="3.6"
-                  y1="4"
-                  x2="11"
-                  y2="4"
-                  stroke="currentColor"
-                  strokeWidth="1.4"
+        {/* Scrollable modal body — listing every tile individually can get
+            tall, so the body scrolls inside the modal rather than the page or
+            the overlay. */}
+        <div className="-mr-2 flex-1 overflow-y-auto pr-2">
+          {/* tile mat */}
+          <div className="pt-4">
+            <span className="bb2-panel-title">Tiles on the mat</span>
+            <p
+              className="pt-1.5 text-[12.5px]"
+              style={{ color: 'rgba(231,215,177,.5)' }}
+            >
+              Lowest level builds first — the brass-ringed tile is the next one
+              out of the mat. Greyed tiles cannot be built in the {era} era.
+            </p>
+            <p
+              className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-1.5 text-[11.5px]"
+              style={{ color: 'rgba(231,215,177,.45)' }}
+            >
+              <span className="flex items-center gap-1">
+                <span
+                  className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
+                  style={{ background: '#55504a', border: '1px solid #8d867c' }}
                 />
-                <circle cx="12.6" cy="4" r="1.6" fill="currentColor" />
-              </svg>
-              link-scoring icons
-            </span>
-          </p>
-          <div className="grid grid-cols-2 gap-x-6 gap-y-4 pt-3 sm:grid-cols-3">
-            {INDUSTRY_TYPES.map((t) => {
-              const levels = [...(player.industryTilesOnMat[t] ?? [])].sort(
-                (a, b) => a.tile.level - b.tile.level,
-              )
-              // Show every remaining tile as its own token, lowest level
-              // first — the physical mat holds each copy separately, so we
-              // list identical tiles one-for-one instead of collapsing them
-              // into a count. Depleted levels drop out (no tile left to show).
-              const tiles = levels.flatMap((r) =>
-                Array.from({ length: r.quantityAvailable }, () => r.tile),
-              )
-              // The mat's next tile is simply the lowest one left — never the
-              // next era-legal one. A barred tile blocks the industry until
-              // Develop removes it, so highlighting past it would promise a
-              // build the engine refuses (rules p.4 step 2 / p.7). Route the
-              // decision through the shared helper so this highlight can never
-              // drift from what the build/develop guards actually allow.
-              const buildableNext = getBuildableTileInEra(levels, era)
-              return (
-                <div key={t} className="flex flex-col gap-1.5">
-                  <span
-                    className="flex items-center gap-1.5 text-[12.5px] font-bold uppercase tracking-[0.14em]"
+                coal to build
+              </span>
+              <span className="flex items-center gap-1">
+                <span
+                  className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
+                  style={{ background: '#c2632f', border: '1px solid #7c3d1c' }}
+                />
+                iron to build
+              </span>
+              <span className="flex items-center gap-1">
+                <LaurelIcon size={11} /> victory points
+              </span>
+              <span className="flex items-center gap-1">
+                <IncomeIcon size={11} /> income when flipped
+              </span>
+              <span className="flex items-center gap-1">
+                <svg width="15" height="8" viewBox="0 0 15 8" aria-hidden>
+                  <circle cx="2" cy="4" r="1.6" fill="currentColor" />
+                  <line
+                    x1="3.6"
+                    y1="4"
+                    x2="11"
+                    y2="4"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                  />
+                  <circle cx="12.6" cy="4" r="1.6" fill="currentColor" />
+                </svg>
+                link-scoring icons
+              </span>
+              <span className="flex items-center gap-1">
+                <CoalIcon size={11} /> resources produced when built
+              </span>
+              <span className="flex items-center gap-1">
+                <BeerSteinIcon size={11} /> beer needed to sell
+              </span>
+              <span className="flex items-center gap-1">
+                <DevelopIcon size={11} /> develop (<span aria-hidden>✕</span> =
+                cannot)
+              </span>
+            </p>
+            <div className="grid grid-cols-2 gap-x-6 gap-y-4 pt-3 sm:grid-cols-3">
+              {INDUSTRY_TYPES.map((t) => {
+                const levels = [...(player.industryTilesOnMat[t] ?? [])].sort(
+                  (a, b) => a.tile.level - b.tile.level,
+                )
+                // Show every remaining tile as its own token, lowest level
+                // first — the physical mat holds each copy separately, so we
+                // list identical tiles one-for-one instead of collapsing them
+                // into a count. Depleted levels drop out (no tile left to show).
+                const tiles = levels.flatMap((r) =>
+                  Array.from({ length: r.quantityAvailable }, () => r.tile),
+                )
+                // The mat's next tile is simply the lowest one left — never the
+                // next era-legal one. A barred tile blocks the industry until
+                // Develop removes it, so highlighting past it would promise a
+                // build the engine refuses (rules p.4 step 2 / p.7). Route the
+                // decision through the shared helper so this highlight can never
+                // drift from what the build/develop guards actually allow.
+                const buildableNext = getBuildableTileInEra(levels, era)
+                return (
+                  <div key={t} className="flex flex-col gap-1.5">
+                    <span
+                      className="flex items-center gap-1.5 text-[12.5px] font-bold uppercase tracking-[0.14em]"
+                      style={{ color: 'var(--bb-parchment)' }}
+                    >
+                      <IndustryChip type={t} size={14} />
+                      {LABEL[t]}
+                    </span>
+                    <div className="flex flex-col gap-1">
+                      {tiles.map((tile, i) => {
+                        const eraOk = canBuildTileInEra(tile, era)
+                        // Only the lowest remaining tile is ever in play, and
+                        // only if this era allows it — otherwise it is what the
+                        // player must Develop away. `buildableNext` is the shared
+                        // helper's verdict on that lowest tile (null when barred).
+                        const isNext = i === 0 && buildableNext !== null
+                        const isBlocking = i === 0 && buildableNext === null
+                        // Resources a tile YIELDS when built (only one of the
+                        // three is ever non-zero): coal mines → coal, iron
+                        // works → iron, breweries → beer. All sourced from the
+                        // tile definition, never hardcoded.
+                        const producedKind =
+                          tile.coalProduced > 0
+                            ? ('coal' as const)
+                            : tile.ironProduced > 0
+                              ? ('iron' as const)
+                              : tile.beerProduced > 0
+                                ? ('beer' as const)
+                                : null
+                        const producedCount =
+                          tile.coalProduced ||
+                          tile.ironProduced ||
+                          tile.beerProduced
+                        // Lightbulb pottery tiles can only be removed by
+                        // selling, never Developed (rules p.6).
+                        const developable = !tile.hasLightbulbIcon
+                        return (
+                          <div
+                            key={`${tile.id}-${i}`}
+                            className="flex flex-wrap items-center gap-2 rounded border px-2 py-1.5 text-[13px]"
+                            style={{
+                              borderColor: isNext
+                                ? 'var(--bb-brass-bright)'
+                                : 'rgba(231,215,177,.12)',
+                              boxShadow: isNext
+                                ? '0 0 0 1px rgba(230,189,99,.35)'
+                                : undefined,
+                              opacity: eraOk ? 1 : 0.45,
+                              background: isNext
+                                ? 'rgba(195,149,56,.09)'
+                                : 'rgba(255,240,200,.02)',
+                            }}
+                          >
+                            <span
+                              className="bb2-display w-7 text-[13.5px] font-bold"
+                              style={{ color: 'var(--bb-brass-bright)' }}
+                            >
+                              {ROMAN[tile.level] ?? tile.level}
+                            </span>
+                            <span
+                              className="tabular-nums"
+                              style={{ color: 'var(--bb-parchment-bright)' }}
+                            >
+                              £{tile.cost}
+                            </span>
+                            {(tile.coalRequired > 0 ||
+                              tile.ironRequired > 0) && (
+                              <span className="flex items-center gap-1">
+                                {Array.from(
+                                  { length: tile.coalRequired },
+                                  (_, k) => (
+                                    <span
+                                      key={`c${k}`}
+                                      className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
+                                      style={{
+                                        background: '#55504a',
+                                        border: '1px solid #8d867c',
+                                      }}
+                                      title="coal required"
+                                    />
+                                  ),
+                                )}
+                                {Array.from(
+                                  { length: tile.ironRequired },
+                                  (_, k) => (
+                                    <span
+                                      key={`i${k}`}
+                                      className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
+                                      style={{
+                                        background: '#c2632f',
+                                        border: '1px solid #7c3d1c',
+                                      }}
+                                      title="iron required"
+                                    />
+                                  ),
+                                )}
+                              </span>
+                            )}
+                            {producedKind && (
+                              <span
+                                className="flex items-center gap-0.5 text-[12px] tabular-nums"
+                                style={{
+                                  color:
+                                    producedKind === 'coal'
+                                      ? '#b6ae9f'
+                                      : producedKind === 'iron'
+                                        ? '#d07135'
+                                        : '#d3a44a',
+                                }}
+                                title={`produces ${producedCount} ${producedKind} when built`}
+                              >
+                                {producedKind === 'coal' ? (
+                                  <CoalIcon size={12} />
+                                ) : producedKind === 'iron' ? (
+                                  <IronIcon size={12} />
+                                ) : (
+                                  <BeerSteinIcon size={12} />
+                                )}
+                                ×{producedCount}
+                              </span>
+                            )}
+                            {tile.beerRequired > 0 && (
+                              <span
+                                className="flex items-center gap-0.5 text-[12px] tabular-nums"
+                                style={{ color: 'rgba(231,215,177,.6)' }}
+                                title={`${tile.beerRequired} beer needed to sell`}
+                              >
+                                <BeerSteinIcon size={12} />×{tile.beerRequired}
+                              </span>
+                            )}
+                            <span
+                              className="ml-auto flex items-center gap-0.5 text-[12px]"
+                              style={{ color: 'rgba(231,215,177,.6)' }}
+                              title="victory points when flipped"
+                            >
+                              <LaurelIcon size={11} />
+                              {tile.victoryPoints}
+                            </span>
+                            <span
+                              className="flex items-center gap-0.5 text-[12px]"
+                              style={{ color: 'rgba(231,215,177,.6)' }}
+                              title="income advance when flipped"
+                            >
+                              <IncomeIcon size={11} />+{tile.incomeAdvancement}
+                            </span>
+                            <span
+                              className="flex items-center gap-0.5 text-[12px]"
+                              style={{ color: 'rgba(231,215,177,.6)' }}
+                              title={`${tile.linkScoringIcons} link-scoring icon(s) on the tile`}
+                            >
+                              {/* one •—• per printed icon, like the physical
+                                tile face (0 icons → an em-dash) */}
+                              {tile.linkScoringIcons === 0 ? (
+                                <span style={{ opacity: 0.5 }}>—</span>
+                              ) : (
+                                Array.from(
+                                  { length: tile.linkScoringIcons },
+                                  (_, k) => (
+                                    <svg
+                                      key={k}
+                                      width="15"
+                                      height="8"
+                                      viewBox="0 0 15 8"
+                                      aria-hidden
+                                    >
+                                      <circle
+                                        cx="2"
+                                        cy="4"
+                                        r="1.6"
+                                        fill="currentColor"
+                                      />
+                                      <line
+                                        x1="3.6"
+                                        y1="4"
+                                        x2="11"
+                                        y2="4"
+                                        stroke="currentColor"
+                                        strokeWidth="1.4"
+                                      />
+                                      <circle
+                                        cx="12.6"
+                                        cy="4"
+                                        r="1.6"
+                                        fill="currentColor"
+                                      />
+                                    </svg>
+                                  ),
+                                )
+                              )}
+                            </span>
+                            <span
+                              className="flex items-center"
+                              style={{
+                                color: developable
+                                  ? 'rgba(231,215,177,.32)'
+                                  : 'var(--bb-brass-bright)',
+                              }}
+                              title={
+                                developable
+                                  ? 'can be developed'
+                                  : 'lightbulb tile — cannot be developed'
+                              }
+                            >
+                              <DevelopIcon size={12} />
+                              {!developable && (
+                                <span className="ml-0.5 text-[11px] font-bold leading-none">
+                                  ✕
+                                </span>
+                              )}
+                            </span>
+                            {isBlocking && (
+                              <span
+                                data-testid={`mat-blocked-${tile.id}`}
+                                className="w-full text-[11px] italic"
+                                style={{ color: 'rgba(231,215,177,.5)' }}
+                              >
+                                {era === 'rail'
+                                  ? 'canal-era tile — Develop to skip'
+                                  : 'rail-era tile — not yet buildable'}
+                              </span>
+                            )}
+                          </div>
+                        )
+                      })}
+                      {tiles.length === 0 && (
+                        <span
+                          className="text-[12px] italic"
+                          style={{ color: 'rgba(231,215,177,.35)' }}
+                        >
+                          None remaining
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          {/* board holdings */}
+          <div className="grid gap-5 pt-6 sm:grid-cols-2">
+            <div>
+              <span className="bb2-panel-title">Works on the board</span>
+              <div className="flex flex-col gap-1 pt-2">
+                {player.industries.map((ind, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-2 text-[13.5px]"
                     style={{ color: 'var(--bb-parchment)' }}
                   >
-                    <IndustryChip type={t} size={14} />
-                    {LABEL[t]}
-                  </span>
-                  <div className="flex flex-col gap-1">
-                    {tiles.map((tile, i) => {
-                      const eraOk = canBuildTileInEra(tile, era)
-                      // Only the lowest remaining tile is ever in play, and
-                      // only if this era allows it — otherwise it is what the
-                      // player must Develop away. `buildableNext` is the shared
-                      // helper's verdict on that lowest tile (null when barred).
-                      const isNext = i === 0 && buildableNext !== null
-                      const isBlocking = i === 0 && buildableNext === null
-                      return (
-                        <div
-                          key={`${tile.id}-${i}`}
-                          className="flex flex-wrap items-center gap-2 rounded border px-2 py-1.5 text-[13px]"
-                          style={{
-                            borderColor: isNext
-                              ? 'var(--bb-brass-bright)'
-                              : 'rgba(231,215,177,.12)',
-                            boxShadow: isNext
-                              ? '0 0 0 1px rgba(230,189,99,.35)'
-                              : undefined,
-                            opacity: eraOk ? 1 : 0.45,
-                            background: isNext
-                              ? 'rgba(195,149,56,.09)'
-                              : 'rgba(255,240,200,.02)',
-                          }}
-                        >
-                          <span
-                            className="bb2-display w-7 text-[13.5px] font-bold"
-                            style={{ color: 'var(--bb-brass-bright)' }}
-                          >
-                            {ROMAN[tile.level] ?? tile.level}
-                          </span>
-                          <span
-                            className="tabular-nums"
-                            style={{ color: 'var(--bb-parchment-bright)' }}
-                          >
-                            £{tile.cost}
-                          </span>
-                          {(tile.coalRequired > 0 || tile.ironRequired > 0) && (
-                            <span className="flex items-center gap-1">
-                              {Array.from(
-                                { length: tile.coalRequired },
-                                (_, k) => (
-                                  <span
-                                    key={`c${k}`}
-                                    className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
-                                    style={{
-                                      background: '#55504a',
-                                      border: '1px solid #8d867c',
-                                    }}
-                                    title="coal required"
-                                  />
-                                ),
-                              )}
-                              {Array.from(
-                                { length: tile.ironRequired },
-                                (_, k) => (
-                                  <span
-                                    key={`i${k}`}
-                                    className="inline-block h-[7px] w-[7px] rounded-[1.5px]"
-                                    style={{
-                                      background: '#c2632f',
-                                      border: '1px solid #7c3d1c',
-                                    }}
-                                    title="iron required"
-                                  />
-                                ),
-                              )}
-                            </span>
-                          )}
-                          <span
-                            className="ml-auto flex items-center gap-0.5 text-[12px]"
-                            style={{ color: 'rgba(231,215,177,.6)' }}
-                            title="victory points when flipped"
-                          >
-                            <LaurelIcon size={11} />
-                            {tile.victoryPoints}
-                          </span>
-                          <span
-                            className="flex items-center gap-0.5 text-[12px]"
-                            style={{ color: 'rgba(231,215,177,.6)' }}
-                            title="income advance when flipped"
-                          >
-                            <IncomeIcon size={11} />+{tile.incomeAdvancement}
-                          </span>
-                          <span
-                            className="flex items-center gap-0.5 text-[12px]"
-                            style={{ color: 'rgba(231,215,177,.6)' }}
-                            title={`${tile.linkScoringIcons} link-scoring icon(s) on the tile`}
-                          >
-                            {/* one •—• per printed icon, like the physical
-                                tile face (0 icons → an em-dash) */}
-                            {tile.linkScoringIcons === 0 ? (
-                              <span style={{ opacity: 0.5 }}>—</span>
-                            ) : (
-                              Array.from(
-                                { length: tile.linkScoringIcons },
-                                (_, k) => (
-                                  <svg
-                                    key={k}
-                                    width="15"
-                                    height="8"
-                                    viewBox="0 0 15 8"
-                                    aria-hidden
-                                  >
-                                    <circle
-                                      cx="2"
-                                      cy="4"
-                                      r="1.6"
-                                      fill="currentColor"
-                                    />
-                                    <line
-                                      x1="3.6"
-                                      y1="4"
-                                      x2="11"
-                                      y2="4"
-                                      stroke="currentColor"
-                                      strokeWidth="1.4"
-                                    />
-                                    <circle
-                                      cx="12.6"
-                                      cy="4"
-                                      r="1.6"
-                                      fill="currentColor"
-                                    />
-                                  </svg>
-                                ),
-                              )
-                            )}
-                          </span>
-                          {isBlocking && (
-                            <span
-                              data-testid={`mat-blocked-${tile.id}`}
-                              className="w-full text-[11px] italic"
-                              style={{ color: 'rgba(231,215,177,.5)' }}
-                            >
-                              {era === 'rail'
-                                ? 'canal-era tile — Develop to skip'
-                                : 'rail-era tile — not yet buildable'}
-                            </span>
-                          )}
-                        </div>
-                      )
-                    })}
-                    {tiles.length === 0 && (
+                    <IndustryChip type={ind.type} size={13} />
+                    <span className="capitalize">
+                      {LABEL[ind.type]} {ROMAN[ind.level] ?? ind.level}
+                    </span>
+                    <span style={{ color: 'rgba(231,215,177,.5)' }}>
+                      at <CityName cityId={ind.location} />
+                    </span>
+                    {ind.flipped && (
                       <span
-                        className="text-[12px] italic"
-                        style={{ color: 'rgba(231,215,177,.35)' }}
+                        className="ml-auto text-[9.5px] font-bold uppercase tracking-[0.14em]"
+                        style={{ color: 'var(--bb-brass-bright)' }}
                       >
-                        None remaining
+                        flipped
                       </span>
                     )}
                   </div>
-                </div>
-              )
-            })}
-          </div>
-        </div>
-
-        {/* board holdings */}
-        <div className="grid gap-5 pt-6 sm:grid-cols-2">
-          <div>
-            <span className="bb2-panel-title">Works on the board</span>
-            <div className="flex flex-col gap-1 pt-2">
-              {player.industries.map((ind, i) => (
-                <div
-                  key={i}
-                  className="flex items-center gap-2 text-[13.5px]"
-                  style={{ color: 'var(--bb-parchment)' }}
-                >
-                  <IndustryChip type={ind.type} size={13} />
-                  <span className="capitalize">
-                    {LABEL[ind.type]} {ROMAN[ind.level] ?? ind.level}
+                ))}
+                {player.industries.length === 0 && (
+                  <span
+                    className="text-[12px] italic"
+                    style={{ color: 'rgba(231,215,177,.35)' }}
+                  >
+                    Nothing built yet
                   </span>
-                  <span style={{ color: 'rgba(231,215,177,.5)' }}>
-                    at <CityName cityId={ind.location} />
-                  </span>
-                  {ind.flipped && (
-                    <span
-                      className="ml-auto text-[9.5px] font-bold uppercase tracking-[0.14em]"
-                      style={{ color: 'var(--bb-brass-bright)' }}
-                    >
-                      flipped
-                    </span>
-                  )}
-                </div>
-              ))}
-              {player.industries.length === 0 && (
-                <span
-                  className="text-[12px] italic"
-                  style={{ color: 'rgba(231,215,177,.35)' }}
-                >
-                  Nothing built yet
-                </span>
-              )}
+                )}
+              </div>
             </div>
-          </div>
-          <div>
-            <span className="bb2-panel-title">Routes claimed</span>
-            <div className="flex flex-col gap-1 pt-2">
-              {player.links.map((l, i) => (
-                <div
-                  key={i}
-                  className="flex items-center gap-2 text-[13.5px]"
-                  style={{ color: 'var(--bb-parchment)' }}
-                >
-                  {l.type === 'canal' ? (
-                    <CanalIcon size={13} />
-                  ) : (
-                    <RailIcon size={13} />
-                  )}
-                  <CityName cityId={l.from} /> — <CityName cityId={l.to} />
-                </div>
-              ))}
-              {player.links.length === 0 && (
-                <span
-                  className="text-[12px] italic"
-                  style={{ color: 'rgba(231,215,177,.35)' }}
-                >
-                  No routes yet
-                </span>
-              )}
+            <div>
+              <span className="bb2-panel-title">Routes claimed</span>
+              <div className="flex flex-col gap-1 pt-2">
+                {player.links.map((l, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center gap-2 text-[13.5px]"
+                    style={{ color: 'var(--bb-parchment)' }}
+                  >
+                    {l.type === 'canal' ? (
+                      <CanalIcon size={13} />
+                    ) : (
+                      <RailIcon size={13} />
+                    )}
+                    <CityName cityId={l.from} /> — <CityName cityId={l.to} />
+                  </div>
+                ))}
+                {player.links.length === 0 && (
+                  <span
+                    className="text-[12px] italic"
+                    style={{ color: 'rgba(231,215,177,.35)' }}
+                  >
+                    No routes yet
+                  </span>
+                )}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -7,6 +7,7 @@
 // works and routes already on the board.
 import { useEffect } from 'react'
 import { type IndustryType } from '~/data/cards'
+import { canBuildTileInEra, getBuildableTileInEra } from '~/data/industryTiles'
 import { type Player } from '~/store/gameStore'
 import { PLAYER_FILL } from './board/board-map'
 import {
@@ -175,7 +176,10 @@ export function PlayerLedger({
               // The mat's next tile is simply the lowest one left — never the
               // next era-legal one. A barred tile blocks the industry until
               // Develop removes it, so highlighting past it would promise a
-              // build the engine refuses (rules p.4 step 2 / p.7).
+              // build the engine refuses (rules p.4 step 2 / p.7). Route the
+              // decision through the shared helper so this highlight can never
+              // drift from what the build/develop guards actually allow.
+              const buildableNext = getBuildableTileInEra(levels, era)
               return (
                 <div key={t} className="flex flex-col gap-1.5">
                   <span
@@ -187,15 +191,13 @@ export function PlayerLedger({
                   </span>
                   <div className="flex flex-col gap-1">
                     {tiles.map((tile, i) => {
-                      const eraOk =
-                        era === 'canal'
-                          ? tile.canBuildInCanalEra
-                          : tile.canBuildInRailEra
+                      const eraOk = canBuildTileInEra(tile, era)
                       // Only the lowest remaining tile is ever in play, and
                       // only if this era allows it — otherwise it is what the
-                      // player must Develop away.
-                      const isNext = i === 0 && eraOk
-                      const isBlocking = i === 0 && !eraOk
+                      // player must Develop away. `buildableNext` is the shared
+                      // helper's verdict on that lowest tile (null when barred).
+                      const isNext = i === 0 && buildableNext !== null
+                      const isBlocking = i === 0 && buildableNext === null
                       return (
                         <div
                           key={`${tile.id}-${i}`}


### PR DESCRIPTION
## Summary

On the player mat (the "Tiles on the mat" panel of the player ledger),
identical remaining tiles were collapsed into a single row with a `×N`
multiplier. This lists every remaining tile individually — one row per
tile, in level order per industry track — matching the physical mat where
each copy is its own token. The modal grew its own scroll container, each
tile now carries its produce / sell-beer / develop facts, and the six
industry stacks are height-packed so a full fresh mat wastes little space.

## Changes

- Expand each industry track by `quantityAvailable` so every remaining
  tile renders as its own row; remove the `×N` multiplier and its legend
  entry. Depleted levels no longer render a `×0` row.
- The brass "next tile" ring marks the single lowest remaining tile per
  track, routed through the shared `getBuildableTileInEra` /
  `canBuildTileInEra` helpers so it can't drift from the build/develop guards.
- The modal owns its scroll: the panel is capped at `85vh` and the
  mat/holdings body scrolls **inside** the modal (not the page or overlay);
  the name + Close header stays fixed.
- Each tile surfaces three more facts, all read from the existing tile
  definitions (never hardcoded): **resources produced when built** (coal /
  iron / beer), **beer needed to sell** (cotton / manufacturer / pottery),
  and **whether it can be developed** (marked `✕` on lightbulb pottery).
- Height-pack the six stacks across three columns (greedy longest-first
  into the shortest column), each column shown shortest-first — short
  stacks on top, tall on the bottom. Cuts a fresh mat's column-height
  spread from ~500px to ~150px; falls back to a single stacked list on
  phones.

Purely presentational — no engine or state changes.

## Height-packed columns — short stacks on top, tall on the bottom

![Packed columns](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-mat-tiles-images/mat-packed-columns.png)

## Each tile listed on its own, with produce / sell-beer / develop

![Per-tile facts](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-mat-tiles-images/mat-perTile-top.png)

## Modal scrolls internally — develop `✕` on lightbulb pottery tiles

![Scrolled + develop marker](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-mat-tiles-images/mat-perTile-develop.png)

## Before — `×2`/`×3` multipliers collapsed duplicates, fixed grid left gaps

![Before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-mat-tiles-images/mat-2x-before.png)

## Testing

- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 608 passed
- `pnpm exec playwright test e2e/coverage.spec.ts -g "player mat"` — passed
