### PR TITLE
fix(ui): restore develop-blocked glyph to IndustryChip (main is RED)

### DIFF
--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -387,7 +387,7 @@ function DevelopTilePicker({
             disabled
             title={reason}
           >
-            <IndustryGlyph type={type} size={20} />
+            <IndustryChip type={type} size={20} />
             <span className="text-[10.5px] font-semibold uppercase tracking-[0.1em]">
               {type === 'manufacturer' ? 'Goods' : type}
             </span>


### PR DESCRIPTION
## 🔴 Hotfix — main is red at typecheck

CI on \`main\` fails at **typecheck** (tests + lint green):

\`\`\`
src/components/action-dock.tsx(390,14): error TS2304: Cannot find name 'IndustryGlyph'.
\`\`\`

### Cause
The merge of #58 (pottery / DevelopTilePicker) and #64 (mat tiles) into main left the **develop-blocked** button rendering \`<IndustryGlyph>\`, which is **not imported** in \`action-dock.tsx\` — and deliberately not: the Linux native \`tsc\` (CI only) fails to resolve \`IndustryGlyph\` at JSX sites in this file (documented gotcha, note at \`action-dock.tsx:1675\` + CLAUDE.md).

### Fix
Render through \`IndustryChip\` like **every other** industry glyph in the file (8 sites), matching the sibling buildable-develop button one block up (line 362). \`IndustryChip\` is the wash-coin wrapper that internally renders \`IndustryGlyph\`; same \`{type, size}\` props, Linux-safe, visually consistent.

One-character site change; no behaviour change.

### Verification
- \`pnpm typecheck\` → exit 0 (was the red)
- \`pnpm lint\` → 0 issues
- \`pnpm test\` → 648 passed, 4 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)