### PR TITLE
chore: make CodeRabbit review opt-in via .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# CodeRabbit review is opt-in for this repo: PRs are NOT auto-reviewed on open,
+# so routine PRs don't consume the shared account's review budget. Ask for a
+# review on the PRs that want one, either way:
+#   - add the `coderabbit` label to the PR (auto-review then fires), or
+#   - comment `@coderabbitai review` (on-demand, always works regardless of config).
+reviews:
+  auto_review:
+    # Disable automatic per-PR review. A positive `labels` match below still
+    # triggers a review even while this is false, giving us the label opt-in.
+    enabled: false
+    # Auto-review only fires when this label is present on the PR.
+    labels:
+      - coderabbit


### PR DESCRIPTION
## Why

The repo has no `.coderabbit.yaml`, so CodeRabbit auto-reviews **every PR on open**. At our PR volume that drains the shared CodeRabbit account's fair-usage/adaptive review budget — and once it's exhausted, every brass PR stalls waiting for a review that never lands (this happened today across ~6 PRs). Making review **opt-in** means a PR only spends budget when we explicitly ask.

## What this does

Adds a root `.coderabbit.yaml` that turns **off** automatic per-PR review while keeping both opt-in paths working:

- **`coderabbit` label** — a positive label match triggers a review even while `auto_review.enabled: false` (per CodeRabbit's v2 schema), so the label is the visible opt-in signal.
- **`@coderabbitai review` comment** — on-demand review, always works regardless of config.

Config is schema-valid against the current CodeRabbit v2 config schema (`reviews.auto_review.enabled` / `reviews.auto_review.labels`). No app or code behavior changes — repo config only.

## ⚠️ Takes effect only once merged

CodeRabbit reads its config from the **base branch**, not the PR head. So this PR itself — and every other currently-open PR — is **not** gated until this merges to `main`. Automated review on this PR is waived (the account is over its shared limit right now anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)