### PR TITLE
feat(mp): seed a playable game from an intent-log prefix (retry-this-moment)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -951,6 +951,19 @@ When updating this file, preserve this bar for all agents and keep entries conci
   src/server/mp/intentlog.test.ts -t 'BB_REPLAY_TOKEN'` (DATABASE_URL at the
   branch holding it). Pinned by replay.test.ts (offline FULL mock-AI game,
   both eras) + intentlog.test.ts (DB round-trip, concurrency, sweep).
+  SEED A PLAYABLE REPLICA at an exact past moment (let a player retry a
+  disputed move): `buildSeededReplica` (`seedReplica.ts`, pure — replays a
+  source log prefix ≤ a cutoff seq into a fresh `phase:'playing'` game with all
+  human seats UNCLAIMED, so a player claims a seat from the invite link) + the
+  env-gated tool in intentlog.test.ts:
+  `BB_SEED_FROM_TOKEN=<token> BB_SEED_CUTOFF_SEQ=<seq> [BB_SEED_WRITE=1] pnpm
+  vitest run src/server/mp/intentlog.test.ts -t 'BB_SEED_FROM_TOKEN'` — DRY-RUN
+  unless `BB_SEED_WRITE=1`, which does exactly ONE new-game INSERT and touches
+  no existing row. Pinned by seedReplica.test.ts (offline). GOTCHA: prod Neon
+  moved US→EU 2026-07-22 (project `brass-birmingham-eu`, `morning-frog-57242526`,
+  eu-central-1) — `vercel env pull` may return the OLD US endpoint or a
+  sensitive-masked DATABASE_URL; get the live conn from
+  `neonctl connection-string main --project-id morning-frog-57242526`.
 - Chat (normalized out 2026-07-16): chat lives in its OWN append-only
   `chat_messages` table (PK = game token + monotonic per-game `seq`, which is
   the wire `id`), NOT the game jsonb row. A POST /api/mp/chat appends ONE row

--- a/src/server/mp/intentlog.test.ts
+++ b/src/server/mp/intentlog.test.ts
@@ -17,10 +17,12 @@ import {
   createGame,
   getGameView,
   joinGame,
+  newToken,
   setSeatReady,
   startGame,
 } from './game'
 import { normalizeSnapshotForComparison, replayIntentLog } from './replay'
+import { buildSeededReplica } from './seedReplica'
 import {
   type GameRecord,
   loadGame,
@@ -290,3 +292,65 @@ describe.runIf(!!REPLAY_TOKEN)('intent log: BB_REPLAY_TOKEN tool', () => {
     )
   })
 })
+
+// The "let me retry that exact moment" tool: reconstruct a NEW, claimable game
+// seeded at the state a source game was in JUST BEFORE a given intent seq, so a
+// player can re-play the disputed move themselves. Point DATABASE_URL at the
+// branch holding the source game and run:
+//   BB_SEED_FROM_TOKEN=<token> BB_SEED_CUTOFF_SEQ=<seq> \
+//     pnpm vitest run src/server/mp/intentlog.test.ts -t 'BB_SEED_FROM_TOKEN'
+// It replays the log up to AND INCLUDING <seq> and prints the new game's URL.
+// DRY-RUN by default — nothing is written unless BB_SEED_WRITE=1 is also set,
+// which performs exactly ONE new-game INSERT (row + its 'setup' intent-log row,
+// atomically via saveGame) and never touches the source game or any other row.
+const SEED_FROM = process.env.BB_SEED_FROM_TOKEN
+const SEED_CUTOFF = process.env.BB_SEED_CUTOFF_SEQ
+describe.runIf(!!SEED_FROM && !!SEED_CUTOFF)(
+  'intent log: BB_SEED_FROM_TOKEN replica tool',
+  () => {
+    test('seeds a claimable replica at the state before a cutoff seq', async () => {
+      const source = SEED_FROM!
+      const cutoff = Number(SEED_CUTOFF)
+      expect(
+        Number.isInteger(cutoff) && cutoff > 0,
+        'bad BB_SEED_CUTOFF_SEQ',
+      ).toBe(true)
+
+      const src = await loadGame(source)
+      expect(src, `source game ${source} not found`).toBeTruthy()
+      const rows = await loadIntentLog(source)
+      expect(rows.length, 'source has no intent log').toBeGreaterThan(0)
+
+      const token = newToken()
+      const { record, setupLog } = buildSeededReplica(rows, cutoff, {
+        token,
+        seats: src!.seats,
+        now: new Date().toISOString(),
+      })
+      const ctx = (
+        record.snapshot as {
+          context: { era: string; round: number; currentPlayerIndex: number }
+        }
+      ).context
+      console.log(
+        `[seed] from ${source} ≤ seq ${cutoff}: new game ${token} — ` +
+          `era ${ctx.era} round ${ctx.round}, seat ${ctx.currentPlayerIndex} to act`,
+      )
+      console.log(`[seed] URL: /g/${token}`)
+
+      if (process.env.BB_SEED_WRITE !== '1') {
+        console.log(
+          '[seed] DRY-RUN — set BB_SEED_WRITE=1 to insert. Nothing written.',
+        )
+        return
+      }
+      // Guard against the (astronomically unlikely) token collision so a write
+      // can only ever be an INSERT, never an overwrite.
+      expect(await loadGame(token), 'token collision').toBeNull()
+      await saveGame(record, setupLog)
+      const back = await loadGame(token)
+      expect(back?.phase).toBe('playing')
+      console.log(`[seed] INSERTED ${token}`)
+    })
+  },
+)

--- a/src/server/mp/seedReplica.test.ts
+++ b/src/server/mp/seedReplica.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+// Offline unit test for `buildSeededReplica` — no DB. We synthesize an intent
+// log the same way `saveGame` would (a 'setup' snapshot + accepted 'intent'
+// rows produced by the real `applyIntent` seam), then assert the replica the
+// tool would insert is a well-formed, claimable, playing-phase game whose
+// snapshot is exactly the prefix replay.
+import { createActor } from 'xstate'
+import { gameStore } from '../../store/gameStore'
+import { applyIntent } from './intent'
+import {
+  type ReplayRow,
+  normalizeSnapshotForComparison,
+  replayIntentLog,
+} from './replay'
+import { type SeatTemplate, buildSeededReplica } from './seedReplica'
+
+const SEATS: SeatTemplate[] = [
+  { seatId: 0, name: 'Ada', color: 'red', character: 'Eliza Tinsley' },
+  { seatId: 1, name: 'Bea', color: 'blue', character: 'George Stephenson' },
+]
+
+/** A minimal, real intent log: START_GAME setup + one accepted loan by seat 0
+ * (TAKE_LOAN → SELECT_CARD → CONFIRM), each event a separate 'intent' row. */
+function makeLog(): ReplayRow[] {
+  const actor = createActor(gameStore)
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: SEATS.map((s) => ({
+      id: String(s.seatId + 1),
+      name: s.name,
+      color: s.color,
+      character: s.character,
+      money: 17,
+      victoryPoints: 0,
+      income: 10,
+      industryTilesOnMat: {},
+    })),
+  } as never)
+  let snapshot: unknown = actor.getPersistedSnapshot()
+  actor.stop()
+
+  const cardId = (
+    snapshot as { context: { players: Array<{ hand: Array<{ id: string }> }> } }
+  ).context.players[0]!.hand[0]!.id
+  const events: Array<{ type: string } & Record<string, unknown>> = [
+    { type: 'TAKE_LOAN' },
+    { type: 'SELECT_CARD', cardId },
+    { type: 'CONFIRM' },
+  ]
+
+  const rows: ReplayRow[] = [
+    { seq: 1, kind: 'setup', seatId: null, payload: snapshot, version: 1 },
+  ]
+  events.forEach((event, i) => {
+    const outcome = applyIntent(snapshot, 0, event)
+    if (!outcome.ok)
+      throw new Error(`setup step ${event.type} refused: ${outcome.error}`)
+    snapshot = outcome.next
+    rows.push({
+      seq: i + 2,
+      kind: 'intent',
+      seatId: 0,
+      payload: event,
+      version: i + 2,
+    })
+  })
+  return rows
+}
+
+describe('buildSeededReplica', () => {
+  const now = '2026-07-22T00:00:00.000Z'
+
+  it('seeds a claimable, playing-phase game at the reconstructed prefix state', () => {
+    const rows = makeLog()
+    const cutoff = 3 // setup + TAKE_LOAN + SELECT_CARD (drop the CONFIRM)
+    const { record, setupLog } = buildSeededReplica(rows, cutoff, {
+      token: 'seedreplica_test_token_abcdef',
+      seats: SEATS,
+      now,
+    })
+
+    expect(record.phase).toBe('playing')
+    expect(record.version).toBe(1)
+    // Every seat is claimable (no accounts: claimed by taking it from the link).
+    for (const s of record.seats) {
+      expect(s.claimed).toBe(false)
+      expect(s.secretHash).toBeNull()
+      expect(s.kind).toBe('human')
+    }
+    // Seat identity (color/character/name) is copied from the template.
+    expect(record.seats.map((s) => s.color)).toEqual(['red', 'blue'])
+
+    // The snapshot is EXACTLY the prefix replay (≤ cutoff), not the full log.
+    const prefix = replayIntentLog(rows.filter((r) => r.seq <= cutoff))
+    expect(normalizeSnapshotForComparison(record.snapshot)).toEqual(
+      normalizeSnapshotForComparison(prefix.snapshot),
+    )
+    // …and NOT the state after the dropped CONFIRM (the loan is not yet taken).
+    const full = replayIntentLog(rows)
+    expect(normalizeSnapshotForComparison(record.snapshot)).not.toEqual(
+      normalizeSnapshotForComparison(full.snapshot),
+    )
+
+    // The setup log seeds a replayable-from-seq-1 replica.
+    expect(setupLog.kind).toBe('setup')
+    expect(setupLog.seatId).toBeNull()
+    expect(setupLog.payload).toBe(record.snapshot)
+  })
+
+  it('cutoff at the setup row reproduces the freshly-started game', () => {
+    const rows = makeLog()
+    const { record } = buildSeededReplica(rows, 1, {
+      token: 'seedreplica_test_token_ghijkl',
+      seats: SEATS,
+      now,
+    })
+    const setupOnly = replayIntentLog([rows[0]!])
+    expect(normalizeSnapshotForComparison(record.snapshot)).toEqual(
+      normalizeSnapshotForComparison(setupOnly.snapshot),
+    )
+  })
+})

--- a/src/server/mp/seedReplica.ts
+++ b/src/server/mp/seedReplica.ts
@@ -1,0 +1,79 @@
+// Seed a NEW, playable multiplayer game from a PREFIX of an existing game's
+// durable intent log — "let me retry the board at exactly this moment".
+//
+// Given the intent-log rows of a source game (see `loadIntentLog`) and a cutoff
+// `seq`, this replays every accepted intent up to AND INCLUDING that seq through
+// the real engine seam (`replayIntentLog` → `applyIntent`) and hands back a
+// fresh `GameRecord` carrying the reconstructed snapshot. The new game is
+// `phase: 'playing'` with every human seat left UNCLAIMED, so a player claims a
+// seat from the invite link exactly as they would any online game (no accounts;
+// token + per-seat secret is the whole auth model). Seat colors/characters are
+// copied from a template (typically the source game's seats) so the board reads
+// identically.
+//
+// Pure on purpose (no DB import), like `replay.ts`: the caller does the one
+// write (`saveGame(record, setupLog)`), so this stays offline-testable and the
+// prod-write decision lives at the call site. The returned `setupLog` is the
+// 'setup' intent-log entry that makes the replica itself replayable from seq 1,
+// mirroring what `startGame`/`createGame` persist.
+import { type ReplayRow, replayIntentLog } from './replay'
+import type { GameRecord, IntentLogEntry, SeatRecord } from './store'
+
+/** The minimum a seat template must carry to seed a legible, claimable seat. */
+export interface SeatTemplate {
+  seatId: number
+  name: string | null
+  color: string
+  character: string
+}
+
+export interface SeededReplica {
+  record: GameRecord
+  /** persist this atomically with the record so the replica replays from seq 1 */
+  setupLog: IntentLogEntry
+}
+
+/**
+ * Reconstruct a playable game seeded at the state produced by replaying
+ * `rows` up to and including `cutoffSeq`. Throws (via `replayIntentLog`) if any
+ * logged event no longer applies — a genuine bug-report signal, not papered
+ * over. Does NOT write anything.
+ */
+export function buildSeededReplica(
+  rows: ReplayRow[],
+  cutoffSeq: number,
+  opts: { token: string; seats: SeatTemplate[]; now: string },
+): SeededReplica {
+  const prefix = rows.filter((r) => r.seq <= cutoffSeq)
+  const result = replayIntentLog(prefix)
+
+  // Every human seat starts unclaimed → the invite link's join screen offers
+  // them, and a join takes the first open seat. Names are cosmetic until a
+  // claim overwrites them, but pre-filling the source names keeps the seat list
+  // legible ("that red seat is Jules").
+  const seats: SeatRecord[] = opts.seats.map((s) => ({
+    seatId: s.seatId,
+    name: s.name,
+    color: s.color,
+    character: s.character,
+    claimed: false,
+    secretHash: null,
+    kind: 'human' as const,
+    ready: false,
+  }))
+
+  const record: GameRecord = {
+    token: opts.token,
+    phase: 'playing',
+    createdAt: opts.now,
+    updatedAt: opts.now,
+    version: 1,
+    seats,
+    snapshot: result.snapshot,
+  }
+
+  return {
+    record,
+    setupLog: { kind: 'setup', seatId: null, payload: result.snapshot },
+  }
+}


### PR DESCRIPTION
## What

Turns the ad-hoc "reconstruct a prod game at an exact past moment and hand it back as a playable game" surgery into a reviewed, reusable tool.

- **`src/server/mp/seedReplica.ts`** — pure `buildSeededReplica(rows, cutoffSeq, {token, seats, now})`: replays a source game's durable intent-log prefix (`≤ cutoffSeq`) through the real seam (`replayIntentLog` → `applyIntent`) into a fresh `phase:'playing'` `GameRecord` with every human seat **unclaimed**, plus its `'setup'` intent-log entry (so the replica replays from seq 1). No DB import — the caller does the single write, mirroring `replay.ts`.
- **`src/server/mp/intentlog.test.ts`** — env-gated tool next to `BB_REPLAY_TOKEN`:
  ```
  BB_SEED_FROM_TOKEN=<token> BB_SEED_CUTOFF_SEQ=<seq> [BB_SEED_WRITE=1] \
    pnpm vitest run src/server/mp/intentlog.test.ts -t 'BB_SEED_FROM_TOKEN'
  ```
  **DRY-RUN unless `BB_SEED_WRITE=1`**, which performs exactly ONE new-game INSERT and touches no existing row.
- **`src/server/mp/seedReplica.test.ts`** — offline unit test (engine only, no DB).
- **`AGENTS.md`** — pointer to the tool + a US→EU prod-Neon migration gotcha.

## Why

A player disputed a final-round move in prod game `y9KEazF6ldi9sQu4FXufhQ`. To let them retry it, we needed the board seeded at the exact state before intent seq 732 (rail round 9, Jules to act). The prior double-rail tasks re-derived a throwaway replay script each time; this makes it a one-liner with a hard dry-run guard.

The resulting retry game is live (`/g/uMdtB52bTz1Fp8G3ZsBVoQ`, EU prod); it needed no repo code to exist — this PR is only the reusable tooling.

## Test

- `seedReplica.test.ts` — 2 passed (offline).
- `pnpm typecheck` (TS7) — clean.
- `pnpm lint` (biome, 203 files) — clean.

The DB-backed `BB_SEED_FROM_TOKEN` block is `describe.runIf(...)`-gated, so normal `pnpm test` skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)