### PR TITLE
feat(ui): view the full income track from the rail's Income stat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,8 +366,11 @@ Implement Correctly: Integrate the retrieved code into the application, customiz
   the marker lives on Progress Track SPACES (0-99, `src/data/incomeTrack.ts`,
   `Player.incomeSpace`); flips/Oxford advance SPACES, loans drop 3 LEVELS to
   the highest space of the new level, setup = space 10 = level 0 (NOT level
-  10). Mapping + engine behaviour pinned in incomeTrack tests. Known
-  remaining data gap: link building does not validate against the board
+  10). Mapping + engine behaviour pinned in incomeTrack tests. The full
+  track is VISIBLE via `IncomeTrackModal` (`src/components/income-track.tsx`),
+  opened from the rail's Income stat; it renders every level from the pure
+  `incomeTrackLevels()` helper (never hand-guessed) with each player's marker.
+  Known remaining data gap: link building does not validate against the board
   graph `connections` (the UI enforces era + graph).
 - Build slot semantics are FREE-SLOT-FIRST (2026-07-13 bug hunt): a build
   goes into a free compatible slot when one exists — overbuild (replace,

--- a/e2e/income-track.spec.ts
+++ b/e2e/income-track.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * The income-track view: clicking a player's Income stat in the rail opens a
+ * modal showing the full progress track (all 41 income levels with their
+ * £/round value and non-linear spacing) and every player's marker. Booted on
+ * the ?demo fixture (canal round 8, three players all on negative income).
+ */
+test('income stat opens the full income track with player markers', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  await expect(page.getByTestId('era-plate')).toHaveText('canal era')
+
+  // The Income stat in each rail card is a control; open from the first.
+  await page.getByTestId('open-income-track').first().click()
+
+  const modal = page.getByTestId('income-track-modal')
+  await expect(modal).toBeVisible()
+
+  // The full track: one row per income level, -10..30 (41 levels).
+  await expect(modal.getByTestId(/^income-level-/)).toHaveCount(41)
+
+  // Non-linear spacing is real track data: level 30 spans 3 spaces (97-99),
+  // level 21 spans 4, level 1 spans 2, level -10 spans 1.
+  await expect(page.getByTitle('Space 97')).toBeVisible()
+  await expect(page.getByTitle('Space 99')).toBeVisible()
+
+  // Player markers sit on the track by name.
+  await expect(modal.getByTitle(/Eliza — space/)).toBeVisible()
+
+  // Escape closes the modal, and the game underneath is untouched.
+  await page.keyboard.press('Escape')
+  await expect(modal).toBeHidden()
+  await expect(page.getByTestId('action-build')).toBeVisible()
+})

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -28,6 +28,10 @@ import {
 } from '~/store/gameStore'
 import { refreshEmbeddedTileStats } from '~/store/saveMigration'
 import {
+  pendingBeerChoice,
+  pendingCoalChoice,
+} from '~/store/shared/resourceSources'
+import {
   ActionDock,
   type ConfirmOutcome,
   INDUSTRY_TYPES,
@@ -37,26 +41,23 @@ import {
 import { linkKey } from './board/board-data'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from './board/board-map'
 import { demoSnapshot } from './demo/demo-snapshot'
-import { demoSnapshotEraEnd } from './demo/demo-snapshot-era-end'
-import { demoSnapshotGameEnd } from './demo/demo-snapshot-game-end'
-import { demoSnapshotRail } from './demo/demo-snapshot-rail'
 import { demoSnapshotBeerChoice } from './demo/demo-snapshot-beer-choice'
 import { demoSnapshotDoubleBeer } from './demo/demo-snapshot-double-beer'
+import { demoSnapshotEraEnd } from './demo/demo-snapshot-era-end'
+import { demoSnapshotGameEnd } from './demo/demo-snapshot-game-end'
 import { demoSnapshotIronChoice } from './demo/demo-snapshot-iron-choice'
+import { demoSnapshotRail } from './demo/demo-snapshot-rail'
 import { demoSnapshotSell } from './demo/demo-snapshot-sell'
 import { demoSnapshotWilds } from './demo/demo-snapshot-wilds'
 import { HandTray } from './hand-tray'
 import { computeHoverCities, focusCityFor } from './hover-highlight'
+import { IncomeTrackModal } from './income-track'
+import { JournalPanel } from './journal'
 import { LocateCityProvider, useLocateCityState } from './locate'
-import {
-  pendingBeerChoice,
-  pendingCoalChoice,
-} from '~/store/shared/resourceSources'
 import { GameOverScreen, PassGate, RoundCurtain } from './overlays'
 import { OpenMatButton, PlayerLedger } from './player-ledger'
 import { PlayerRail } from './player-rail'
 import { SetupScreen } from './setup-screen'
-import { JournalPanel } from './journal'
 import { MarketsPanel } from './side-panels'
 
 const SAVE_KEY = 'bb2-save-v1'
@@ -403,6 +404,7 @@ function GameInner({
       : null,
   )
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
+  const [incomeTrackOpen, setIncomeTrackOpen] = useState(false)
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
   // Hover-a-name spotlight: the player whose rail mat is hovered/focused right
   // now — the board lights up their network (links + tiles) and recedes the rest.
@@ -467,13 +469,13 @@ function GameInner({
   // An open ledger swallows the keypress — PlayerLedger closes itself.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || ledgerFor) return
+      if (e.key !== 'Escape' || ledgerFor || incomeTrackOpen) return
       const snap = actorRef.getSnapshot()
       if (snap.can({ type: 'CANCEL' })) send({ type: 'CANCEL' })
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [ledgerFor, actorRef, send])
+  }, [ledgerFor, incomeTrackOpen, actorRef, send])
 
   // ---------- undo (first action of the turn, hotseat) ----------
   // Snapshot the machine when a player's turn begins; while they still
@@ -969,6 +971,7 @@ function GameInner({
           turnOrder={ctx.turnOrder}
           playerSpending={ctx.playerSpending}
           onOpenLedger={(id) => setLedgerFor(id)}
+          onOpenIncomeTrack={() => setIncomeTrackOpen(true)}
           onHoverPlayer={setHoveredPlayerId}
         />
 
@@ -1058,6 +1061,14 @@ function GameInner({
             era={ctx.era}
             isCurrent={ledgerPlayer.id === currentPlayer.id}
             onClose={() => setLedgerFor(null)}
+          />
+        )}
+
+        {incomeTrackOpen && (
+          <IncomeTrackModal
+            players={ctx.players}
+            currentPlayerId={currentPlayer.id}
+            onClose={() => setIncomeTrackOpen(false)}
           />
         )}
 

--- a/src/components/income-track.tsx
+++ b/src/components/income-track.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+// The income Progress Track — the snaking 0..99 track printed around the
+// board edge, made visible. Shows every income level with its £/round coin
+// value, the non-linear number of spaces it spans (1→2→3→4 as income climbs,
+// so higher income is slower to reach), and where each player's marker sits.
+// Opened from the rail's Income stat; mirrors PlayerLedger's modal shell.
+import { useEffect } from 'react'
+import { incomeTrackLevels } from '~/data/incomeTrack'
+import { type Player } from '~/store/gameStore'
+import { PLAYER_FILL } from './board/board-map'
+import { IncomeIcon } from './icons'
+
+const TRACK = incomeTrackLevels()
+
+// £/round the coin pays. Negative levels are a debt settled from the treasury.
+function formatIncome(level: number): string {
+  return level < 0 ? `−£${-level}` : `£${level}`
+}
+
+export function IncomeTrackModal({
+  players,
+  currentPlayerId,
+  onClose,
+}: {
+  players: Player[]
+  currentPlayerId: string | undefined
+  onClose: () => void
+}) {
+  // Escape closes, matching every other overlay in the game.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  const currentPlayer = players.find((p) => p.id === currentPlayerId)
+  const currentLevel = currentPlayer?.income
+
+  // Which players sit on each space, resolved once.
+  const playersOnSpace = new Map<number, Player[]>()
+  for (const p of players) {
+    const list = playersOnSpace.get(p.incomeSpace) ?? []
+    list.push(p)
+    playersOnSpace.set(p.incomeSpace, list)
+  }
+
+  // Highest income at the top — reads like climbing the track.
+  const rows = [...TRACK].reverse()
+
+  return (
+    <div
+      className="bb2-curtain fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 sm:p-8"
+      style={{ background: 'rgba(10, 8, 6, 0.82)' }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="bb2-panel bb2-rise flex max-h-[92vh] w-full max-w-xl flex-col p-5"
+        role="dialog"
+        aria-label="Income track"
+        data-testid="income-track-modal"
+      >
+        {/* header */}
+        <div className="flex items-center gap-3 pb-4">
+          <IncomeIcon size={22} />
+          <div className="flex flex-col">
+            <span
+              className="bb2-display text-[24px] font-black leading-none"
+              style={{ color: 'var(--bb-parchment-bright)' }}
+            >
+              Income track
+            </span>
+            <span
+              className="text-[12px] uppercase tracking-[0.18em]"
+              style={{ color: 'rgba(231,215,177,.45)' }}
+            >
+              £ collected each round
+            </span>
+          </div>
+          <button
+            type="button"
+            className="bb2-ghost-btn ml-auto"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+        <hr className="bb2-rule" />
+
+        {/* per-player summary */}
+        <div className="flex flex-wrap gap-x-5 gap-y-1.5 pt-4">
+          {players.map((p) => {
+            const isCurrent = p.id === currentPlayerId
+            return (
+              <span
+                key={p.id}
+                className="flex items-center gap-1.5 text-[13px]"
+                style={{ color: 'var(--bb-parchment)' }}
+              >
+                <span
+                  className="inline-block h-2.5 w-2.5 rounded-full"
+                  style={{ background: PLAYER_FILL[p.color] }}
+                />
+                <span style={{ fontWeight: isCurrent ? 700 : 400 }}>
+                  {p.name}
+                </span>
+                <span
+                  className="tabular-nums"
+                  style={{ color: 'var(--bb-parchment-bright)' }}
+                >
+                  {formatIncome(p.income)}/rd
+                </span>
+                {isCurrent && (
+                  <span
+                    className="text-[9.5px] font-bold uppercase tracking-[0.18em]"
+                    style={{ color: 'var(--bb-brass-bright)' }}
+                  >
+                    · to act
+                  </span>
+                )}
+              </span>
+            )
+          })}
+        </div>
+
+        <p
+          className="pt-3 text-[12px] leading-snug"
+          style={{ color: 'rgba(231,215,177,.5)' }}
+        >
+          Each cell is one space on the board track. A level spans more spaces
+          the higher the income — one space low down, up to four near the top —
+          so each extra £ of income takes longer to earn. Loans drop you three
+          levels; a negative level is a debt paid from your treasury.
+        </p>
+
+        {/* the track — scrolls within the modal, highest income first */}
+        <div
+          className="mt-3 flex flex-col gap-[3px] overflow-y-auto pr-1"
+          data-testid="income-track-levels"
+        >
+          {rows.map(({ level, spaces }) => {
+            const isCurrentLevel = level === currentLevel
+            return (
+              <div
+                key={level}
+                data-testid={`income-level-${level}`}
+                data-current={isCurrentLevel || undefined}
+                className="flex items-center gap-2 rounded px-2 py-1"
+                style={{
+                  background: isCurrentLevel
+                    ? 'rgba(195,149,56,.12)'
+                    : 'rgba(255,240,200,.02)',
+                  boxShadow: isCurrentLevel
+                    ? 'inset 0 0 0 1px rgba(230,189,99,.4)'
+                    : undefined,
+                }}
+              >
+                <span
+                  className="bb2-display w-12 flex-none text-right text-[14px] font-bold tabular-nums"
+                  style={{
+                    color: isCurrentLevel
+                      ? 'var(--bb-brass-bright)'
+                      : level < 0
+                        ? 'var(--bb-danger)'
+                        : 'var(--bb-parchment)',
+                  }}
+                >
+                  {formatIncome(level)}
+                </span>
+                <div className="flex flex-wrap items-center gap-[3px]">
+                  {spaces.map((space) => {
+                    const here = playersOnSpace.get(space) ?? []
+                    return (
+                      <span
+                        key={space}
+                        title={`Space ${space}`}
+                        className="relative flex h-5 min-w-[20px] items-center justify-center gap-0.5 rounded-[3px] px-0.5"
+                        style={{
+                          border: '1px solid rgba(231,215,177,.14)',
+                          background:
+                            here.length > 0
+                              ? 'rgba(255,240,200,.05)'
+                              : 'transparent',
+                        }}
+                      >
+                        {here.length === 0 ? (
+                          <span
+                            className="text-[8px] tabular-nums"
+                            style={{ color: 'rgba(231,215,177,.28)' }}
+                          >
+                            {space}
+                          </span>
+                        ) : (
+                          here.map((p) => (
+                            <span
+                              key={p.id}
+                              title={`${p.name} — space ${space}`}
+                              className="inline-block h-2.5 w-2.5 rounded-full"
+                              style={{
+                                background: PLAYER_FILL[p.color],
+                                boxShadow: '0 0 0 1px rgba(10,8,6,.6)',
+                              }}
+                            />
+                          ))
+                        )}
+                      </span>
+                    )
+                  })}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/income-track.tsx
+++ b/src/components/income-track.tsx
@@ -1,10 +1,6 @@
 'use client'
 
-// The income Progress Track — the snaking 0..99 track printed around the
-// board edge, made visible. Shows every income level with its £/round coin
-// value, the non-linear number of spaces it spans (1→2→3→4 as income climbs,
-// so higher income is slower to reach), and where each player's marker sits.
-// Opened from the rail's Income stat; mirrors PlayerLedger's modal shell.
+// The income Progress Track made visible; mirrors PlayerLedger's modal shell.
 import { useEffect } from 'react'
 import { incomeTrackLevels } from '~/data/incomeTrack'
 import { type Player } from '~/store/gameStore'
@@ -13,7 +9,6 @@ import { IncomeIcon } from './icons'
 
 const TRACK = incomeTrackLevels()
 
-// £/round the coin pays. Negative levels are a debt settled from the treasury.
 function formatIncome(level: number): string {
   return level < 0 ? `−£${-level}` : `£${level}`
 }
@@ -27,7 +22,6 @@ export function IncomeTrackModal({
   currentPlayerId: string | undefined
   onClose: () => void
 }) {
-  // Escape closes, matching every other overlay in the game.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -39,7 +33,6 @@ export function IncomeTrackModal({
   const currentPlayer = players.find((p) => p.id === currentPlayerId)
   const currentLevel = currentPlayer?.income
 
-  // Which players sit on each space, resolved once.
   const playersOnSpace = new Map<number, Player[]>()
   for (const p of players) {
     const list = playersOnSpace.get(p.incomeSpace) ?? []
@@ -47,7 +40,7 @@ export function IncomeTrackModal({
     playersOnSpace.set(p.incomeSpace, list)
   }
 
-  // Highest income at the top — reads like climbing the track.
+  // Highest income at the top.
   const rows = [...TRACK].reverse()
 
   return (
@@ -137,7 +130,7 @@ export function IncomeTrackModal({
           levels; a negative level is a debt paid from your treasury.
         </p>
 
-        {/* the track — scrolls within the modal, highest income first */}
+        {/* track */}
         <div
           className="mt-3 flex flex-col gap-[3px] overflow-y-auto pr-1"
           data-testid="income-track-levels"

--- a/src/components/player-rail.tsx
+++ b/src/components/player-rail.tsx
@@ -14,24 +14,56 @@ function Stat({
   icon,
   accent,
   testId,
+  onClick,
+  title,
 }: {
   label: string
   value: React.ReactNode
   icon?: React.ReactNode
   accent?: string
   testId?: string
+  /** When set, the value becomes a nested control (e.g. open the track). */
+  onClick?: () => void
+  title?: string
 }) {
+  const inner = (
+    <span
+      className="bb2-stat-value flex items-center gap-1"
+      style={accent ? { color: accent } : undefined}
+    >
+      {icon}
+      {value}
+    </span>
+  )
   return (
     <div className="flex min-w-[52px] flex-col items-start gap-0.5">
       <span className="bb2-stat-label">{label}</span>
-      <span
-        className="bb2-stat-value flex items-center gap-1"
-        data-testid={testId}
-        style={accent ? { color: accent } : undefined}
-      >
-        {icon}
-        {value}
-      </span>
+      {onClick ? (
+        // The rail card is itself a button, so this sub-affordance is a
+        // role=button span that stops propagation rather than a real <button>.
+        <span
+          role="button"
+          tabIndex={0}
+          data-testid={testId}
+          title={title}
+          className="bb2-stat-tap -mx-1 rounded px-1"
+          onClick={(e) => {
+            e.stopPropagation()
+            onClick()
+          }}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              e.stopPropagation()
+              onClick()
+            }
+          }}
+        >
+          {inner}
+        </span>
+      ) : (
+        <span data-testid={testId}>{inner}</span>
+      )}
     </div>
   )
 }
@@ -42,6 +74,7 @@ export function PlayerRail({
   turnOrder,
   playerSpending,
   onOpenLedger,
+  onOpenIncomeTrack,
   onHoverPlayer,
 }: {
   players: Player[]
@@ -49,6 +82,8 @@ export function PlayerRail({
   turnOrder: GameState['turnOrder']
   playerSpending: GameState['playerSpending']
   onOpenLedger?: (playerId: string) => void
+  /** Tapping a player's Income stat opens the shared income-track view. */
+  onOpenIncomeTrack?: () => void
   /** Hovering/focusing a mat spotlights that player's network on the board. */
   onHoverPlayer?: (playerId: string | null) => void
 }) {
@@ -128,6 +163,16 @@ export function PlayerRail({
                   label="Income"
                   value={p.income}
                   icon={<IncomeIcon size={12} />}
+                  testId="open-income-track"
+                  title="Open the income track"
+                  onClick={
+                    onOpenIncomeTrack
+                      ? () => {
+                          onHoverPlayer?.(null)
+                          onOpenIncomeTrack()
+                        }
+                      : undefined
+                  }
                 />
                 <Stat
                   label="Victory"

--- a/src/components/player-rail.tsx
+++ b/src/components/player-rail.tsx
@@ -22,7 +22,6 @@ function Stat({
   icon?: React.ReactNode
   accent?: string
   testId?: string
-  /** When set, the value becomes a nested control (e.g. open the track). */
   onClick?: () => void
   title?: string
 }) {
@@ -39,8 +38,7 @@ function Stat({
     <div className="flex min-w-[52px] flex-col items-start gap-0.5">
       <span className="bb2-stat-label">{label}</span>
       {onClick ? (
-        // The rail card is itself a button, so this sub-affordance is a
-        // role=button span that stops propagation rather than a real <button>.
+        // role=button span, not a real <button>: the rail card is already one.
         <span
           role="button"
           tabIndex={0}

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -442,6 +442,19 @@ button.bb2-mat:hover {
   color: var(--bb-parchment-bright);
   font-variant-numeric: tabular-nums;
 }
+/* A stat value that doubles as a control (opens the income track). */
+.bb2-stat-tap {
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    box-shadow 0.12s ease;
+}
+.bb2-stat-tap:hover,
+.bb2-stat-tap:focus-visible {
+  background: rgba(230, 189, 99, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(230, 189, 99, 0.35);
+  outline: none;
+}
 
 /* ---------------- cards ---------------- */
 

--- a/src/data/incomeTrack.test.ts
+++ b/src/data/incomeTrack.test.ts
@@ -4,11 +4,14 @@
 // verified against the printed coins on the photographed track.
 import { describe, expect, it } from 'vitest'
 import {
+  MAX_INCOME_LEVEL,
   MAX_INCOME_SPACE,
+  MIN_INCOME_LEVEL,
   STARTING_INCOME_SPACE,
   advanceIncomeSpaces,
   highestSpaceForLevel,
   incomeLevelForSpace,
+  incomeTrackLevels,
 } from './incomeTrack'
 
 describe('income track — space → level mapping (retail board)', () => {
@@ -93,5 +96,49 @@ describe('income track — helpers', () => {
     expect(advanceIncomeSpaces(10, 5)).toBe(15)
     expect(incomeLevelForSpace(advanceIncomeSpaces(10, 5))).toBe(3)
     expect(advanceIncomeSpaces(97, 10)).toBe(99)
+  })
+})
+
+describe('income track — full-track view derivation', () => {
+  const track = incomeTrackLevels()
+
+  it('covers every level from -10 to 30 in ascending order', () => {
+    expect(track[0]!.level).toBe(MIN_INCOME_LEVEL)
+    expect(track[track.length - 1]!.level).toBe(MAX_INCOME_LEVEL)
+    expect(track.map((l) => l.level)).toEqual(
+      Array.from(
+        { length: MAX_INCOME_LEVEL - MIN_INCOME_LEVEL + 1 },
+        (_, i) => MIN_INCOME_LEVEL + i,
+      ),
+    )
+  })
+
+  it('reproduces the non-linear spacing (1→2→3→4 spaces per level)', () => {
+    const spacesFor = (level: number) =>
+      track.find((l) => l.level === level)!.spaces.length
+    expect(spacesFor(-10)).toBe(1)
+    expect(spacesFor(0)).toBe(1)
+    expect(spacesFor(1)).toBe(2)
+    expect(spacesFor(10)).toBe(2)
+    expect(spacesFor(11)).toBe(3)
+    expect(spacesFor(20)).toBe(3)
+    expect(spacesFor(21)).toBe(4)
+    expect(spacesFor(29)).toBe(4)
+    expect(spacesFor(30)).toBe(3)
+  })
+
+  it('spaces tile the whole track 0..99 with no gaps or overlaps', () => {
+    const all = track.flatMap((l) => l.spaces)
+    expect(all).toEqual(
+      Array.from({ length: MAX_INCOME_SPACE + 1 }, (_, i) => i),
+    )
+  })
+
+  it('every space maps back to its own level', () => {
+    for (const { level, spaces } of track) {
+      for (const space of spaces) {
+        expect(incomeLevelForSpace(space)).toBe(level)
+      }
+    }
   })
 })

--- a/src/data/incomeTrack.ts
+++ b/src/data/incomeTrack.ts
@@ -40,3 +40,33 @@ export function highestSpaceForLevel(level: number): number {
 export function advanceIncomeSpaces(space: number, spaces: number): number {
   return Math.min(MAX_INCOME_SPACE, Math.max(0, space) + Math.max(0, spaces))
 }
+
+/** The lowest and highest income level printed on the track. */
+export const MIN_INCOME_LEVEL = -10
+export const MAX_INCOME_LEVEL = 30
+
+export interface IncomeTrackLevel {
+  /** The income level (= £ collected per round; negative levels are a debt). */
+  level: number
+  /** Progress-track spaces (0..99) this level spans, ascending. */
+  spaces: number[]
+}
+
+/**
+ * The full income track as an ordered list of levels, each with the exact
+ * progress-track spaces it spans — derived entirely from the audited
+ * `highestSpaceForLevel`/`incomeLevelForSpace` mapping so the non-linear
+ * spacing (1→2→3→4 spaces per level) is never hand-guessed. Ascending by
+ * level (lowest income first).
+ */
+export function incomeTrackLevels(): IncomeTrackLevel[] {
+  const levels: IncomeTrackLevel[] = []
+  for (let level = MIN_INCOME_LEVEL; level <= MAX_INCOME_LEVEL; level++) {
+    const last = highestSpaceForLevel(level)
+    const prev = level > MIN_INCOME_LEVEL ? highestSpaceForLevel(level - 1) : -1
+    const spaces: number[] = []
+    for (let space = prev + 1; space <= last; space++) spaces.push(space)
+    levels.push({ level, spaces })
+  }
+  return levels
+}


### PR DESCRIPTION
## Summary

The player rail showed only each player's current income *number*; the Brass income **track** itself — its non-linear level spacing and where each player's marker sits — was not visible anywhere.

Clicking a player's **Income** stat in the rail now opens a modal that renders the full progress track:

- All 41 income levels (−10..30) with their **£/round** coin value.
- The real **non-linear spacing** — a level spans 1→2→3→4 board spaces as income climbs, so the higher levels are visibly wider (slower to earn).
- A **colored marker per player** on their exact current space; the current player's level is highlighted, and negative (debt) levels are called out.

The modal mirrors the existing player-mat modal's shell (backdrop, Escape/Close, styling) and owns its own scroll.

## Data source

The track is derived entirely from the audited income-track mapping (`highestSpaceForLevel`/`incomeLevelForSpace` in `src/data/incomeTrack.ts`) via a new pure `incomeTrackLevels()` helper — **no hand-guessed track data**. Display only; no engine or rules changes.

## Screenshots

Top of the track (non-linear spacing — £30 spans 3 spaces, £29–£21 span 4):

![Income track top](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-income-track-images/income-track-top.png)

Bottom, showing player markers on their spaces and the highlighted current level:

![Income track markers](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-income-track-images/income-track2.png)

## Tests

- `src/data/incomeTrack.test.ts` — pins the new `incomeTrackLevels()` derivation (level coverage, 1→2→3→4 spacing, full 0..99 tiling, space→level consistency).
- `e2e/income-track.spec.ts` — opens the modal from the rail, asserts 41 levels, real space spans, player markers, and Escape-to-close leaving the game untouched.
- `pnpm lint` + `pnpm typecheck` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
