### PR TITLE
Migrate production database to an EU Neon project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -896,21 +896,41 @@ When updating this file, preserve this bar for all agents and keep entries conci
   but the race handler is the safety net for the window before that.
 - DEPLOY (Vercel, wired 2026-07-15): ship is direct-PR → Vercel Git
   integration (project `brass-birmingham`, prod branch = `main`, PR previews
-  on). The Neon<->Vercel native integration (store "brass") manages the
-  `DATABASE_URL`/`POSTGRES_*`/`STACK_*` env vars. Per-environment DB
-  isolation is by Neon BRANCH, all in project `muddy-night-85782525`:
-  Vercel `production` → `main`, `preview` → the long-lived `preview` branch,
-  `development` → still `main`; local `.env` → `dev`. The preview isolation
-  is a manual preview-scoped `DATABASE_URL` override in Vercel (the shared
-  integration entry was narrowed to production+development) — a future
-  integration re-sync can clobber it. DURABLE FIX (needs a Neon-console
-  click, not in neonctl): project brass → Integrations → Vercel → enable
-  "create a branch per preview deployment". Previews sit behind Vercel
-  Deployment Protection (SSO) — viewable only when logged into the Vercel
-  account (for automated repro, append
+  on). Previews sit behind Vercel Deployment Protection (SSO) — viewable only
+  when logged into the Vercel account (for automated repro, append
   `?x-vercel-protection-bypass=<automation-secret>&x-vercel-set-bypass-cookie=true`
   — the secret is in Vercel project → Deployment Protection → Protection
   Bypass for Automation).
+- PROD DB = EU NEON PROJECT (cutover 2026-07-22): the app's runtime/prod
+  database is Neon project **`morning-frog-57242526`** ("brass-birmingham-eu",
+  region `aws-eu-central-1`, pg17), in the console-managed org
+  `org-wispy-frog-41468579` ("Julius Retzer"). It was migrated (pg_dump →
+  pg_restore of the whole `neondb`, incl. the `drizzle.__drizzle_migrations`
+  journal so build-time `migrate()` sees 0 pending) from the OLD project
+  `muddy-night-85782525` ("brass", `aws-us-east-1`), which had hit its free
+  plan limit in the Vercel-managed org. The OLD project is RETAINED UNTOUCHED
+  as rollback — do not delete it without owner sign-off.
+  - The native Vercel↔Neon integration (store "brass") was **DISCONNECTED**
+    from the Vercel project: it re-injected the OLD project's `DATABASE_URL`
+    on every deploy and clobbered manual edits (that was the real cause of
+    "runtime still on the old DB" during cutover). Vercel now manages the DB
+    env vars **manually** — only `DATABASE_URL` (pooled, runtime) and
+    `DATABASE_URL_UNPOOLED` (direct, build `migrate()`) matter; the app reads
+    nothing else (the old `POSTGRES_*`/`PG*`/`STACK_*` integration vars are
+    gone and were never read). Mapping: Vercel `production`+`development` →
+    new project `main`; `preview` → new project `preview` branch (both set to
+    the EU host, pooled + unpooled).
+  - ROLLBACK: re-point the three Vercel envs' `DATABASE_URL`/
+    `DATABASE_URL_UNPOOLED` back at `muddy-night-85782525` (or re-add the Neon
+    integration via Vercel → Storage), then redeploy prod. A plain
+    `vercel redeploy` reuses the OLD deploy's env snapshot — force a FRESH
+    build (`vercel deploy --prod`) so new env vars take effect.
+  - STILL ON THE OLD PROJECT (separate follow-up, not migrated): CI and
+    local-test ephemeral branching (`NEON_PROJECT_ID`/`NEON_API_KEY`, the
+    `ci`/`test`/`dev` parent branches — see the CI and Local-test-DB notes,
+    which still name `muddy-night-85782525`). They keep working because the old
+    project stays alive; move them to the EU project only if the owner wants
+    the old one retired.
 - DEPLOY MIGRATIONS (2026-07-21): the Vercel `build` script is
   `node scripts/vercel-migrate.mjs && next build` — it runs drizzle-orm's
   `migrate()` (pending-only, forward-only, idempotent) for ALL Vercel envs


### PR DESCRIPTION
## Migrate the production database to an EU Neon project

The production Neon project (`brass`, `aws-us-east-1`) had reached its free
plan limit, so I moved the app's database to a new EU project and cut the
deployed app over to it. The old project is left completely untouched as a
rollback point.

### What changed

- **New database:** `brass-birmingham-eu` — Neon project `morning-frog-57242526`,
  region `aws-eu-central-1`, Postgres 17 (same major as before). Created in the
  console-managed Neon org, since the old project's org is Vercel-managed and
  blocks creating projects outside the Vercel dashboard.
- **Data:** full `pg_dump`/`pg_restore` of `neondb` (schemas `public`,
  `drizzle`, `neon_auth`), including the `drizzle.__drizzle_migrations` journal
  so the build-time `migrate()` sees a consistent, up-to-date state. Verified
  row-for-row parity and byte-identical restore of a known finished game.
- **Vercel:** `DATABASE_URL` / `DATABASE_URL_UNPOOLED` repointed at the EU
  project for production, preview, and development (production/development →
  `main` branch, preview → a `preview` branch). The Neon↔Vercel native
  integration was **disconnected** from the project — it was re-injecting the
  old project's `DATABASE_URL` on every deploy and overriding the manual values,
  which is why the connection strings are now managed by hand.

### This PR

Only a documentation change — the migration itself is Vercel env + Neon
dashboard work with no code impact (the app already reads the DB purely from
`DATABASE_URL`, and the migration journal matched so no migration files moved).
The doc update in `AGENTS.md` records the new layout, rollback steps, and what
still lives on the old project (CI and local-test branching, deliberately left
in place while the old project stays alive).

### Verified

- Prod redeploy came up on the EU database; a throwaway game created through
  the live app landed in the EU DB (and not the old one), then was removed.
- A fresh preview deployment writes to the EU `preview` branch.
- Build logs show `migrate()` reporting "up to date" (0 pending) on both
  branches — no accidental re-run of existing migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
