### PR TITLE
fix(engine): stop offering rail routes that can't be claimed + show link cost/sources

### DIFF
--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -8,15 +8,22 @@ import { type CityId, cities } from '~/data/board'
 import { type Card, type IndustryType } from '~/data/cards'
 import {
   type GameEvent,
+  type GameState,
   type GameStoreSnapshot,
   type Player,
 } from '~/store/gameStore'
+import {
+  type RailCoalSourceView,
+  railNetworkCostView,
+} from '~/store/market/marketActions'
 import { pendingDevelopBonusChoice } from '~/store/shared/developBonus'
 import { isDevelopable } from '~/store/shared/gameUtils'
 import {
+  type BeerSource,
   type BeerSourceOption,
   type CoalSourceOption,
   type IronSourceOption,
+  beerChoiceForDoubleLink,
   beerSourceKey,
   coalSourceKey,
   ironSourceKey,
@@ -65,6 +72,128 @@ function LinkLabel({
     <>
       <CityName cityId={link.from} /> — <CityName cityId={link.to} />
     </>
+  )
+}
+
+/**
+ * Read-only "sourced from" line naming where a rail link's 1 coal comes from —
+ * a connected mine (free) or the coal market (£). The names are hover-to-locate
+ * CityNames. Facts come from the engine (`railNetworkCostView`); never
+ * re-derived here.
+ */
+function CoalSourceText({ coal }: { coal: RailCoalSourceView | null }) {
+  if (!coal) return null
+  if (coal.kind === 'mine') {
+    return (
+      <span>
+        coal: free from{' '}
+        {coal.location ? (
+          <CityName cityId={coal.location} />
+        ) : (
+          'a connected mine'
+        )}
+        {coal.ownerName && !coal.own ? ` (${coal.ownerName})` : ''}
+      </span>
+    )
+  }
+  return (
+    <span>
+      coal: {coal.location ? <CityName cityId={coal.location} /> : ''} market £
+      {coal.cost}
+    </span>
+  )
+}
+
+/** The beer feeding a double rail's second link — own or a rival's brewery. */
+function BeerSourceText({
+  source,
+  currentPlayer,
+  players,
+}: {
+  source: BeerSource
+  currentPlayer: Player
+  players: Player[]
+}) {
+  if (source.kind === 'merchant') {
+    return (
+      <span>
+        beer: <CityName cityId={source.location} /> merchant
+      </span>
+    )
+  }
+  const own = source.ownerId === currentPlayer.id
+  const owner = players.find((p) => p.id === source.ownerId)
+  return (
+    <span>
+      beer: {own ? 'your' : `${owner?.name ?? 'a rival'}'s`} brewery at{' '}
+      <CityName cityId={source.location} />
+    </span>
+  )
+}
+
+/**
+ * The concrete cost of the rail Network action the machine is holding, shown
+ * before the player commits: base £ + coal (+ beer for a double), then each
+ * link's coal source and the beer source named inline. All engine-computed
+ * (`railNetworkCostView` / `beerChoiceForDoubleLink`) so it can never disagree
+ * with the confirm guard.
+ */
+function NetworkCostBreakdown({
+  context,
+  currentPlayer,
+}: {
+  context: GameState
+  currentPlayer: Player
+}) {
+  const view = railNetworkCostView(context)
+  if (!view?.ok) return null
+
+  let beer: BeerSource | null = null
+  if (view.double) {
+    const choice = beerChoiceForDoubleLink(context, currentPlayer)
+    const picked = (context.chosenBeerSources ?? [])[0]
+    beer =
+      choice?.options.find(
+        (o) => picked && beerSourceKey(o.source) === beerSourceKey(picked),
+      )?.source ??
+      // No explicit pick: name the engine's auto-pick (first offered).
+      choice?.options[0]?.source ??
+      null
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-1 text-[12.5px]"
+      style={{ color: 'rgba(231,215,177,.62)' }}
+      data-testid="network-cost"
+    >
+      <div className="tabular-nums">
+        <b style={{ color: 'var(--bb-parchment-bright)' }}>
+          Lay {view.double ? '2 tracks' : '1 track'}
+        </b>{' '}
+        — £{view.baseCost} + {view.double ? '2 coal + 1 beer' : '1 coal'}
+      </div>
+      {view.links.map((link) => (
+        <div
+          key={`${link.from}-${link.to}`}
+          className="flex flex-wrap items-center gap-x-1"
+        >
+          {view.double && (
+            <span>
+              <CityName cityId={link.from} /> — <CityName cityId={link.to} />:
+            </span>
+          )}
+          <CoalSourceText coal={link.coal} />
+        </div>
+      ))}
+      {beer && (
+        <BeerSourceText
+          source={beer}
+          currentPlayer={currentPlayer}
+          players={context.players}
+        />
+      )}
+    </div>
   )
 }
 
@@ -1275,6 +1404,9 @@ export function ActionDock({
           </b>{' '}
           ({c.era})
         </Note>
+        {c.era === 'rail' ? (
+          <NetworkCostBreakdown context={c} currentPlayer={currentPlayer} />
+        ) : null}
         <Confirm
           disabled={!can({ type: 'CONFIRM' })}
           onClick={() => send({ type: 'CONFIRM' })}
@@ -1386,6 +1518,7 @@ export function ActionDock({
             <LinkLabel link={c.selectedSecondLink} />
           </b>
         </Note>
+        <NetworkCostBreakdown context={c} currentPlayer={currentPlayer} />
         <Confirm
           disabled={!can({ type: 'EXECUTE_DOUBLE_NETWORK_ACTION' })}
           onClick={() => send({ type: 'EXECUTE_DOUBLE_NETWORK_ACTION' })}

--- a/src/store/gameStore.routeselectability.test.ts
+++ b/src/store/gameStore.routeselectability.test.ts
@@ -1,0 +1,185 @@
+// Rail-route selection must equal confirmability: a route is offered
+// (pulses selectable, passes `canBuildLink`) only when it can actually be laid
+// once placed. The bug this pins: `canBuildLink` checked network + base cost
+// but NOT coal, while the confirm guard `hasSelectedLink` did — so coal-dead
+// spur routes (no connected mine AND no coal-market reach) pulsed as selectable
+// then got rejected at confirm. Reproduces the diagnosis state around the Derby
+// spur: derby→nottingham is payable via the £-market, belper→derby and
+// derby→uttoxeter are genuine dead ends.
+import { afterEach, describe, expect, it } from 'vitest'
+import { connections } from '../data/board'
+import { type GameState, type Player, gameStore } from './gameStore'
+import { pendingCoalChoice } from './shared/resourceSources'
+import { createActor } from 'xstate'
+
+type Industry = Player['industries'][number]
+
+const nonCoalIndustry = (location: string): Industry =>
+  ({
+    type: 'cotton',
+    location,
+    flipped: false,
+    coalCubesOnTile: 0,
+    ironCubesOnTile: 0,
+    beerBarrelsOnTile: 0,
+    level: 1,
+    tile: { incomeAdvancement: 1 },
+  }) as unknown as Industry
+
+const linkOf = (player: Player, from: string, to: string) =>
+  player.links.some(
+    (l) => (l.from === from && l.to === to) || (l.from === to && l.to === from),
+  )
+
+const resolveCoalTies = (actor: ReturnType<typeof createActor>) => {
+  for (let guard = 0; guard < 8; guard++) {
+    const choice = pendingCoalChoice(actor.getSnapshot().context as GameState)
+    if (!choice?.hasChoice || !choice.options[0]) break
+    actor.send({ type: 'SELECT_COAL_SOURCE', source: choice.options[0].source })
+  }
+}
+
+describe('rail-route selection == confirmability', () => {
+  let actors: ReturnType<typeof createActor>[] = []
+  afterEach(() => {
+    actors.forEach((a) => {
+      try {
+        a.stop()
+      } catch {}
+    })
+    actors = []
+  })
+
+  // A rail-era game with the current player holding a single non-coal industry
+  // at Derby (so Derby is in their network) and NO coal mines or links anywhere
+  // — Derby's spurs can reach coal only through the market, and only if the
+  // placed link touches a merchant.
+  const derbySpurGame = () => {
+    const actor = createActor(gameStore)
+    actors.push(actor)
+    actor.subscribe({ error: () => {} })
+    actor.start()
+    actor.send({
+      type: 'START_GAME',
+      players: [
+        {
+          id: '1',
+          name: 'Player 1',
+          color: 'red' as const,
+          character: 'Richard Arkwright' as const,
+          money: 100,
+          victoryPoints: 0,
+          income: 10,
+          industryTilesOnMat: {} as never,
+        },
+        {
+          id: '2',
+          name: 'Player 2',
+          color: 'blue' as const,
+          character: 'Eliza Tinsley' as const,
+          money: 100,
+          victoryPoints: 0,
+          income: 10,
+          industryTilesOnMat: {} as never,
+        },
+      ],
+    })
+    actor.send({ type: 'TRIGGER_CANAL_ERA_END' })
+    const seat = actor.getSnapshot().context.currentPlayerIndex
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: seat,
+      money: 100,
+      industries: [nonCoalIndustry('derby')],
+      links: [] as never,
+    })
+    return { actor, seat }
+  }
+
+  const openNetworkStep = (actor: ReturnType<typeof createActor>) => {
+    const snap = actor.getSnapshot()
+    const seat = snap.context.currentPlayerIndex
+    const cardId = snap.context.players[seat]!.hand[0]!.id
+    actor.send({ type: 'NETWORK' })
+    actor.send({ type: 'SELECT_CARD', cardId })
+  }
+
+  it('offers the market-coal route derby→nottingham and lays it', () => {
+    const { actor } = derbySpurGame()
+    openNetworkStep(actor)
+
+    // Nottingham is a merchant, so the placed derby→nottingham link reaches the
+    // coal market — payable via £, therefore offered.
+    expect(
+      actor.getSnapshot().can({
+        type: 'SELECT_LINK',
+        from: 'derby',
+        to: 'nottingham',
+      }),
+    ).toBe(true)
+
+    actor.send({ type: 'SELECT_LINK', from: 'derby', to: 'nottingham' })
+    expect(actor.getSnapshot().can({ type: 'CONFIRM' })).toBe(true)
+    actor.send({ type: 'CONFIRM' })
+    resolveCoalTies(actor)
+
+    const seat = actor.getSnapshot().context.currentPlayerIndex
+    const me = actor.getSnapshot().context.players[seat]!
+    expect(linkOf(me, 'derby', 'nottingham')).toBe(true)
+  })
+
+  it('does NOT offer coal-dead spur routes (belper→derby, derby→uttoxeter)', () => {
+    const { actor } = derbySpurGame()
+    openNetworkStep(actor)
+
+    // Both touch Derby (in-network) so pass the old adjacency-only check, but
+    // once placed they reach no mine and no merchant — genuine dead ends.
+    for (const [from, to] of [
+      ['belper', 'derby'],
+      ['derby', 'uttoxeter'],
+    ] as const) {
+      expect(actor.getSnapshot().can({ type: 'SELECT_LINK', from, to })).toBe(
+        false,
+      )
+    }
+  })
+
+  it('every offered rail first-link is confirmable and executable', () => {
+    // Enumerate the offered set once, then lay each on a fresh game — proving
+    // offer==execute end-to-end, not merely via the shared guard.
+    const { actor: probe } = derbySpurGame()
+    openNetworkStep(probe)
+    const snap = probe.getSnapshot()
+    const offered = connections
+      .filter((c) => (c.types as readonly string[]).includes('rail'))
+      .flatMap((c) => [
+        { from: c.from, to: c.to },
+        { from: c.to, to: c.from },
+      ])
+      .filter((route) =>
+        snap.can({ type: 'SELECT_LINK', from: route.from, to: route.to }),
+      )
+
+    expect(offered.length).toBeGreaterThan(0)
+
+    for (const route of offered) {
+      const { actor } = derbySpurGame()
+      openNetworkStep(actor)
+      actor.send({ type: 'SELECT_LINK', from: route.from, to: route.to })
+      // The confirm guard must agree with selection…
+      expect(
+        actor.getSnapshot().can({ type: 'CONFIRM' }),
+        `CONFIRM after offering ${route.from}->${route.to}`,
+      ).toBe(true)
+      // …and the link must actually land.
+      actor.send({ type: 'CONFIRM' })
+      resolveCoalTies(actor)
+      const seat = actor.getSnapshot().context.currentPlayerIndex
+      const me = actor.getSnapshot().context.players[seat]!
+      expect(
+        linkOf(me, route.from, route.to),
+        `link ${route.from}->${route.to} placed`,
+      ).toBe(true)
+    }
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -51,6 +51,7 @@ import {
   consumeBeerFromSources,
   consumeCoalFromSources,
   consumeIronFromSources,
+  railNetworkCostView,
 } from './market/marketActions'
 import {
   calculateLinkVictoryPoints,
@@ -648,6 +649,20 @@ export const validateSale = (
   }
 
   return { isValid: true, industry }
+}
+
+// A rail Network action is payable when every link reaches coal once placed
+// (rules L116/L308) and the player can afford the base cost plus any market
+// coal (Brass has no debt). The preview (`railNetworkCostView`) reads
+// `context.selectedLink`/`selectedSecondLink` and is the single source of truth
+// for both SELECT candidacy and the confirm guards, so an offered route is
+// always confirmable and the dock's cost display can never drift from the
+// guard. The double form also needs beer, checked separately by
+// `canCompleteDoubleLink`.
+function railNetworkPayable(context: GameState): boolean {
+  const preview = railNetworkCostView(context)
+  if (preview === null || !preview.ok) return false
+  return getCurrentPlayer(context).money >= preview.total
 }
 
 // Setup the machine with proper typing
@@ -2994,30 +3009,11 @@ export const gameStore = setup({
       if (context.selectedLink === null) {
         return false
       }
-
-      const linkCost =
-        context.era === 'canal'
-          ? GAME_CONSTANTS.CANAL_LINK_COST
-          : GAME_CONSTANTS.RAIL_LINK_COST
-      let coalCost = 0
-
-      // Check coal availability for rail era links. Judge against the
-      // post-placement network (both endpoints), matching execution — a mine
-      // reachable only through the new link must be seen here too.
       if (context.era === 'rail') {
-        const coalResult = consumeCoalFromSources(
-          withProvisionalLink(context),
-          [context.selectedLink.from, context.selectedLink.to],
-          1,
-        )
-        if (!coalResult.success) {
-          return false
-        }
-        coalCost = coalResult.coalCost
+        return railNetworkPayable(context)
       }
-
       // Brass has no debt: the player must be able to pay the full cost
-      return getCurrentPlayer(context).money >= linkCost + coalCost
+      return getCurrentPlayer(context).money >= GAME_CONSTANTS.CANAL_LINK_COST
     },
     canBuildLink: ({ context, event }) => {
       if (event.type !== 'SELECT_LINK' && event.type !== 'SELECT_SECOND_LINK') {
@@ -3039,8 +3035,8 @@ export const gameStore = setup({
 
       const currentPlayer = getCurrentPlayer(context)
 
-      // Brass has no debt. Coal cost isn't known until a link is picked, so
-      // this only gates on the base cost; hasSelectedLink checks cost + coal.
+      // Brass has no debt. The base cost is a fast reject before the network
+      // and (rail) coal checks; the full cost incl. coal is enforced below.
       const baseLinkCost =
         context.era === 'canal'
           ? GAME_CONSTANTS.CANAL_LINK_COST
@@ -3095,7 +3091,24 @@ export const gameStore = setup({
       })
 
       // Check if either end of the new link is part of player's network
-      return playerLocations.has(event.from) || playerLocations.has(event.to)
+      const isAdjacent =
+        playerLocations.has(event.from) || playerLocations.has(event.to)
+      if (!isAdjacent) {
+        return false
+      }
+
+      // A rail link must also reach coal once placed and be fully affordable
+      // (rules L116/L308). The event carries the concrete route, so coal is
+      // computable here — folding it in makes an offered route always
+      // confirmable (no coal-dead spur pulses as selectable). Canal links need
+      // no coal, so the adjacency + base-cost checks above suffice.
+      if (context.era === 'rail') {
+        const candidate = { from: event.from, to: event.to }
+        return event.type === 'SELECT_SECOND_LINK'
+          ? railNetworkPayable({ ...context, selectedSecondLink: candidate })
+          : railNetworkPayable({ ...context, selectedLink: candidate })
+      }
+      return true
     },
     canSelectLocation: ({ context, event }) => {
       if (event.type !== 'SELECT_LOCATION') return false
@@ -3335,47 +3348,8 @@ export const gameStore = setup({
       }
 
       // Brass has no debt: £15 plus the coal for both links must be payable.
-      // Mirror execution: the FIRST link is on the board before its coal is
-      // sourced, anchored over both its endpoints.
-      const firstCoal = consumeCoalFromSources(
-        withProvisionalLink(context),
-        [context.selectedLink.from, context.selectedLink.to],
-        1,
-      )
-      if (!firstCoal.success) {
-        return false
-      }
-      // ...and both links are on the board before the second link's coal.
-      const playerWithLinks =
-        firstCoal.updatedPlayers[context.currentPlayerIndex]!
-      const secondCoal = consumeCoalFromSources(
-        {
-          ...context,
-          players: updatePlayerInList(
-            firstCoal.updatedPlayers,
-            context.currentPlayerIndex,
-            {
-              ...playerWithLinks,
-              links: [
-                ...playerWithLinks.links,
-                { ...context.selectedSecondLink, type: 'rail' as const },
-              ],
-            },
-          ),
-          coalMarket: firstCoal.updatedCoalMarket,
-        },
-        [context.selectedSecondLink.from, context.selectedSecondLink.to],
-        1,
-      )
-      if (!secondCoal.success) {
-        return false
-      }
-
-      const totalCost =
-        GAME_CONSTANTS.RAIL_DOUBLE_LINK_COST +
-        firstCoal.coalCost +
-        secondCoal.coalCost
-      return getCurrentPlayer(context).money >= totalCost
+      // Each link sources coal after it is placed (rules L116/L308).
+      return railNetworkPayable(context)
     },
   },
 }).createMachine({

--- a/src/store/market/marketActions.ts
+++ b/src/store/market/marketActions.ts
@@ -6,6 +6,7 @@ import {
   calculateNetworkDistance,
   checkAndFlipIndustryTilesLogic,
   getCurrentPlayer,
+  updatePlayerInList,
 } from '../shared/gameUtils'
 import {
   type BeerSource,
@@ -19,6 +20,7 @@ import {
   ironSourceKey,
   planResourceSources,
   runCoalAllocation,
+  withProvisionalLink,
 } from '../shared/resourceSources'
 
 export function consumeCoalFromSources(
@@ -653,5 +655,138 @@ export function consumeBeerFromSources(
     updatedMerchants,
     merchantBonusesCollected,
     logDetails,
+  }
+}
+
+// A rail link burns exactly 1 coal, sourced from the nearest connected mine or,
+// failing that, the coal market (rules L116/L308). Names where that cube comes
+// from and its price, engine-truthfully.
+export interface RailCoalSourceView {
+  kind: 'mine' | 'market'
+  // Mine location, or the connected merchant that opens the market.
+  location?: CityId
+  ownerName?: string
+  own?: boolean
+  cost: number
+}
+
+export interface RailLinkCostView {
+  from: CityId
+  to: CityId
+  coal: RailCoalSourceView | null
+}
+
+// The full cost of the rail Network action the machine is holding: one link
+// (context.selectedLink alone) or a double (both links set). Coal is judged
+// after each link is placed, matching consumption. `ok` is false when a link
+// cannot reach coal or the whole action is unaffordable — the single source of
+// truth for both the SELECT/CONFIRM guards and the dock's cost preview.
+export interface RailNetworkCostView {
+  ok: boolean
+  double: boolean
+  baseCost: number
+  coalTotal: number
+  total: number
+  links: RailLinkCostView[]
+}
+
+// Where the one cube for a link at `anchor` (both endpoints) comes from, in the
+// board state `ctx` (link already provisionally placed). `picks` honours the
+// player's tie choices, if any.
+function railCoalCubeView(
+  ctx: GameState,
+  anchor: CityId[],
+  picks: CoalSource[],
+): { view: RailCoalSourceView | null; cost: number; ok: boolean } {
+  const consume = consumeCoalFromSources(ctx, anchor, 1, picks)
+  if (!consume.success) return { view: null, cost: 0, ok: false }
+  const alloc = runCoalAllocation(
+    [{ context: ctx, anchor, required: 1 }],
+    picks,
+  )
+  if (alloc.fromMines.length > 0) {
+    const mine = alloc.fromMines[0]!
+    const owner = ctx.players.find((p) => p.id === mine.ownerId)
+    return {
+      view: {
+        kind: 'mine',
+        location: mine.location,
+        ownerName: owner?.name,
+        own: mine.ownerId === getCurrentPlayer(ctx)?.id,
+        cost: 0,
+      },
+      cost: 0,
+      ok: true,
+    }
+  }
+  const [merchant] = isLocationConnectedToMerchant(
+    ctx,
+    anchor,
+  ).connectedMerchants
+  return {
+    view: { kind: 'market', location: merchant, cost: consume.coalCost },
+    cost: consume.coalCost,
+    ok: true,
+  }
+}
+
+export function railNetworkCostView(
+  context: GameState,
+): RailNetworkCostView | null {
+  if (context.era !== 'rail' || context.selectedLink === null) return null
+  const idx = context.currentPlayerIndex
+  const picks = context.chosenCoalSources ?? []
+  const link1 = context.selectedLink
+
+  const ctx1 = withProvisionalLink(context)
+  const c1 = railCoalCubeView(ctx1, [link1.from, link1.to], picks)
+
+  if (context.selectedSecondLink === null) {
+    const total = GAME_CONSTANTS.RAIL_LINK_COST + c1.cost
+    return {
+      ok: c1.ok,
+      double: false,
+      baseCost: GAME_CONSTANTS.RAIL_LINK_COST,
+      coalTotal: c1.cost,
+      total,
+      links: [{ from: link1.from, to: link1.to, coal: c1.view }],
+    }
+  }
+
+  // Double: the second link's coal is judged with the first placed AND drained,
+  // matching execution (the first link is on the board before its coal, then
+  // both are before the second's).
+  const link2 = context.selectedSecondLink
+  const firstConsume = consumeCoalFromSources(
+    ctx1,
+    [link1.from, link1.to],
+    1,
+    picks,
+  )
+  const playerWithLinks = firstConsume.updatedPlayers[idx]!
+  const ctx2: GameState = {
+    ...context,
+    players: updatePlayerInList(firstConsume.updatedPlayers, idx, {
+      ...playerWithLinks,
+      links: [...playerWithLinks.links, { ...link2, type: 'rail' as const }],
+    }),
+    coalMarket: firstConsume.updatedCoalMarket,
+  }
+  const c2 = railCoalCubeView(
+    ctx2,
+    [link2.from, link2.to],
+    picks.slice(firstConsume.picksUsed),
+  )
+  const coalTotal = c1.cost + c2.cost
+  return {
+    ok: c1.ok && c2.ok,
+    double: true,
+    baseCost: GAME_CONSTANTS.RAIL_DOUBLE_LINK_COST,
+    coalTotal,
+    total: GAME_CONSTANTS.RAIL_DOUBLE_LINK_COST + coalTotal,
+    links: [
+      { from: link1.from, to: link1.to, coal: c1.view },
+      { from: link2.from, to: link2.to, coal: c2.view },
+    ],
   }
 }


### PR DESCRIPTION
## The defect

Rail-route **selection** (`SELECT_LINK`/`SELECT_SECOND_LINK` → `canBuildLink`) checked network adjacency + base cost but **not coal**, while the **confirm** guard (`hasSelectedLink`) did. So a coal-dead spur route — no connected mine *and* no coal-market reach (e.g. Belper→Derby, Derby→Uttoxeter in the diagnosed prod state) — pulsed as selectable, got clicked, then was rejected at confirm.

## The fix (§1)

Fold the coal-when-placed + full-cost check into `canBuildLink` for the link-select events (the event carries `from`/`to`, so coal *is* computable at selection). Selection now `==` confirmability.

- **Market-coal routes stay offered** — they're payable via £ (e.g. Derby→Nottingham £1). Only genuine no-coal-path spurs drop out.
- Guards + the new cost preview share **one engine source of truth**, `railNetworkCostView` (`market/marketActions.ts`): the offered set, the confirm guards (`hasSelectedLink` / `canCompleteDoubleLink`) and the displayed cost can never drift. `hasSelectedLink` and `canCompleteDoubleLink` were refactored onto it (no behaviour change to the confirm side).
- This is the single guard feeding both the UI's `legalLinks` and the AI enumeration (`legal-moves.ts`), so it fixes both surfaces and removes the human/AI asymmetry in one place.

## The UI (§2, §3)

At the 1-rail (`confirmingLink`) and 2-rail (`confirmingDoubleLink`) confirm steps, the player now sees each path's real cost **before committing**:

- **Single:** `Lay 1 track — £5 + 1 coal` · `coal: free from Burton upon Trent`
- **Double:** `Lay 2 tracks — £15 + 2 coal + 1 beer`, each link's coal source and the beer source named inline.

All values are engine-computed (`railNetworkCostView` / `beerChoiceForDoubleLink`) and every source name reuses the hover-to-locate plumbing (`locate.tsx`) — hovering spotlights it on the map. (The disabled-confirm *reason text* shipped in #72 and is untouched here.)

![Double-rail confirm showing the £15 + 2 coal + 1 beer breakdown with each link's coal source and the beer source named inline](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-74-images/double-rail-cost.png)

## Tests

- New `gameStore.routeselectability.test.ts` pins **selection == confirmability**: coal-dead spurs are not offered, market-coal routes are, and every offered first-link is confirmable *and* executable end-to-end. Verified it fails without the guard change.
- Full suite green (629 passed), lint + typecheck clean.
- Browser-verified locally on `?era=rail`; single and double breakdowns render as above.
