### PR TITLE
feat(hotseat): load a past game moment into the local hotseat surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -951,6 +951,17 @@ When updating this file, preserve this bar for all agents and keep entries conci
   src/server/mp/intentlog.test.ts -t 'BB_REPLAY_TOKEN'` (DATABASE_URL at the
   branch holding it). Pinned by replay.test.ts (offline FULL mock-AI game,
   both eras) + intentlog.test.ts (DB round-trip, concurrency, sweep).
+- HOTSEAT REPLAY BRIDGE (2026-07-22): load a PAST MOMENT of a game into the
+  fully-local hotseat surface (all seats in one browser, every hand visible,
+  undo working) — `/?replay=<token>&cutoff=<seq>`. `game.tsx`'s boot fetches
+  `GET /api/replay?token=&cutoff=` (route.ts), which reads the source game's
+  intent log (`loadIntentLog`, DB, READ-ONLY — writes nothing) and replays the
+  prefix via `buildHotseatReplaySnapshot` (`hotseatReplay.ts`, pure →
+  `replayIntentLog`). `cutoff` is EXCLUSIVE (state BEFORE that seq; omit for the
+  whole game). The reconstructed snapshot becomes an ordinary `bb2-save-v1`
+  hotseat game — playing it needs no DB. Distinct from `seedReplica.ts` (which
+  seeds a DB-backed, hand-HIDING multiplayer game). Pinned offline by
+  `hotseatReplay.test.ts` (synthetic log → prefix replay → boots in gameStore).
 - Chat (normalized out 2026-07-16): chat lives in its OWN append-only
   `chat_messages` table (PK = game token + monotonic per-game `seq`, which is
   the wire `id`), NOT the game jsonb row. A POST /api/mp/chat appends ONE row

--- a/src/app/api/replay/route.ts
+++ b/src/app/api/replay/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server'
+import { buildHotseatReplaySnapshot } from '~/server/mp/hotseatReplay'
+import { loadIntentLog } from '~/server/mp/store'
+
+export const runtime = 'nodejs'
+// Depends on live DB rows for the requested token — never build-time cached.
+export const dynamic = 'force-dynamic'
+
+/**
+ * Dev/support bridge: reconstruct the snapshot for a PAST MOMENT of a game and
+ * hand it to the fully-local hotseat surface (`src/components/game.tsx`,
+ * `?replay=<token>&cutoff=<seq>`).
+ *
+ * Read-only: it loads the source game's durable intent log (`loadIntentLog`)
+ * and replays the prefix BEFORE `cutoff` through the real engine seam
+ * (`buildHotseatReplaySnapshot` → `replayIntentLog`). It writes NOTHING — no
+ * game row is created or touched — and the reconstructed snapshot needs no DB
+ * to play once it lands in the browser's hotseat save.
+ *
+ * `cutoff` is EXCLUSIVE: the board comes back as it stood the instant BEFORE
+ * the event logged at that seq. Omit `cutoff` (or pass a value past the last
+ * seq) to reconstruct the whole game up to its final logged move.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const token = url.searchParams.get('token')
+  if (!token) {
+    return NextResponse.json({ error: 'Missing token' }, { status: 400 })
+  }
+
+  const cutoffParam = url.searchParams.get('cutoff')
+  // Default to the whole game: Infinity keeps every logged intent (< cutoff).
+  const cutoff =
+    cutoffParam === null || cutoffParam === '' ? Infinity : Number(cutoffParam)
+  if (!Number.isFinite(cutoff) && cutoff !== Infinity) {
+    return NextResponse.json({ error: 'Malformed cutoff' }, { status: 400 })
+  }
+
+  const rows = await loadIntentLog(token)
+  if (rows.length === 0) {
+    return NextResponse.json(
+      { error: 'No intent log for that token (unknown or unlogged game)' },
+      { status: 404 },
+    )
+  }
+
+  try {
+    const { snapshot, steps } = buildHotseatReplaySnapshot(rows, cutoff)
+    return NextResponse.json(
+      { snapshot, steps },
+      { headers: { 'Cache-Control': 'no-store' } },
+    )
+  } catch (err) {
+    // Replay refused the prefix (no leading setup, or a logged event no longer
+    // applies) — surface it; it is the interesting bug-report signal.
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : 'Replay failed' },
+      { status: 422 },
+    )
+  }
+}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -200,6 +200,48 @@ export function Game() {
   // mount gate so SSR and hydration always agree.
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
+    // ?replay=<token>&cutoff=<seq> — dev/support bridge: fetch a source game's
+    // durable intent log server-side, replay it to the moment BEFORE `cutoff`,
+    // and load THAT board into this fully-local hotseat (all seats in one
+    // browser, every hand visible, undo working). Once loaded it is a normal
+    // live game — playing it needs no DB. `cutoff` optional (whole game).
+    const replayToken = params.get('replay')
+    if (replayToken) {
+      const qs = new URLSearchParams({ token: replayToken })
+      const cutoff = params.get('cutoff')
+      if (cutoff) qs.set('cutoff', cutoff)
+      let cancelled = false
+      void (async () => {
+        try {
+          const res = await fetch(`/api/replay?${qs.toString()}`)
+          const body = (await res.json().catch(() => null)) as {
+            snapshot?: unknown
+            error?: string
+          } | null
+          if (!res.ok || !body?.snapshot) {
+            throw new Error(body?.error ?? `Replay failed (${res.status})`)
+          }
+          if (cancelled) return
+          // Drop any prior save so a refresh resumes THIS moment; the persist
+          // effect then re-saves it as an ordinary hotseat game.
+          clearSave()
+          setBoot({
+            kind: 'demo',
+            snapshot: rehydrateSnapshot(body.snapshot),
+            resumed: false,
+          })
+        } catch (err) {
+          if (cancelled) return
+          toast.error(
+            err instanceof Error ? err.message : 'Could not load that moment',
+          )
+          setBoot({ kind: 'fresh', resumed: false })
+        }
+      })()
+      return () => {
+        cancelled = true
+      }
+    }
     if (params.get('preview') === 'gameover') {
       setBoot({ kind: 'preview-gameover', resumed: false })
       return

--- a/src/server/mp/hotseatReplay.test.ts
+++ b/src/server/mp/hotseatReplay.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest'
+// Offline unit test for `buildHotseatReplaySnapshot` — no DB. We synthesize an
+// intent log exactly as `saveGame` would (a 'setup' snapshot + accepted
+// 'intent' rows produced by the real `applyIntent` seam), then assert the
+// reconstructed snapshot is the prefix replay AND that it boots cleanly in the
+// hotseat store (createActor on the rehydrated snapshot), i.e. a past moment
+// loads into a fully-local, all-hands-visible game.
+import { createActor } from 'xstate'
+import { gameStore } from '../../store/gameStore'
+import { buildHotseatReplaySnapshot } from './hotseatReplay'
+import { applyIntent } from './intent'
+import { type ReplayRow, normalizeSnapshotForComparison } from './replay'
+
+interface SeatDef {
+  seatId: number
+  name: string
+  color: string
+  character: string
+}
+
+const SEATS: SeatDef[] = [
+  { seatId: 0, name: 'Ada', color: 'red', character: 'Eliza Tinsley' },
+  { seatId: 1, name: 'Bea', color: 'blue', character: 'George Stephenson' },
+]
+
+/** A minimal, real intent log: START_GAME setup + one accepted loan by seat 0
+ * (TAKE_LOAN → SELECT_CARD → CONFIRM), each event a separate 'intent' row —
+ * mirroring what the durable log stores. */
+function makeLog(): { rows: ReplayRow[]; afterSetup: unknown } {
+  const actor = createActor(gameStore)
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: SEATS.map((s) => ({
+      id: String(s.seatId + 1),
+      name: s.name,
+      color: s.color,
+      character: s.character,
+      money: 17,
+      victoryPoints: 0,
+      income: 10,
+      industryTilesOnMat: {},
+    })),
+  } as never)
+  const afterSetup: unknown = actor.getPersistedSnapshot()
+  actor.stop()
+
+  const cardId = (
+    afterSetup as {
+      context: { players: Array<{ hand: Array<{ id: string }> }> }
+    }
+  ).context.players[0]!.hand[0]!.id
+  const events: Array<{ type: string } & Record<string, unknown>> = [
+    { type: 'TAKE_LOAN' },
+    { type: 'SELECT_CARD', cardId },
+    { type: 'CONFIRM' },
+  ]
+
+  let snapshot = afterSetup
+  const rows: ReplayRow[] = [
+    { seq: 1, kind: 'setup', seatId: null, payload: afterSetup, version: 1 },
+  ]
+  events.forEach((event, i) => {
+    const outcome = applyIntent(snapshot, 0, event)
+    if (!outcome.ok)
+      throw new Error(`setup step ${event.type} refused: ${outcome.error}`)
+    snapshot = outcome.next
+    rows.push({
+      seq: i + 2,
+      kind: 'intent',
+      seatId: 0,
+      payload: event,
+      version: i + 2,
+    })
+  })
+  return { rows, afterSetup }
+}
+
+/** Rebuild Infinity market caps the same way the hotseat boot's
+ * `rehydrateSnapshot` does — a JSON round-trip turned them into null. */
+function rehydrate(snapshot: unknown): unknown {
+  const clone = structuredClone(snapshot) as {
+    context?: {
+      coalMarket?: Array<{ maxCubes: number | null }>
+      ironMarket?: Array<{ maxCubes: number | null }>
+    }
+  }
+  for (const market of [clone.context?.coalMarket, clone.context?.ironMarket]) {
+    if (!Array.isArray(market)) continue
+    for (const row of market) {
+      if (row && row.maxCubes === null) row.maxCubes = Infinity
+    }
+  }
+  return clone
+}
+
+describe('buildHotseatReplaySnapshot', () => {
+  it('reconstructs the state BEFORE the cutoff seq (exclusive)', () => {
+    const { rows } = makeLog()
+    // Cutoff at the CONFIRM (seq 4): reconstruct the moment just before it —
+    // TAKE_LOAN + SELECT_CARD applied, loan not yet committed.
+    const beforeConfirm = buildHotseatReplaySnapshot(rows, 4)
+    expect(beforeConfirm.steps).toBe(2)
+
+    // Cutoff at the first move (seq 2): only the setup — a fresh board.
+    const beforeFirstMove = buildHotseatReplaySnapshot(rows, 2)
+    expect(beforeFirstMove.steps).toBe(0)
+    expect(normalizeSnapshotForComparison(beforeFirstMove.snapshot)).toEqual(
+      normalizeSnapshotForComparison(rows[0]!.payload),
+    )
+  })
+
+  it('committing the loan is only visible past the cutoff', () => {
+    const { rows } = makeLog()
+    const moneyAt = (snap: unknown) =>
+      (snap as { context: { players: Array<{ money: number }> } }).context
+        .players[0]!.money
+
+    const before = buildHotseatReplaySnapshot(rows, 4) // before CONFIRM
+    const after = buildHotseatReplaySnapshot(rows, 5) // after CONFIRM
+    // A loan pays £30 and drops income — money strictly grows across the CONFIRM.
+    expect(moneyAt(after.snapshot)).toBeGreaterThan(moneyAt(before.snapshot))
+  })
+
+  it('the reconstructed snapshot boots into the hotseat store', () => {
+    const { rows } = makeLog()
+    const { snapshot } = buildHotseatReplaySnapshot(rows, 4)
+    // The exact hotseat boot path: rehydrate, then createActor from it.
+    const actor = createActor(gameStore, {
+      snapshot: rehydrate(snapshot) as never,
+    })
+    actor.start()
+    const state = actor.getSnapshot()
+    // A live, playable game — not setup, not over — with all seats present so
+    // every hand is controllable in one browser.
+    expect(state.matches('setup')).toBe(false)
+    expect(state.matches('gameOver')).toBe(false)
+    expect(state.context.players).toHaveLength(SEATS.length)
+    actor.stop()
+  })
+
+  it('throws when the prefix has no setup (cutoff at/below the setup seq)', () => {
+    const { rows } = makeLog()
+    expect(() => buildHotseatReplaySnapshot(rows, 1)).toThrow(/setup/i)
+  })
+})

--- a/src/server/mp/hotseatReplay.ts
+++ b/src/server/mp/hotseatReplay.ts
@@ -1,0 +1,42 @@
+// Reconstruct the snapshot for a PAST MOMENT of an existing game so it can be
+// dropped into the fully-local hotseat surface — "hand me the board at exactly
+// this moment and let me retry it".
+//
+// Unlike `seedReplica.ts` (which seeds a DB-backed, hand-hiding multiplayer
+// game), this produces a plain persisted engine snapshot for the client-side
+// hotseat shell (`src/components/game.tsx`): all seats controlled in one
+// browser, every hand visible, hotseat undo available, and — once loaded — NO
+// multiplayer/DB involvement to play it.
+//
+// Pure on purpose (no DB import), like `replay.ts`: the caller fetches the
+// source game's intent log (`loadIntentLog` in store.ts, DB) and hands the rows
+// here; this only replays. That keeps it offline-testable.
+import { type ReplayRow, replayIntentLog } from './replay'
+
+export interface HotseatReplayResult {
+  /** the persisted engine snapshot at the reconstructed moment — feed it
+   * straight into the hotseat boot (after `rehydrateSnapshot`) */
+  snapshot: unknown
+  /** number of 'intent' rows replayed to reach it (the 'setup' row excluded) */
+  steps: number
+}
+
+/**
+ * Replay `rows` up to — but NOT including — `cutoffSeq`, yielding the snapshot
+ * as it stood the instant BEFORE the event logged at that seq was applied. So
+ * to retry a disputed move recorded at seq N, pass `cutoffSeq = N`: the board
+ * comes back exactly as it was before that move.
+ *
+ * Throws (via `replayIntentLog`) if the prefix has no leading 'setup' record
+ * (e.g. an unknown token, or a cutoff at/below the setup seq) or if any logged
+ * event no longer applies — a genuine bug-report signal, not papered over.
+ * Does NOT write anything.
+ */
+export function buildHotseatReplaySnapshot(
+  rows: ReplayRow[],
+  cutoffSeq: number,
+): HotseatReplayResult {
+  const prefix = rows.filter((r) => r.seq < cutoffSeq)
+  const result = replayIntentLog(prefix)
+  return { snapshot: result.snapshot, steps: result.steps }
+}


### PR DESCRIPTION
## What

A player disputed a late move in an online game and we want to hand them (and ourselves) the board at an exact past moment to retry. This adds a bridge that reconstructs any historical moment of a game and loads it directly into the **client-side hotseat** surface — all seats controlled in one browser, every hand visible, hotseat undo working, and **no multiplayer/DB sync needed to play it**.

The existing seed tool writes a DB-backed multiplayer game (`/g/<token>`), which hides other players' hands and has no undo — a poor fit for retrying a move. This is the hotseat path instead.

## How

- **`src/server/mp/hotseatReplay.ts`** (pure, no DB import) — `buildHotseatReplaySnapshot(rows, cutoffSeq)` replays a source game's durable intent log up to — but **not including** — `cutoffSeq` through the real engine seam (`replayIntentLog`), yielding the persisted snapshot as it stood the instant *before* that move. Mirror of `replay.ts` / `seedReplica.ts`, so it stays offline-testable.
- **`GET /api/replay?token=&cutoff=`** — loads the source game's intent log (`loadIntentLog`, **read-only — writes nothing**) and returns the reconstructed snapshot. `cutoff` is **exclusive** (the state before that seq); omit it for the whole game.
- **`src/components/game.tsx`** — boots `?replay=<token>&cutoff=<seq>`: fetches the snapshot, rehydrates it, and loads it as an ordinary `bb2-save-v1` hotseat game — so it persists across refresh and hotseat undo works like any other game.

## Entrypoint

```
/?replay=<sourceGameToken>&cutoff=<seq>
```

## Testing

- **`hotseatReplay.test.ts`** (offline, no DB): synthesizes a real intent log via `applyIntent`, asserts the exclusive-cutoff prefix replay is correct, that a loan committed at the cutoff is only visible past it, and that the reconstructed snapshot **boots cleanly in the `gameStore`** (the exact hotseat path).
- Verified end-to-end locally against a seeded game: `/api/replay` returns 200 with the correct pre-cutoff state (404 on unknown token), and `/?replay=...&cutoff=...` renders the board at that moment with both seats visible and the hotseat save persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)