### PR TITLE
feat(ui): give disabled action confirms the engine's definite refusal reason

### DIFF
--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -23,12 +23,12 @@ import {
   pendingCoalChoice,
   pendingIronChoice,
 } from '~/store/shared/resourceSources'
+import { disabledActionReason } from './action-reason'
 import { CardChip, cardTitle } from './cards'
 import {
   doubleLinkDisabledReason,
   showsDoubleLinkOption,
 } from './double-link-availability'
-import { CityName, useLocateCity } from './locate'
 import {
   BuildIcon,
   CanalIcon,
@@ -41,6 +41,7 @@ import {
   ScoutIcon,
   SellIcon,
 } from './icons'
+import { CityName, useLocateCity } from './locate'
 
 export const INDUSTRY_TYPES: IndustryType[] = [
   'cotton',
@@ -840,6 +841,11 @@ export function ActionDock({
 }: ActionDockProps) {
   const is = (path: string) => snapshot.matches(path as never)
   const can = (event: GameEvent) => snapshot.can(event)
+  // The definite reason a disabled confirm is refused — the engine's own, not a
+  // hand-written requirement list. Falls back to the generic line only when the
+  // engine cannot pin a single cause.
+  const whyDisabled = (event: GameEvent, fallback: string) =>
+    disabledActionReason(snapshot, event, fallback)
   const { locate, unlocate } = useLocateCity()
   const c = snapshot.context
 
@@ -1152,7 +1158,10 @@ export function ActionDock({
         <Confirm
           disabled={!can({ type: 'CONFIRM' })}
           onClick={() => send({ type: 'CONFIRM' })}
-          disabledReason="The ledger refuses this build — check your funds and coal / iron access from this site."
+          disabledReason={whyDisabled(
+            { type: 'CONFIRM' },
+            'This build cannot be completed from this site.',
+          )}
           outcome={confirmOutcome}
         >
           Raise the works
@@ -1277,7 +1286,10 @@ export function ActionDock({
         <Confirm
           disabled={!can({ type: 'CONFIRM' })}
           onClick={() => send({ type: 'CONFIRM' })}
-          disabledReason="This route can't be claimed — it must touch your network and be payable."
+          disabledReason={whyDisabled(
+            { type: 'CONFIRM' },
+            'This route cannot be claimed.',
+          )}
           outcome={confirmOutcome}
         >
           Lay the {c.era === 'canal' ? 'canal' : 'track'}
@@ -1388,7 +1400,10 @@ export function ActionDock({
         <Confirm
           disabled={!can({ type: 'EXECUTE_DOUBLE_NETWORK_ACTION' })}
           onClick={() => send({ type: 'EXECUTE_DOUBLE_NETWORK_ACTION' })}
-          disabledReason="Two rails need £15, 2 coal and 1 beer within reach."
+          disabledReason={whyDisabled(
+            { type: 'EXECUTE_DOUBLE_NETWORK_ACTION' },
+            'Two rails cannot be laid from here.',
+          )}
           outcome={confirmOutcome}
         >
           Lay both tracks
@@ -1444,7 +1459,10 @@ export function ActionDock({
         <Confirm
           disabled={!can({ type: 'CONFIRM' })}
           onClick={() => send({ type: 'CONFIRM' })}
-          disabledReason="No iron within reach (or none on the market you can afford)."
+          disabledReason={whyDisabled(
+            { type: 'CONFIRM' },
+            'This develop cannot be completed.',
+          )}
           outcome={confirmOutcome}
         >
           Scrap the tile
@@ -1587,6 +1605,10 @@ export function ActionDock({
             <Confirm
               disabled={!can({ type: 'CONFIRM' })}
               onClick={() => send({ type: 'CONFIRM' })}
+              disabledReason={whyDisabled(
+                { type: 'CONFIRM' },
+                'This sale cannot be closed.',
+              )}
             >
               Close the sale
             </Confirm>
@@ -1615,7 +1637,9 @@ export function ActionDock({
           disabled={!can({ type: 'CONFIRM' })}
           onClick={() => send({ type: 'CONFIRM' })}
           disabledReason={
-            picked.length < 3 ? undefined : 'Scout is not available right now.'
+            picked.length < 3
+              ? undefined
+              : whyDisabled({ type: 'CONFIRM' }, 'Scout is not available.')
           }
         >
           Send the scout
@@ -1655,6 +1679,10 @@ export function ActionDock({
         <Confirm
           disabled={!can({ type: 'CONFIRM' })}
           onClick={() => send({ type: 'CONFIRM' })}
+          disabledReason={whyDisabled(
+            { type: 'CONFIRM' },
+            'This loan cannot be taken.',
+          )}
         >
           Sign with the bank
         </Confirm>

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -841,9 +841,6 @@ export function ActionDock({
 }: ActionDockProps) {
   const is = (path: string) => snapshot.matches(path as never)
   const can = (event: GameEvent) => snapshot.can(event)
-  // The definite reason a disabled confirm is refused — the engine's own, not a
-  // hand-written requirement list. Falls back to the generic line only when the
-  // engine cannot pin a single cause.
   const whyDisabled = (event: GameEvent, fallback: string) =>
     disabledActionReason(snapshot, event, fallback)
   const { locate, unlocate } = useLocateCity()

--- a/src/components/action-reason.test.ts
+++ b/src/components/action-reason.test.ts
@@ -1,7 +1,3 @@
-// The disabled-confirm reason is the engine's own definite reason, never a
-// generic "needs X, Y, Z" list and never an "X or Y". This drives a real actor
-// to a disabled "Lay both tracks" double-rail confirm and asserts the wired
-// reason (disabledActionReason) is exactly what explainRefusal reports.
 import { afterEach, describe, expect, test } from 'vitest'
 import { createActor } from 'xstate'
 import type { CityId } from '~/data/board'
@@ -28,8 +24,6 @@ const resolveCoalTies = (actor: ReturnType<typeof createActor>) => {
   }
 }
 
-// A brewery (beer) plus a coal mine, so the whole double-rail path is legal
-// until we deliberately break one requirement.
 const industriesWithBeerAndCoal =
   (): GameState['players'][number]['industries'] => [
     {
@@ -173,7 +167,7 @@ describe('disabled action reason', () => {
 
   test('disabled double-rail confirm shows the engine reason, not the generic list', () => {
     const { actor, playerId } = reachConfirmingDoubleLink()
-    // Knock money below the £15 double-rail cost while everything else is fine.
+    // below the £15 double-rail cost, everything else fine
     actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId, money: 14 })
     const snap = actor.getSnapshot()
 
@@ -182,9 +176,7 @@ describe('disabled action reason', () => {
     const engineReason = explainRefusal(snap, EXECUTE)
     const wired = disabledActionReason(snap, EXECUTE, GENERIC)
 
-    // The dock renders exactly what the engine reports.
     expect(wired).toBe(engineReason)
-    // Definite, specific — not the generic requirement list, and never an "or".
     expect(wired).not.toBe(GENERIC)
     expect(wired).not.toMatch(/\bor\b/i)
     expect(wired).toContain('14')
@@ -195,9 +187,8 @@ describe('disabled action reason', () => {
     const live = actor.getSnapshot()
     const first = live.context.selectedLink!
 
-    // Surgery: strip every coal source (no connected mine, empty market) while
-    // keeping beer reachable. EXECUTE's refusal case reads only context, so a
-    // context-only snapshot stand-in is enough to exercise explainDoubleLink.
+    // strip every coal source (no mine, empty market), keep beer; EXECUTE's
+    // refusal reads only context, so a context-only stand-in suffices
     const starved = {
       ...live,
       context: {

--- a/src/components/action-reason.test.ts
+++ b/src/components/action-reason.test.ts
@@ -1,0 +1,219 @@
+// The disabled-confirm reason is the engine's own definite reason, never a
+// generic "needs X, Y, Z" list and never an "X or Y". This drives a real actor
+// to a disabled "Lay both tracks" double-rail confirm and asserts the wired
+// reason (disabledActionReason) is exactly what explainRefusal reports.
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import type { CityId } from '~/data/board'
+import { type GameEvent, type GameState, gameStore } from '~/store/gameStore'
+import { explainRefusal } from '~/store/refusal'
+import { pendingCoalChoice } from '~/store/shared/resourceSources'
+import { disabledActionReason } from './action-reason'
+
+let actors: ReturnType<typeof createActor>[] = []
+afterEach(() => {
+  actors.forEach((a) => {
+    try {
+      a.stop()
+    } catch {}
+  })
+  actors = []
+})
+
+const resolveCoalTies = (actor: ReturnType<typeof createActor>) => {
+  for (let guard = 0; guard < 8; guard++) {
+    const choice = pendingCoalChoice(actor.getSnapshot().context as GameState)
+    if (!choice?.hasChoice || !choice.options[0]) break
+    actor.send({ type: 'SELECT_COAL_SOURCE', source: choice.options[0].source })
+  }
+}
+
+// A brewery (beer) plus a coal mine, so the whole double-rail path is legal
+// until we deliberately break one requirement.
+const industriesWithBeerAndCoal =
+  (): GameState['players'][number]['industries'] => [
+    {
+      location: 'birmingham',
+      type: 'brewery' as const,
+      level: 2,
+      flipped: false,
+      tile: {
+        id: 'brewery_2',
+        type: 'brewery' as const,
+        level: 2,
+        canBuildInCanalEra: true,
+        canBuildInRailEra: true,
+        incomeAdvancement: 5,
+        victoryPoints: 5,
+        cost: 7,
+        incomeSpaces: 5,
+        linkScoringIcons: 1,
+        coalRequired: 1,
+        ironRequired: 0,
+        beerRequired: 0,
+        beerProduced: 1,
+        coalProduced: 0,
+        ironProduced: 0,
+        hasLightbulbIcon: false,
+        quantity: 1,
+      },
+      coalCubesOnTile: 0,
+      ironCubesOnTile: 0,
+      beerBarrelsOnTile: 2,
+    },
+    {
+      location: 'birmingham',
+      type: 'coal' as const,
+      level: 1,
+      flipped: false,
+      tile: {
+        id: 'coal_1',
+        type: 'coal' as const,
+        level: 1,
+        canBuildInCanalEra: true,
+        canBuildInRailEra: false,
+        incomeAdvancement: 4,
+        victoryPoints: 1,
+        cost: 5,
+        incomeSpaces: 4,
+        linkScoringIcons: 1,
+        coalRequired: 0,
+        ironRequired: 0,
+        beerRequired: 0,
+        beerProduced: 0,
+        coalProduced: 2,
+        ironProduced: 0,
+        hasLightbulbIcon: false,
+        quantity: 2,
+      },
+      coalCubesOnTile: 3,
+      ironCubesOnTile: 0,
+      beerBarrelsOnTile: 0,
+    },
+  ]
+
+/** Drive a fresh actor to the disabled double-rail "Lay both tracks" confirm. */
+const reachConfirmingDoubleLink = () => {
+  const actor = createActor(gameStore)
+  actors.push(actor)
+  actor.subscribe({ error: () => {} })
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: [
+      {
+        id: '1',
+        name: 'P1',
+        color: 'red',
+        character: 'Richard Arkwright',
+        money: 17,
+        victoryPoints: 0,
+        income: 10,
+        industryTilesOnMat: {} as never,
+      },
+      {
+        id: '2',
+        name: 'P2',
+        color: 'blue',
+        character: 'Eliza Tinsley',
+        money: 17,
+        victoryPoints: 0,
+        income: 10,
+        industryTilesOnMat: {} as never,
+      },
+    ],
+  })
+
+  actor.send({ type: 'TRIGGER_CANAL_ERA_END' })
+  const playerId = actor.getSnapshot().context.currentPlayerIndex
+  actor.send({
+    type: 'TEST_SET_PLAYER_STATE',
+    playerId,
+    money: 50,
+    industries: industriesWithBeerAndCoal(),
+  })
+
+  // Establish a rail link so a second link has network to build off.
+  const card = actor.getSnapshot().context.players[playerId]!.hand[0]!
+  actor.send({ type: 'NETWORK' })
+  actor.send({ type: 'SELECT_CARD', cardId: card.id })
+  actor.send({ type: 'SELECT_LINK', from: 'birmingham', to: 'coventry' })
+  actor.send({ type: 'CONFIRM' })
+  resolveCoalTies(actor)
+
+  // Start the double-rail flow: first link, then the second.
+  const card2 = actor.getSnapshot().context.players[playerId]!.hand[0]!
+  actor.send({ type: 'NETWORK' })
+  actor.send({ type: 'SELECT_CARD', cardId: card2.id })
+  actor.send({ type: 'SELECT_LINK', from: 'coventry', to: 'nuneaton' })
+  actor.send({ type: 'CHOOSE_DOUBLE_LINK_BUILD' })
+  actor.send({
+    type: 'SELECT_SECOND_LINK',
+    from: 'birmingham',
+    to: 'wolverhampton',
+  })
+
+  return { actor, playerId }
+}
+
+const EXECUTE: GameEvent = { type: 'EXECUTE_DOUBLE_NETWORK_ACTION' }
+const GENERIC = 'Two rails cannot be laid from here.'
+
+describe('disabled action reason', () => {
+  test('reaches the double-rail confirm and it is legal when funded', () => {
+    const { actor } = reachConfirmingDoubleLink()
+    const snap = actor.getSnapshot()
+    expect(
+      snap.matches({
+        playing: { action: { networking: 'confirmingDoubleLink' } },
+      } as never),
+    ).toBe(true)
+    expect(snap.can(EXECUTE)).toBe(true)
+  })
+
+  test('disabled double-rail confirm shows the engine reason, not the generic list', () => {
+    const { actor, playerId } = reachConfirmingDoubleLink()
+    // Knock money below the £15 double-rail cost while everything else is fine.
+    actor.send({ type: 'TEST_SET_PLAYER_STATE', playerId, money: 14 })
+    const snap = actor.getSnapshot()
+
+    expect(snap.can(EXECUTE)).toBe(false)
+
+    const engineReason = explainRefusal(snap, EXECUTE)
+    const wired = disabledActionReason(snap, EXECUTE, GENERIC)
+
+    // The dock renders exactly what the engine reports.
+    expect(wired).toBe(engineReason)
+    // Definite, specific — not the generic requirement list, and never an "or".
+    expect(wired).not.toBe(GENERIC)
+    expect(wired).not.toMatch(/\bor\b/i)
+    expect(wired).toContain('14')
+  })
+
+  test('a coal-starved double rail names coal on the first link (repro shape)', () => {
+    const { actor } = reachConfirmingDoubleLink()
+    const live = actor.getSnapshot()
+    const first = live.context.selectedLink!
+
+    // Surgery: strip every coal source (no connected mine, empty market) while
+    // keeping beer reachable. EXECUTE's refusal case reads only context, so a
+    // context-only snapshot stand-in is enough to exercise explainDoubleLink.
+    const starved = {
+      ...live,
+      context: {
+        ...live.context,
+        coalMarket: [],
+        players: live.context.players.map((p) => ({
+          ...p,
+          industries: p.industries.filter((i) => i.type !== 'coal'),
+        })),
+      },
+    } as typeof live
+
+    const reason = explainRefusal(starved, EXECUTE)
+    expect(reason).toContain('coal')
+    expect(reason).toContain(first.from as CityId)
+    expect(reason).toContain(first.to as CityId)
+    expect(reason).not.toMatch(/\bor\b/i)
+  })
+})

--- a/src/components/action-reason.ts
+++ b/src/components/action-reason.ts
@@ -1,19 +1,8 @@
-// The definite reason a disabled action control is disabled.
-//
-// A disabled confirm used to print a hand-written requirement list ("Two rails
-// need £15, 2 coal and 1 beer within reach.") — it never said WHICH requirement
-// actually failed or on WHICH link/tile. The engine already knows: `explainRefusal`
-// re-derives the one blocking cause from the same validators the guards call.
-// This wires that answer onto the control, falling back to the generic line only
-// when the engine cannot pin a cause (a wrong reason is worse than a vague one).
-//
-// CONTRACT mirrors explainRefusal's: it answers "why is this refused", so only
-// call it under a control the machine already refuses. The dock only renders the
-// result beneath a disabled button, where `can(event)` is already false; the
-// `can` short-circuit here keeps that guarantee even if a caller slips.
 import type { GameEvent, GameStoreSnapshot } from '~/store/gameStore'
 import { explainRefusal } from '~/store/refusal'
 
+// explainRefusal's contract is "why is this refused", so only ask once the
+// machine already refuses — the `can` short-circuit enforces that.
 export function disabledActionReason(
   snapshot: GameStoreSnapshot,
   event: GameEvent,

--- a/src/components/action-reason.ts
+++ b/src/components/action-reason.ts
@@ -1,0 +1,24 @@
+// The definite reason a disabled action control is disabled.
+//
+// A disabled confirm used to print a hand-written requirement list ("Two rails
+// need £15, 2 coal and 1 beer within reach.") — it never said WHICH requirement
+// actually failed or on WHICH link/tile. The engine already knows: `explainRefusal`
+// re-derives the one blocking cause from the same validators the guards call.
+// This wires that answer onto the control, falling back to the generic line only
+// when the engine cannot pin a cause (a wrong reason is worse than a vague one).
+//
+// CONTRACT mirrors explainRefusal's: it answers "why is this refused", so only
+// call it under a control the machine already refuses. The dock only renders the
+// result beneath a disabled button, where `can(event)` is already false; the
+// `can` short-circuit here keeps that guarantee even if a caller slips.
+import type { GameEvent, GameStoreSnapshot } from '~/store/gameStore'
+import { explainRefusal } from '~/store/refusal'
+
+export function disabledActionReason(
+  snapshot: GameStoreSnapshot,
+  event: GameEvent,
+  fallback: string,
+): string {
+  if (snapshot.can(event)) return fallback
+  return explainRefusal(snapshot, event) ?? fallback
+}

--- a/src/store/refusal.ts
+++ b/src/store/refusal.ts
@@ -165,14 +165,72 @@ const explainBuildConfirm = (context: GameState): string | null => {
   return null
 }
 
-/** CONFIRM on a develop — hasSelectedTilesForDevelop's iron affordability. */
+/**
+ * CONFIRM on a develop — mirrors hasSelectedTilesForDevelop: the iron for the
+ * chosen tiles must both be sourceable AND affordable. When no tiles are named
+ * the machine develops the single lowest, so price against a count of 1.
+ */
 const explainDevelopConfirm = (context: GameState): string | null => {
-  const count = context.selectedTilesForDevelop.length
-  if (count === 0) return 'No tiles selected to develop.'
+  const selected = context.selectedTilesForDevelop
+  const count = selected.length > 0 ? selected.length : 1
+  const label = count === 1 ? 'this tile' : `these ${count} tiles`
   const player = getCurrentPlayer(context)
-  const { ironCost } = consumeIronFromSources(context, count)
-  if (player.money < ironCost) {
-    return `Not enough money: you have ${money(player.money)}, the iron to develop ${count === 1 ? 'this tile' : `these ${count} tiles`} costs ${money(ironCost)}.`
+  const iron = consumeIronFromSources(
+    context,
+    count,
+    context.chosenIronSources ?? [],
+  )
+  if (!iron.success) {
+    return (
+      iron.errorMessage ??
+      `No iron reachable to develop ${label} — Develop consumes ${count} iron.`
+    )
+  }
+  if (player.money < iron.ironCost) {
+    return `Not enough money: you have ${money(player.money)}, the iron to develop ${label} costs ${money(iron.ironCost)}.`
+  }
+  return null
+}
+
+/** CONFIRM on a loan — mirrors canTakeLoan (card held + income stays legal). */
+const explainLoanConfirm = (context: GameState): string | null => {
+  if (context.selectedCard === null) return 'No card selected for the loan.'
+  const player = getCurrentPlayer(context)
+  const after = player.income - GAME_CONSTANTS.LOAN_INCOME_PENALTY
+  if (after < GAME_CONSTANTS.MIN_INCOME) {
+    return `A loan drops your income ${GAME_CONSTANTS.LOAN_INCOME_PENALTY} levels to ${after}, below the minimum of ${GAME_CONSTANTS.MIN_INCOME}.`
+  }
+  return null
+}
+
+/** CONFIRM on a scout — mirrors canScout (three cards, no wild in hand, piles). */
+const explainScoutConfirm = (context: GameState): string | null => {
+  const player = getCurrentPlayer(context)
+  if (
+    player.hand.some(
+      (c) => c.type === 'wild_location' || c.type === 'wild_industry',
+    )
+  ) {
+    return 'You cannot Scout while holding a wild card.'
+  }
+  if (
+    context.wildLocationPile.length === 0 ||
+    context.wildIndustryPile.length === 0
+  ) {
+    return 'No wild cards are left to Scout for.'
+  }
+  if (
+    context.selectedCardsForScout.length !== GAME_CONSTANTS.SCOUT_CARDS_REQUIRED
+  ) {
+    return `Scout needs exactly ${GAME_CONSTANTS.SCOUT_CARDS_REQUIRED} cards discarded.`
+  }
+  return null
+}
+
+/** CONFIRM on a sell — mirrors hasSoldThisAction: at least one industry flipped. */
+const explainSellConfirm = (context: GameState): string | null => {
+  if (context.salesMadeThisAction === 0) {
+    return 'Flip at least one industry before closing the sale.'
   }
   return null
 }
@@ -299,39 +357,11 @@ export function explainRefusal(
     case 'EXECUTE_DOUBLE_NETWORK_ACTION':
       return explainDoubleLink(context)
 
-    case 'TAKE_LOAN': {
-      if (context.selectedCard === null) return 'No card selected for the loan.'
-      const player = getCurrentPlayer(context)
-      const after = player.income - GAME_CONSTANTS.LOAN_INCOME_PENALTY
-      if (after < GAME_CONSTANTS.MIN_INCOME) {
-        return `A loan drops your income ${GAME_CONSTANTS.LOAN_INCOME_PENALTY} levels to ${after}, below the minimum of ${GAME_CONSTANTS.MIN_INCOME}.`
-      }
-      return null
-    }
+    case 'TAKE_LOAN':
+      return explainLoanConfirm(context)
 
-    case 'SCOUT': {
-      const player = getCurrentPlayer(context)
-      if (
-        player.hand.some(
-          (c) => c.type === 'wild_location' || c.type === 'wild_industry',
-        )
-      ) {
-        return 'You cannot Scout while holding a wild card.'
-      }
-      if (
-        context.wildLocationPile.length === 0 ||
-        context.wildIndustryPile.length === 0
-      ) {
-        return 'No wild cards are left to Scout for.'
-      }
-      if (
-        context.selectedCardsForScout.length !==
-        GAME_CONSTANTS.SCOUT_CARDS_REQUIRED
-      ) {
-        return `Scout needs exactly ${GAME_CONSTANTS.SCOUT_CARDS_REQUIRED} cards discarded.`
-      }
-      return null
-    }
+    case 'SCOUT':
+      return explainScoutConfirm(context)
 
     case 'CONFIRM':
       if (at({ playing: { action: { networking: 'confirmingLink' } } })) {
@@ -342,6 +372,17 @@ export function explainRefusal(
       }
       if (at({ playing: { action: { developing: 'confirmingDevelop' } } })) {
         return explainDevelopConfirm(context)
+      }
+      // These three settle a card-consuming action on CONFIRM; the machine's
+      // own event for each is CONFIRM, so name the missing piece per step.
+      if (at({ playing: { action: { takingLoan: 'confirmingLoan' } } })) {
+        return explainLoanConfirm(context)
+      }
+      if (at({ playing: { action: { scouting: 'selectingCards' } } })) {
+        return explainScoutConfirm(context)
+      }
+      if (at({ playing: { action: { selling: 'selectingSale' } } })) {
+        return explainSellConfirm(context)
       }
       return null
 

--- a/src/store/refusal.ts
+++ b/src/store/refusal.ts
@@ -165,11 +165,8 @@ const explainBuildConfirm = (context: GameState): string | null => {
   return null
 }
 
-/**
- * CONFIRM on a develop — mirrors hasSelectedTilesForDevelop: the iron for the
- * chosen tiles must both be sourceable AND affordable. When no tiles are named
- * the machine develops the single lowest, so price against a count of 1.
- */
+/** CONFIRM on a develop — mirrors hasSelectedTilesForDevelop (iron sourceable
+ * AND affordable; no tile named ⇒ the single lowest, count 1). */
 const explainDevelopConfirm = (context: GameState): string | null => {
   const selected = context.selectedTilesForDevelop
   const count = selected.length > 0 ? selected.length : 1
@@ -373,8 +370,6 @@ export function explainRefusal(
       if (at({ playing: { action: { developing: 'confirmingDevelop' } } })) {
         return explainDevelopConfirm(context)
       }
-      // These three settle a card-consuming action on CONFIRM; the machine's
-      // own event for each is CONFIRM, so name the missing piece per step.
       if (at({ playing: { action: { takingLoan: 'confirmingLoan' } } })) {
         return explainLoanConfirm(context)
       }


### PR DESCRIPTION
## What & why

When an action confirm is disabled, the UI showed a **generic requirement list** — e.g. the disabled double-rail "Lay both tracks" printed *"Two rails need £15, 2 coal and 1 beer within reach."* — which never said **which** requirement failed or on **which** link/tile.

The engine already computes the precise reason via `explainRefusal` (`src/store/refusal.ts`), but that answer only reached multiplayer refusals. The disabled-button tooltip fell back to the generic string because the shadow-actor probe (`confirmOutcome`) returns `null` the moment the machine guard refuses — so the specific reason was never surfaced on the disabled control.

## What changed

- **New pure helper** `disabledActionReason` (`src/components/action-reason.ts`): under a disabled control (where `can(event)` is already false) it returns `explainRefusal(snapshot, event)`, falling back to a single definite sentence only when no cause can be pinned.
- **Wired onto every main confirm** in `action-dock.tsx`: build, network link, **double-link ("Lay both tracks")**, develop, sell, scout, loan. No more generic "needs X, Y, Z" lists; the old "check your funds and coal / iron access" (an implicit *or*) is gone.
- **Refusal ownership stays in `refusal.ts`** (one owner): extended `explainRefusal`'s `CONFIRM` handler to cover the loan / scout / sell confirm steps (whose machine event is also `CONFIRM`), factored the loan/scout reasons into reusable helpers, and sharpened the develop explainer to mirror its guard (iron **sourceable** *and* **affordable**, auto-lowest count of 1 when no tile is named).

For the diagnosis repro (Derby→Uttoxeter first + Stone→Uttoxeter second) this now reads as the coal-on-first-link reason: *"No coal reachable from derby/uttoxeter — each rail link needs 1 coal."*

## Tests

- `src/components/action-reason.test.ts` drives a real actor to a **disabled** double-rail confirm and asserts the wired reason equals `explainRefusal`, is specific (not generic), contains no *"or"*, and — in a coal-starved variant — names coal + the first link's endpoints (the repro shape).
- Full suite green: **611 passed / 4 skipped**. Typecheck + lint clean.

No engine rules-logic change — this only surfaces reasons the engine already produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Confirmation dialogs now provide more accurate explanations when Build, Network, Develop, Sell, Scout, or Loan actions cannot be completed.
  * Improved guidance identifies specific requirements, such as available funds, coal, iron, selected cards, income, or eligible industries.
  * Double-network confirmations now display detailed refusal reasons instead of generic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->