### PR TITLE
feat(ui): show the era round total in the top bar and drop the seat chip

### DIFF
--- a/e2e/ai-opponent.spec.ts
+++ b/e2e/ai-opponent.spec.ts
@@ -34,8 +34,7 @@ test('found a company against an AI rival and watch it take its turn', async ({
 
   // No lobby: the AI seat is claimed at creation, the game is live.
   await expect(page.getByTestId('era-plate')).toHaveText('canal era')
-  await expect(page.getByTestId('you-chip')).toHaveText('You are Ada')
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 1')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 1/11')
 
   // The rival's journal panel is present before the AI has moved.
   await expect(page.getByTestId('ai-mind')).toBeVisible()
@@ -56,6 +55,6 @@ test('found a company against an AI rival and watch it take its turn', async ({
   )
   await expect(page.getByTestId('ai-cost')).toContainText('model call')
   // …and play returns to Ada for round 2.
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 2')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 2/11')
   await expect(page.getByTestId('action-pass')).toBeVisible()
 })

--- a/e2e/atlas.spec.ts
+++ b/e2e/atlas.spec.ts
@@ -33,7 +33,7 @@ test('fresh game: setup charter → Loan action end-to-end → pass gate', async
 
   // Round 1, canal era, Ada to act with £17.
   await expect(page.getByTestId('era-plate')).toHaveText('canal era')
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 1')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 1/11')
   await expect(treasuryOf(page, 'Ada')).toHaveText('£17')
 
   // Loan: choose action → discard any card → confirm.

--- a/e2e/coverage.spec.ts
+++ b/e2e/coverage.spec.ts
@@ -73,7 +73,7 @@ test('Network: claim a canal route by clicking it on the map', async ({
   // £19 − £3 canal; this was the LAST action of Eliza's turn, so the
   // device passes on (round 8 continues with the next player).
   await expect(treasuryOf(page, 'Eliza')).toHaveText('£16')
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 8')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 8/10')
   await expect(page.getByTestId('pass-curtain')).toBeVisible()
 })
 
@@ -242,7 +242,7 @@ test('Scout: discard three cards for the two wilds', async ({ page }) => {
     page.getByText(/Eliza scouted gained 2 wild cards discarded 3 cards/),
   ).toBeVisible()
   // Her turn ends but the round continues with the next player.
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 8')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 8/10')
 })
 
 test('Develop: scrap the lowest tile, consuming iron', async ({ page }) => {
@@ -260,7 +260,7 @@ test('Develop: scrap the lowest tile, consuming iron', async ({ page }) => {
 
   await expect(page.getByText(/Eliza developed removed 1 tile/)).toBeVisible()
   // Her turn ends but the round continues with the next player.
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 8')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 8/10')
 })
 
 test('era transition: one pass ends the Canal Era and opens the Rail Era', async ({
@@ -268,7 +268,7 @@ test('era transition: one pass ends the Canal Era and opens the Rail Era', async
 }) => {
   await page.goto('/?demo=eraend')
   await expect(page.getByTestId('era-plate')).toHaveText('canal era')
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 10')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 10/10')
 
   // Passing is two-tap: the first click arms the button, the second confirms.
   await page.getByTestId('action-pass').click()
@@ -285,7 +285,7 @@ test('era transition: one pass ends the Canal Era and opens the Rail Era', async
   await expect(
     page.getByText('All players drew new 8-card hands').first(),
   ).toBeVisible()
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 1')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 1/9')
 })
 
 test('capstone: play the final turns through the UI to the winner', async ({
@@ -293,7 +293,7 @@ test('capstone: play the final turns through the UI to the winner', async ({
 }) => {
   await page.goto('/?demo=gameend')
   await expect(page.getByTestId('era-plate')).toHaveText('rail era')
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 8')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 8/9')
 
   // Play the game out: pass every remaining turn (8 passes across three
   // players, with the hotseat curtain between turns) until the books close.

--- a/e2e/multiplayer.spec.ts
+++ b/e2e/multiplayer.spec.ts
@@ -62,7 +62,6 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
   // the game starts for BOTH, live
   await expect(host.getByTestId('era-plate')).toHaveText('canal era')
   await expect(guest.getByTestId('era-plate')).toHaveText('canal era')
-  await expect(guest.getByTestId('you-chip')).toHaveText('You are Brunel')
   // Ada opens; the guest is spectating her turn behind the waiting panel
   await expect(guest.getByTestId('waiting-panel')).toBeVisible()
   await expect(guest.getByText('Waiting for Ada to act…')).toBeVisible()
@@ -92,8 +91,8 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
   // Two-tap pass: arm, then confirm.
   await guest.getByTestId('action-pass').click()
   await guest.getByTestId('action-pass').click()
-  await expect(host.getByTestId('round-chip')).toHaveText('Round 2')
-  await expect(guest.getByTestId('round-chip')).toHaveText('Round 2')
+  await expect(host.getByTestId('round-chip')).toHaveText('Round 2/11')
+  await expect(guest.getByTestId('round-chip')).toHaveText('Round 2/11')
 
   /* ---- table talk: message, unread badge, reply ---- */
   await host.getByTestId('chat-toggle').click()
@@ -116,8 +115,7 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
 
   /* ---- mid-game refresh reclaims the seat from the stored secret ---- */
   await guest.reload()
-  await expect(guest.getByTestId('you-chip')).toHaveText('You are Brunel')
-  await expect(guest.getByTestId('round-chip')).toHaveText('Round 2')
+  await expect(guest.getByTestId('round-chip')).toHaveText('Round 2/11')
 
   /* ---- wire hygiene: read the guest's OWN stream bytes and inspect ---- */
   const rawEvent = await guest.evaluate(

--- a/e2e/round-curtain.spec.ts
+++ b/e2e/round-curtain.spec.ts
@@ -39,7 +39,7 @@ test('round end: curtain reports spends and switches the turn order', async ({
   await page.getByRole('button', { name: '2', exact: true }).click()
   await page.getByPlaceholder('Eliza').fill('Ada')
   await page.getByRole('button', { name: 'Open the ledger' }).click()
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 1')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 1/11')
 
   // Ada claims a canal route — £3 spent.
   await page.getByTestId('action-network').click()
@@ -77,7 +77,7 @@ test('round end: curtain reports spends and switches the turn order', async ({
   // Dismissing hands the board back, in the new round.
   await page.getByTestId('round-curtain-dismiss').click()
   await expect(curtain).toBeHidden()
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 2')
+  await expect(page.getByTestId('round-chip')).toHaveText('Round 2/11')
 })
 
 test('round curtain: any key dismisses it and it does not return', async ({

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -17,7 +17,7 @@ import { toast } from 'sonner'
 import { createActor, transition } from 'xstate'
 import { Toaster } from '~/components/ui/sonner'
 import { type CityId, cities, connections } from '~/data/board'
-import { type Card, type IndustryType } from '~/data/cards'
+import { type Card, type IndustryType, roundsInEra } from '~/data/cards'
 import { type InspectFn, useXstateInspect } from '~/lib/xstate-inspector'
 import {
   type GameEvent,
@@ -928,7 +928,7 @@ function GameInner({
             {ctx.era} era
           </span>
           <span className="bb2-chip" data-testid="round-chip">
-            Round {ctx.round}
+            Round {ctx.round}/{roundsInEra(ctx.players.length, ctx.era)}
           </span>
           <span className="bb2-chip">
             Actions

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -13,6 +13,7 @@ import { createActor } from 'xstate'
 import { Toaster } from '~/components/ui/sonner'
 import { type CityId, cities, connections } from '~/data/board'
 import type { Card } from '~/data/cards'
+import { roundsInEra } from '~/data/cards'
 import {
   type GameStoreSnapshot,
   type Player,
@@ -1293,7 +1294,7 @@ function MpTable({
             {ctx.era} era
           </span>
           <span className="bb2-chip" data-testid="round-chip">
-            Round {ctx.round}
+            Round {ctx.round}/{roundsInEra(ctx.players.length, ctx.era)}
           </span>
           <span className="bb2-chip">
             Actions
@@ -1306,13 +1307,6 @@ function MpTable({
                 />
               ))}
             </span>
-          </span>
-          <span
-            className="bb2-chip"
-            data-testid="you-chip"
-            style={{ color: 'var(--bb-brass)' }}
-          >
-            You are {me.name}
           </span>
           <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2 lg:flex-nowrap lg:gap-3">
             {inFlight && (

--- a/src/data/cards.test.ts
+++ b/src/data/cards.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'vitest'
 import {
   INDUSTRY_DISPLAY_NAMES,
   describeCardId,
+  getInitialCards,
   industryDisplayName,
+  roundsInEra,
 } from './cards'
 
 describe('industryDisplayName', () => {
@@ -53,5 +55,28 @@ describe('describeCardId', () => {
     expect(describeCardId('coventry')).toBeNull()
     expect(describeCardId('not_a_card')).toBeNull()
     expect(describeCardId('£30')).toBeNull()
+  })
+})
+
+describe('roundsInEra', () => {
+  test('the Rail Era runs deck / (players * 2) rounds — 10/9/8', () => {
+    expect(roundsInEra(2, 'rail')).toBe(10)
+    expect(roundsInEra(3, 'rail')).toBe(9)
+    expect(roundsInEra(4, 'rail')).toBe(8)
+  })
+
+  test('the Canal Era plays one extra round for its 1-action opener', () => {
+    expect(roundsInEra(2, 'canal')).toBe(11)
+    expect(roundsInEra(3, 'canal')).toBe(10)
+    expect(roundsInEra(4, 'canal')).toBe(8 + 1)
+  })
+
+  test('the rail total is derived from the real deck size, not a table', () => {
+    for (const players of [2, 3, 4]) {
+      const deckSize = getInitialCards(players).regularCards.length
+      expect(roundsInEra(players, 'rail')).toBe(
+        Math.floor(deckSize / (players * 2)),
+      )
+    }
   })
 })

--- a/src/data/cards.ts
+++ b/src/data/cards.ts
@@ -1,3 +1,4 @@
+import { GAME_CONSTANTS } from '../store/constants'
 import { type CityId, cities } from './board'
 
 export type IndustryType =
@@ -372,4 +373,26 @@ export function getInitialCards(playerCount: number): CardDecks {
     wildLocationCards,
     wildIndustryCards,
   }
+}
+
+/**
+ * How many rounds an era lasts for a given player count.
+ *
+ * The deck is fixed per player count (40/54/64 regular cards for 2/3/4
+ * players) and a normal turn spends its two actions on two cards, so an era
+ * runs `deck / (players * 2)` rounds once the draw pile and every hand are
+ * empty — 10/9/8 for 2/3/4 players. The Canal Era's opening round grants only
+ * one action (see GAME_CONSTANTS.FIRST_ROUND_ACTIONS), leaving the deck one
+ * round short, so the Canal Era plays one extra round (11/10/9). This mirrors
+ * the engine's own end-of-era detection rather than hard-coding a table.
+ */
+export function roundsInEra(
+  playerCount: number,
+  era: 'canal' | 'rail',
+): number {
+  const deckSize = getInitialCards(playerCount).regularCards.length
+  const railRounds = Math.floor(
+    deckSize / (playerCount * GAME_CONSTANTS.NORMAL_ROUND_ACTIONS),
+  )
+  return era === 'canal' ? railRounds + 1 : railRounds
 }


### PR DESCRIPTION
## What

Two small top-bar tweaks:

1. **Round chip shows the era total** — reads `Round N/T` (e.g. `Round 2/9`) instead of just `Round 2`, so players can see how far through the era they are.
2. **Removes the "You are &lt;name&gt;" seat chip** from the multiplayer top bar.

## Round total derivation

The total comes from the engine's own round math, not a new hard-coded table. A new `roundsInEra(playerCount, era)` in `src/data/cards.ts`:

- The deck is fixed per player count (40/54/64 regular cards for 2/3/4 players, via `getInitialCards`).
- A normal turn spends its two actions on two cards, so an era runs `deck / (players * NORMAL_ROUND_ACTIONS)` rounds once the draw pile and every hand are empty → **10/9/8** for 2/3/4 players.
- The **Canal Era's opening round grants only one action** (`GAME_CONSTANTS.FIRST_ROUND_ACTIONS`), leaving the deck one round short, so the Canal Era plays **one extra round (11/10/9)**.

Computing the total per era keeps `N ≤ T` in every state. This matters in practice: the `?demo=eraend` fixture is a 3-player game sitting at **canal round 10**, so an era-independent `9` would render `Round 10/9`. The engine's actual end-of-era counts (measured across 2/3/4-player games) are canal `11/10/9`, rail `10/9/8`, which `roundsInEra` matches exactly.

> Note: the canal era's extra round is a consequence of this engine's one-action opening round. If you'd prefer the chip to always show the rulebook's canonical `10/9/8` in both eras, that's a one-line change — happy to switch it.

## Seat chip removal

The `you-chip` ("You are Jules") is gone from `mp-game.tsx`. Seat identity is still available in the lobby/seats panel (the `you` marker) and in chat ("You"), so nothing is orphaned. No dead styles were left behind (the chip used shared `bb2-chip` + inline color only).

## Tests

- New `roundsInEra` unit tests in `cards.test.ts` (rail 10/9/8, canal 11/10/9, and a check that the rail total is derived from the real deck size).
- Re-pinned every `round-chip` e2e assertion to `Round N/T` with the correct per-era total, and removed the `you-chip` assertions.
- `pnpm test`, `pnpm lint`, `pnpm typecheck` all green; the affected offline and DB-backed e2e specs (`atlas`, `coverage`, `round-curtain`, `multiplayer`, `ai-opponent`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)