### PR TITLE
feat(ui): collapse the right dock to the board edge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,6 +567,13 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   dock type. The right column is `lg:w-[416px]` and the hand tray clears it
   with `lg:right-[428px]` — keep those in sync; both are lg-gated so phone
   (w-full / right-0) is untouched.
+- PANEL COLLAPSE (2026-07-22): the right column collapses to the board edge
+  (lg-only) via `usePanelCollapsed` + `SidePanelRail` (`side-panels.tsx`),
+  shared by `game.tsx` and `mp-game.tsx`. Collapsed = aside `lg:w-0` (inner
+  keeps `lg:w-[416px]` so it clips, not squashes) and the hand tray moves to
+  `lg:right-[44px]` — a THIRD offset to keep in sync with the two above. The
+  pref is its own localStorage flag `bb2-panel-collapsed-v1` (separate from
+  `bb2-save-v1`, survives a new game; session-only if storage is unavailable).
 - HOVER-TO-LOCATE (2026-07-17): hovering/focusing any city NAME (journal,
   source pickers, sale list, dock steps, ledger, card chips) spotlights its
   plate on the map. The name reads as interactive (`.bb2-locate-name` in

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -58,7 +58,7 @@ import { GameOverScreen, PassGate, RoundCurtain } from './overlays'
 import { OpenMatButton, PlayerLedger } from './player-ledger'
 import { PlayerRail } from './player-rail'
 import { SetupScreen } from './setup-screen'
-import { MarketsPanel } from './side-panels'
+import { MarketsPanel, SidePanelRail, usePanelCollapsed } from './side-panels'
 
 const SAVE_KEY = 'bb2-save-v1'
 
@@ -447,6 +447,7 @@ function GameInner({
   )
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [incomeTrackOpen, setIncomeTrackOpen] = useState(false)
+  const [panelCollapsed, togglePanel] = usePanelCollapsed()
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
   // Hover-a-name spotlight: the player whose rail mat is hovered/focused right
   // now — the board lights up their network (links + tiles) and recedes the rest.
@@ -1050,33 +1051,51 @@ function GameInner({
             </div>
           </div>
 
-          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[416px] lg:overflow-y-auto lg:pb-0">
-            <div className="bb2-panel bb2-panel-active flex flex-col gap-3 p-5">
-              {!needsReveal && (
-                <ActionDock
-                  snapshot={state as GameStoreSnapshot}
-                  send={send}
-                  currentPlayer={currentPlayer}
-                  canSellAnything={canSellAnything}
-                  viableIndustries={viableIndustries}
-                  confirmOutcome={confirmOutcome}
-                  actionsLeft={{
-                    remaining: ctx.actionsRemaining,
-                    max: maxActions,
-                  }}
-                  legalSiteCount={pickingSite ? (legalCities?.size ?? 0) : null}
-                  onUndo={canUndo ? onUndo : null}
-                />
-              )}
-              {!needsReveal && (
-                <OpenMatButton onClick={() => setLedgerFor(currentPlayer.id)} />
-              )}
+          <SidePanelRail collapsed={panelCollapsed} onToggle={togglePanel} />
+
+          <aside
+            data-testid="side-panel"
+            data-collapsed={panelCollapsed}
+            className={`flex w-full flex-none flex-col pb-44 transition-[width] duration-300 ease-in-out lg:pb-0 ${
+              panelCollapsed
+                ? 'lg:w-0 lg:overflow-hidden'
+                : 'lg:w-[416px] lg:overflow-y-auto'
+            }`}
+          >
+            {/* Inner keeps its full width so a collapse clips the column to
+                the edge instead of squashing its contents mid-animation. */}
+            <div className="flex w-full flex-col gap-3 lg:w-[416px]">
+              <div className="bb2-panel bb2-panel-active flex flex-col gap-3 p-5">
+                {!needsReveal && (
+                  <ActionDock
+                    snapshot={state as GameStoreSnapshot}
+                    send={send}
+                    currentPlayer={currentPlayer}
+                    canSellAnything={canSellAnything}
+                    viableIndustries={viableIndustries}
+                    confirmOutcome={confirmOutcome}
+                    actionsLeft={{
+                      remaining: ctx.actionsRemaining,
+                      max: maxActions,
+                    }}
+                    legalSiteCount={
+                      pickingSite ? (legalCities?.size ?? 0) : null
+                    }
+                    onUndo={canUndo ? onUndo : null}
+                  />
+                )}
+                {!needsReveal && (
+                  <OpenMatButton
+                    onClick={() => setLedgerFor(currentPlayer.id)}
+                  />
+                )}
+              </div>
+              <MarketsPanel
+                coalMarket={ctx.coalMarket}
+                ironMarket={ctx.ironMarket}
+              />
+              <JournalPanel logs={ctx.logs} players={ctx.players} />
             </div>
-            <MarketsPanel
-              coalMarket={ctx.coalMarket}
-              ironMarket={ctx.ironMarket}
-            />
-            <JournalPanel logs={ctx.logs} players={ctx.players} />
           </aside>
         </div>
 
@@ -1093,6 +1112,7 @@ function GameInner({
             selectedIds={handSel?.selectedIds ?? []}
             hint={handSel?.hint ?? null}
             onHoverCard={setHoveredCard}
+            panelCollapsed={panelCollapsed}
           />
         )}
 

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -49,6 +49,8 @@ export interface HandTrayProps {
   hint?: string | null
   /** Hover preview: the shell highlights the card's targets on the map. */
   onHoverCard?: (card: GameCard | null) => void
+  /** Right dock collapsed — the tray extends toward the reclaimed edge. */
+  panelCollapsed?: boolean
 }
 
 export function HandTray({
@@ -58,6 +60,7 @@ export function HandTray({
   selectedIds = [],
   hint,
   onHoverCard,
+  panelCollapsed = false,
 }: HandTrayProps) {
   const n = hand.length
   const selecting = canSelect !== null
@@ -189,7 +192,9 @@ export function HandTray({
   return (
     <div
       ref={rootRef}
-      className="bb2-handtray pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center lg:right-[428px]"
+      className={`bb2-handtray pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center transition-[right] duration-300 ease-in-out ${
+        panelCollapsed ? 'lg:right-[44px]' : 'lg:right-[428px]'
+      }`}
       style={
         { '--bb-hint-clear': `${hintClearance(lens)}px` } as React.CSSProperties
       }

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -31,7 +31,12 @@ import { GameOverScreen, RoundCurtain } from '../overlays'
 import { OpenMatButton, PlayerLedger } from '../player-ledger'
 import { PlayerRail } from '../player-rail'
 import { JournalPanel } from '../journal'
-import { CollapsiblePanel, MarketsPanel } from '../side-panels'
+import {
+  CollapsiblePanel,
+  MarketsPanel,
+  SidePanelRail,
+  usePanelCollapsed,
+} from '../side-panels'
 import { UNREACHABLE, refusalToShow } from './refusal'
 import { didBecomeMyTurn, playTurnChime, titleForTurn } from './turnNotify'
 import { useInFlight } from './use-in-flight'
@@ -905,6 +910,7 @@ function MpTable({
   applyView: (view: GameViewWire) => void
 }) {
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
+  const [panelCollapsed, togglePanel] = usePanelCollapsed()
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
   // Hover-a-name spotlight: the player whose rail mat is hovered/focused right
   // now — the board lights up their network (links + tiles) and recedes the rest.
@@ -1376,119 +1382,136 @@ function MpTable({
             </div>
           </div>
 
-          <aside className="flex w-full flex-none flex-col gap-3 pb-44 lg:w-[416px] lg:overflow-y-auto lg:pb-0">
-            <div
-              className={`bb2-panel bb2-panel-active flex flex-col gap-3 p-5 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
-              aria-busy={myTurn && inFlight}
-            >
-              {myTurn ? (
-                <ActionDock
-                  snapshot={state}
-                  send={send as never}
-                  currentPlayer={currentPlayer}
-                  canSellAnything={canSellAnything}
-                  actionsLeft={{
-                    remaining: ctx.actionsRemaining,
-                    max: maxActions,
-                  }}
-                />
-              ) : aiTurn ? (
-                <div className="flex flex-col gap-2" data-testid="ai-panel">
-                  <span className="bb2-panel-title">
-                    The rival&rsquo;s desk
-                  </span>
-                  <p
-                    className="text-[14px]"
-                    style={{ color: 'var(--bb-parchment)' }}
-                  >
-                    <b style={{ color: 'var(--bb-brass-bright)' }}>
-                      {currentPlayer.name}
-                    </b>{' '}
-                    <span
-                      className="text-[11px] uppercase tracking-[0.12em]"
+          <SidePanelRail collapsed={panelCollapsed} onToggle={togglePanel} />
+
+          <aside
+            data-testid="side-panel"
+            data-collapsed={panelCollapsed}
+            className={`flex w-full flex-none flex-col pb-44 transition-[width] duration-300 ease-in-out lg:pb-0 ${
+              panelCollapsed
+                ? 'lg:w-0 lg:overflow-hidden'
+                : 'lg:w-[416px] lg:overflow-y-auto'
+            }`}
+          >
+            {/* Inner keeps its full width so a collapse clips the column to
+                the edge instead of squashing its contents mid-animation. */}
+            <div className="flex w-full flex-col gap-3 lg:w-[416px]">
+              <div
+                className={`bb2-panel bb2-panel-active flex flex-col gap-3 p-5 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
+                aria-busy={myTurn && inFlight}
+              >
+                {myTurn ? (
+                  <ActionDock
+                    snapshot={state}
+                    send={send as never}
+                    currentPlayer={currentPlayer}
+                    canSellAnything={canSellAnything}
+                    actionsLeft={{
+                      remaining: ctx.actionsRemaining,
+                      max: maxActions,
+                    }}
+                  />
+                ) : aiTurn ? (
+                  <div className="flex flex-col gap-2" data-testid="ai-panel">
+                    <span className="bb2-panel-title">
+                      The rival&rsquo;s desk
+                    </span>
+                    <p
+                      className="text-[14px]"
+                      style={{ color: 'var(--bb-parchment)' }}
+                    >
+                      <b style={{ color: 'var(--bb-brass-bright)' }}>
+                        {currentPlayer.name}
+                      </b>{' '}
+                      <span
+                        className="text-[11px] uppercase tracking-[0.12em]"
+                        style={{ color: 'rgba(231,215,177,.5)' }}
+                      >
+                        ({currentSeat?.aiTier?.difficulty ?? 'ai'})
+                      </span>{' '}
+                      {aiIsThinking ? (
+                        <span
+                          className="animate-pulse"
+                          data-testid="ai-thinking"
+                        >
+                          is thinking…
+                        </span>
+                      ) : (
+                        <span>is moving…</span>
+                      )}
+                    </p>
+                    <p
+                      className="text-[12px]"
                       style={{ color: 'rgba(231,215,177,.5)' }}
                     >
-                      ({currentSeat?.aiTier?.difficulty ?? 'ai'})
-                    </span>{' '}
-                    {aiIsThinking ? (
-                      <span className="animate-pulse" data-testid="ai-thinking">
-                        is thinking…
-                      </span>
-                    ) : (
-                      <span>is moving…</span>
-                    )}
-                  </p>
-                  <p
-                    className="text-[12px]"
-                    style={{ color: 'rgba(231,215,177,.5)' }}
+                      Its moves and reasoning appear in the rival&rsquo;s
+                      journal below.
+                    </p>
+                  </div>
+                ) : (
+                  <div
+                    className="flex flex-col gap-2"
+                    data-testid="waiting-panel"
                   >
-                    Its moves and reasoning appear in the rival&rsquo;s journal
-                    below.
-                  </p>
-                </div>
-              ) : (
-                <div
-                  className="flex flex-col gap-2"
-                  data-testid="waiting-panel"
-                >
-                  <span className="bb2-panel-title">The table</span>
-                  <p
-                    className="text-[14px]"
-                    style={{ color: 'var(--bb-parchment)' }}
-                  >
-                    Waiting for{' '}
-                    <b style={{ color: 'var(--bb-brass-bright)' }}>
-                      {currentPlayer.name}
-                    </b>{' '}
-                    to act…
-                  </p>
-                  <p
-                    className="text-[12px]"
-                    style={{ color: 'rgba(231,215,177,.5)' }}
-                  >
-                    Moves appear here live. Your hand stays private below.
-                  </p>
-                </div>
-              )}
-              {/* Always yours, never the seat that happens to be acting. */}
-              {me && <OpenMatButton onClick={() => setLedgerFor(me.id)} />}
-            </div>
-            {view.ai && <AiMindPanel ai={view.ai} seats={view.seats} />}
-            <MarketsPanel
-              coalMarket={ctx.coalMarket}
-              ironMarket={ctx.ironMarket}
-            />
-            <ChatPanel
-              messages={view.messages ?? []}
-              you={you}
-              seats={view.seats}
-              onSend={(text) => {
-                void (async () => {
-                  try {
-                    const res = await fetch('/api/mp/chat', {
-                      method: 'POST',
-                      headers: { 'Content-Type': 'application/json' },
-                      body: JSON.stringify({
-                        token,
-                        seatId: creds.seatId,
-                        seatSecret: creds.seatSecret,
-                        text,
-                      }),
-                    })
-                    const body = (await res.json()) as {
-                      ok: boolean
-                      view?: GameViewWire
+                    <span className="bb2-panel-title">The table</span>
+                    <p
+                      className="text-[14px]"
+                      style={{ color: 'var(--bb-parchment)' }}
+                    >
+                      Waiting for{' '}
+                      <b style={{ color: 'var(--bb-brass-bright)' }}>
+                        {currentPlayer.name}
+                      </b>{' '}
+                      to act…
+                    </p>
+                    <p
+                      className="text-[12px]"
+                      style={{ color: 'rgba(231,215,177,.5)' }}
+                    >
+                      Moves appear here live. Your hand stays private below.
+                    </p>
+                  </div>
+                )}
+                {/* Always yours, never the seat that happens to be acting. */}
+                {me && <OpenMatButton onClick={() => setLedgerFor(me.id)} />}
+              </div>
+              {view.ai && <AiMindPanel ai={view.ai} seats={view.seats} />}
+              <MarketsPanel
+                coalMarket={ctx.coalMarket}
+                ironMarket={ctx.ironMarket}
+              />
+              <ChatPanel
+                messages={view.messages ?? []}
+                you={you}
+                seats={view.seats}
+                onSend={(text) => {
+                  void (async () => {
+                    try {
+                      const res = await fetch('/api/mp/chat', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                          token,
+                          seatId: creds.seatId,
+                          seatSecret: creds.seatSecret,
+                          text,
+                        }),
+                      })
+                      const body = (await res.json()) as {
+                        ok: boolean
+                        view?: GameViewWire
+                      }
+                      // Apply the sender's fresh view (with the new message) at once,
+                      // same version-guarded path as an SSE frame.
+                      if (body.ok && body.view) applyView(body.view)
+                    } catch {
+                      toast.error('Could not send the message')
                     }
-                    // Apply the sender's fresh view (with the new message) at once,
-                    // same version-guarded path as an SSE frame.
-                    if (body.ok && body.view) applyView(body.view)
-                  } catch {
-                    toast.error('Could not send the message')
-                  }
-                })()
-              }}
-            />
-            <JournalPanel logs={ctx.logs} players={ctx.players} />
+                  })()
+                }}
+              />
+              <JournalPanel logs={ctx.logs} players={ctx.players} />
+            </div>
           </aside>
         </div>
 
@@ -1504,6 +1527,7 @@ function MpTable({
           selectedIds={handSel?.selectedIds ?? []}
           hint={handSel?.hint ?? null}
           onHoverCard={setHoveredCard}
+          panelCollapsed={panelCollapsed}
         />
 
         {ledgerPlayer && (

--- a/src/components/side-panels.tsx
+++ b/src/components/side-panels.tsx
@@ -3,8 +3,69 @@
 // Right-dock reference panels: the collapsible shell and the coal & iron
 // exchanges. The journal moved to journal.tsx (with its presentation model
 // in journal-model.ts).
-import { type ReactNode, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useState } from 'react'
 import { type GameState } from '~/store/gameStore'
+
+/* ---------------- side-dock collapse ---------------- */
+
+// Whole-column collapse: slide the right dock (dock + exchanges + journal)
+// out to the screen edge so the board reclaims the width. Desktop-only —
+// on phones the dock stacks below the board, where hiding it buys nothing.
+// The preference is a single lightweight localStorage flag, deliberately
+// separate from the game save (bb2-save-v1) so it survives a new game.
+const PANEL_COLLAPSE_KEY = 'bb2-panel-collapsed-v1'
+
+export function usePanelCollapsed(): [boolean, () => void] {
+  const [collapsed, setCollapsed] = useState(false)
+  // Read after mount so SSR/first paint always agree (the shell renders
+  // client-side behind a boot gate, but keep this honest regardless).
+  useEffect(() => {
+    try {
+      setCollapsed(localStorage.getItem(PANEL_COLLAPSE_KEY) === '1')
+    } catch {
+      // storage unavailable — session-only toggle, default expanded
+    }
+  }, [])
+  const toggle = useCallback(() => {
+    setCollapsed((c) => {
+      const next = !c
+      try {
+        localStorage.setItem(PANEL_COLLAPSE_KEY, next ? '1' : '0')
+      } catch {
+        // storage full/unavailable — the toggle still works this session
+      }
+      return next
+    })
+  }, [])
+  return [collapsed, toggle]
+}
+
+// The persistent handle that lives in the gutter between board and dock.
+// One affordance for both directions: chevron points toward the edge to
+// collapse, back toward the board to expand.
+export function SidePanelRail({
+  collapsed,
+  onToggle,
+}: {
+  collapsed: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      data-testid="panel-collapse-toggle"
+      aria-expanded={!collapsed}
+      aria-label={collapsed ? 'Expand side panel' : 'Collapse side panel'}
+      title={collapsed ? 'Expand side panel' : 'Collapse side panel'}
+      className="bb2-panel-rail hidden flex-none lg:flex"
+    >
+      <span aria-hidden className="bb2-panel-rail-chevron">
+        {collapsed ? '‹' : '›'}
+      </span>
+    </button>
+  )
+}
 
 /* ---------------- collapsible shell ---------------- */
 

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -153,6 +153,39 @@
   );
 }
 
+/* The board↔dock collapse handle: a slim brass gutter rail. Persistent so
+   the same control both hides and restores the right column. */
+.bb2-panel-rail {
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  align-self: stretch;
+  border: 1px solid var(--bb-brass-hairline-soft);
+  border-radius: 6px;
+  background: linear-gradient(
+    170deg,
+    var(--bb-iron-raised) 0%,
+    var(--bb-iron-panel) 100%
+  );
+  color: rgba(231, 215, 177, 0.55);
+  cursor: pointer;
+  transition: color 0.18s ease, border-color 0.18s ease, background 0.18s ease;
+}
+.bb2-panel-rail:hover {
+  color: var(--bb-brass-bright);
+  border-color: var(--bb-brass);
+  background: linear-gradient(170deg, #2c2417 0%, var(--bb-iron-raised) 100%);
+}
+.bb2-panel-rail:focus-visible {
+  outline: 2px solid var(--bb-brass);
+  outline-offset: 2px;
+}
+.bb2-panel-rail-chevron {
+  font-size: 15px;
+  line-height: 1;
+  font-weight: 700;
+}
+
 .bb2-panel-title {
   font-family: var(--bb-body);
   font-weight: 600;


### PR DESCRIPTION
## What

Adds a **collapsible right dock** so players can reclaim board space. A slim brass rail lives in the gutter between the board and the right-hand column (action dock + exchanges + journal). Clicking it slides the column out to the screen edge; clicking again brings it back. Expanded is the default.

## How it behaves

- **Persistent single affordance** — the same gutter rail both collapses and expands; its chevron points toward the edge to hide, back toward the board to restore.
- **Smooth animation** — the column animates its width. Its content keeps full width and clips rather than squashing mid-transition; the board flexes into the freed space and the hand tray extends toward the reclaimed edge.
- **Desktop-only (lg+)** — on phones the column stacks below the board, where hiding it buys nothing, so the rail is hidden there. No layout change on mobile.
- **Preference persists** in its own `localStorage` flag (`bb2-panel-collapsed-v1`), separate from the game save so it survives a new game. Falls back to a session-only toggle when storage is unavailable.
- **Accessible** — the rail is a keyboard-operable `<button>` with `aria-label` and `aria-expanded` reflecting the current state (verified expand via keyboard Enter).
- **Shared** between the hotseat (`/`) and multiplayer (`/g/...`) surfaces via `usePanelCollapsed` + `SidePanelRail` in `side-panels.tsx`.

## Verification

- `pnpm typecheck` and `biome lint` on touched files: clean.
- Browser-checked on the hotseat `?demo` fixture at 1440×900: collapse drops the column to width 0 and the board grows to fill it; expand restores 416px; preference persists across the toggle; keyboard focus + Enter operate the rail.

_Preview screenshots and the Vercel branch preview link are in a comment below._