### PR TITLE
fix(mp): stop broadcasting a player's in-progress selection to opponents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -866,11 +866,21 @@ When updating this file, preserve this bar for all agents and keep entries conci
   DOM, like `turnNotify.ts`). If a guard starts refusing something new, teach
   `explainRefusal` about it in the same commit.
 - HIDDEN INFO IS FILTERED SERVER-SIDE in `filterSnapshotForSeat`: foreign
-  hands, the draw pile, and foreign in-flight selections become `hidden-*`
-  placeholders (lengths preserved — guards need counts). Wire-level tests:
-  `gameStore.multiplayer.test.ts` + `e2e/multiplayer.spec.ts` (reads raw
-  SSE bytes). NEVER add a field to the snapshot without deciding its
-  filtering here.
+  hands and the draw pile become `hidden-*` placeholders (lengths preserved —
+  guards need counts), and the CURRENT player's whole in-progress selection is
+  emptied for every other seat (2026-07-23: `selectedLink`/`selectedSecondLink`
+  /`selectedLocation`/`selectedIndustryTile`/`selectedTilesForDevelop`/
+  `pendingSale`/`chosen{Beer,Iron,Coal}Sources`/`pending{Iron,Coal}Step`, on
+  top of the card fields). Every wizard step is a persisted intent that bumps
+  `version` and broadcasts, so leaving them in let opponents WATCH the acting
+  player's route/site picks light up on their own board. They are emptied, not
+  shape-preserved: nothing a bystander renders or any guard they evaluate reads
+  them, and a placeholder city would light a FALSE plate. Safe because
+  restoring a snapshot never re-runs the `always` chains (`StateMachine.start`
+  only starts children), so the read-only client actor stays parked in its
+  step. Wire-level tests: `gameStore.multiplayer.test.ts` +
+  `e2e/multiplayer.spec.ts` (reads raw SSE bytes). NEVER add a field to the
+  snapshot without deciding its filtering here.
 - Transport = SSE (`/api/mp/stream`) + POST intents: first-class in Next
   route handlers, EventSource auto-reconnects across dev restarts.
   WebSockets would need a custom server. Store = the `games` table (Drizzle,

--- a/e2e/multiplayer.spec.ts
+++ b/e2e/multiplayer.spec.ts
@@ -15,13 +15,28 @@ const expect = baseExpect.configure({ timeout: 15_000 })
  *  - actions round-trip live in both directions (loan → pass → round 2)
  *  - a mid-game refresh reclaims the seat from the localStorage secret
  *  - WIRE-LEVEL hidden-information check: the guest's own SSE stream bytes
- *    contain no real card of the host's hand and no real draw-pile card
+ *    contain no real card of the host's hand, no real draw-pile card, and
+ *    none of the host's in-progress selection (the route she is mid-way
+ *    through picking)
  */
 
 test.skip(!hasDatabaseUrl, `multiplayer e2e ${NEEDS_DB_MESSAGE}`)
 // One long journey over a REAL network database: ~15 round-trips at ~1s each
 // plus the ~8s chat-wire window blow the 30s default on a slow/contended DB.
 test.setTimeout(150_000)
+
+// Map routes are CURVED: a bbox-centre click misses the fat hit-stroke, so
+// aim at the path's own midpoint (same helper as coverage.spec.ts).
+async function clickRoute(page: Page, conn: string) {
+  const path = page.locator(`path[data-conn="${conn}"]`)
+  const pt = await path.evaluate((el) => {
+    const p = el as unknown as SVGPathElement
+    const mid = p.getPointAtLength(p.getTotalLength() / 2)
+    const sp = new DOMPoint(mid.x, mid.y).matrixTransform(p.getScreenCTM()!)
+    return { x: sp.x, y: sp.y }
+  })
+  await page.mouse.click(pt.x, pt.y)
+}
 
 function treasuryOf(page: Page, name: string) {
   return page
@@ -117,6 +132,24 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
   await guest.reload()
   await expect(guest.getByTestId('round-chip')).toHaveText('Round 2/11')
 
+  /* ---- the host opens a Network action and picks a route, but does NOT
+     confirm: every step is a persisted intent that broadcasts, so this is
+     exactly the moment an opponent could watch the pick live ---- */
+  await expect(host.getByTestId('action-network')).toBeVisible()
+  await host.getByTestId('action-network').click()
+  await expect(
+    host.locator('button.bb2-card:not([disabled])').first(),
+  ).toBeVisible()
+  await host.locator('button.bb2-card:not([disabled])').first().click()
+  await expect(
+    host.getByText(/Choose a canal route — \d+ available/),
+  ).toBeVisible()
+  const legalRoute = host.locator('path[data-conn][data-legal="true"]')
+  await expect(legalRoute).not.toHaveCount(0)
+  const pickedConn = (await legalRoute.first().getAttribute('data-conn'))!
+  await clickRoute(host, pickedConn)
+  await expect(host.getByTestId('confirm-action')).toBeEnabled()
+
   /* ---- wire hygiene: read the guest's OWN stream bytes and inspect ---- */
   const rawEvent = await guest.evaluate(
     async ({ token }) => {
@@ -156,6 +189,16 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
       context: {
         players: Array<{ hand: Array<{ id: string }> }>
         drawPile: Array<{ id: string }>
+        selectedCard: { id: string } | null
+        selectedLink: unknown
+        selectedSecondLink: unknown
+        selectedLocation: unknown
+        selectedIndustryTile: unknown
+        selectedTilesForDevelop: unknown[]
+        pendingSale: unknown
+        chosenBeerSources: unknown[]
+        chosenIronSources: unknown[]
+        chosenCoalSources: unknown[]
       }
     }
   }
@@ -172,6 +215,33 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
     true,
   )
   expect(ctx.drawPile.every((c) => c.id.startsWith('hidden-'))).toBe(true)
+  // …and the host's IN-PROGRESS selection is redacted: the route she just
+  // picked is nowhere in the guest's frame, so it cannot light up their map.
+  expect(ctx.selectedLink).toBeNull()
+  expect(ctx.selectedSecondLink).toBeNull()
+  expect(ctx.selectedLocation).toBeNull()
+  expect(ctx.selectedIndustryTile).toBeNull()
+  expect(ctx.selectedTilesForDevelop).toEqual([])
+  expect(ctx.pendingSale).toBeNull()
+  expect(ctx.chosenBeerSources).toEqual([])
+  expect(ctx.chosenIronSources).toEqual([])
+  expect(ctx.chosenCoalSources).toEqual([])
+  expect(ctx.selectedCard?.id).toMatch(/^hidden-/)
+  // Belt-and-braces at the byte level: neither endpoint of the picked route
+  // appears in the selection payload the guest received.
+  // (selectedCard is excluded: its placeholder is a legit-shaped Birmingham
+  // location card, which would false-positive a raw city-id search.)
+  const selectionWire = JSON.stringify({
+    selectedLink: ctx.selectedLink,
+    selectedSecondLink: ctx.selectedSecondLink,
+    selectedLocation: ctx.selectedLocation,
+    selectedIndustryTile: ctx.selectedIndustryTile,
+    selectedTilesForDevelop: ctx.selectedTilesForDevelop,
+    pendingSale: ctx.pendingSale,
+  })
+  for (const city of pickedConn.split('|')) {
+    expect(selectionWire).not.toContain(city)
+  }
 
   /* ---- chat delta on the wire: a NEW chat line arrives as an `event: chat`
      increment (NOT a full-state `data:` view frame), proving a message never

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -4,8 +4,9 @@
 // (token + per-seat secret), checks the event against the machine's own
 // guards, executes it on the proven gameStore engine, persists, and
 // broadcasts per-seat FILTERED views. A client never receives another
-// player's hand, the draw pile contents, or an opponent's in-flight card
-// selections — only shapes (counts) that the machine's public guards need.
+// player's hand, the draw pile contents, or an opponent's in-flight
+// selections (held card, site, route, staged sale, resource picks) — only
+// shapes (counts) that the machine's public guards need.
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { createActor } from 'xstate'
 import { gameStore } from '../../store/gameStore'
@@ -183,6 +184,17 @@ export function filterSnapshotForSeat(
       currentPlayerIndex?: number
       selectedCard?: unknown
       selectedCardsForScout?: unknown[]
+      selectedLink?: unknown
+      selectedSecondLink?: unknown
+      selectedLocation?: unknown
+      selectedIndustryTile?: unknown
+      selectedTilesForDevelop?: unknown[]
+      pendingSale?: unknown
+      chosenBeerSources?: unknown[]
+      chosenIronSources?: unknown[]
+      chosenCoalSources?: unknown[]
+      pendingIronStep?: unknown
+      pendingCoalStep?: unknown
       lastError?: string | null
       errorContext?: string | null
     }
@@ -209,6 +221,27 @@ export function filterSnapshotForSeat(
     ctx.selectedCardsForScout = (ctx.selectedCardsForScout ?? []).map((_, k) =>
       hiddenCard('scout', k),
     )
+    // Every step of an action is a persisted intent that bumps `version` and
+    // broadcasts, so an unredacted in-progress selection let opponents WATCH
+    // the acting player pick their route/site/sources live (the board renders
+    // `selectedLocation`/`selectedLink`). None of these is public until the
+    // action is confirmed and logged, so they are emptied wholesale rather
+    // than shape-preserved: unlike hand/deck sizes, nothing a bystander
+    // renders or any guard they evaluate reads them, and a placeholder value
+    // would light a FALSE plate on their board. Restoring a snapshot never
+    // re-runs the `always` chains (`StateMachine.start` only starts children),
+    // so the read-only client actor stays parked in its step regardless.
+    ctx.selectedLink = null
+    ctx.selectedSecondLink = null
+    ctx.selectedLocation = null
+    ctx.selectedIndustryTile = null
+    ctx.selectedTilesForDevelop = []
+    ctx.pendingSale = null
+    ctx.chosenBeerSources = []
+    ctx.chosenIronSources = []
+    ctx.chosenCoalSources = []
+    ctx.pendingIronStep = null
+    ctx.pendingCoalStep = null
   }
   return clone
 }

--- a/src/store/gameStore.multiplayer.test.ts
+++ b/src/store/gameStore.multiplayer.test.ts
@@ -56,9 +56,37 @@ type Ctx = {
   players: Array<{ hand: Array<{ id: string }>; name: string }>
   drawPile: Array<{ id: string }>
   currentPlayerIndex: number
+  selectedCard: { id: string } | null
+  selectedLink: unknown
+  selectedSecondLink: unknown
+  selectedLocation: unknown
+  selectedIndustryTile: unknown
+  selectedTilesForDevelop: unknown[]
+  pendingSale: unknown
+  chosenBeerSources: unknown[]
+  chosenIronSources: unknown[]
+  chosenCoalSources: unknown[]
+  pendingIronStep: unknown
+  pendingCoalStep: unknown
 }
 const ctxOf = (view: { snapshot: unknown }) =>
   (view.snapshot as { context: Ctx }).context
+
+/** Every field holding an action's in-progress picks — the hidden zone. */
+const selectionFieldsOf = (ctx: Ctx) => ({
+  selectedCard: ctx.selectedCard,
+  selectedLink: ctx.selectedLink,
+  selectedSecondLink: ctx.selectedSecondLink,
+  selectedLocation: ctx.selectedLocation,
+  selectedIndustryTile: ctx.selectedIndustryTile,
+  selectedTilesForDevelop: ctx.selectedTilesForDevelop,
+  pendingSale: ctx.pendingSale,
+  chosenBeerSources: ctx.chosenBeerSources,
+  chosenIronSources: ctx.chosenIronSources,
+  chosenCoalSources: ctx.chosenCoalSources,
+  pendingIronStep: ctx.pendingIronStep,
+  pendingCoalStep: ctx.pendingCoalStep,
+})
 
 describe('multiplayer: lifecycle and authority', () => {
   test('create → join fills seats and starts the engine', async () => {
@@ -360,6 +388,61 @@ describe('multiplayer: hidden information never crosses the wire', () => {
     for (const card of hostCtx.players[0]!.hand) {
       expect(allCardZones.filter((id) => id === card.id)).toHaveLength(0)
     }
+  })
+
+  test("an opponent's in-progress selection never reaches the other seats", async () => {
+    const { host, guest } = await freshGame()
+    const start = await getGameView(host.token, 0, host.seatSecret)
+    const current = ctxOf(start!).currentPlayerIndex
+    const other = current === 0 ? 1 : 0
+    const creds = current === 0 ? host : guest
+    const otherCreds = other === 0 ? host : guest
+
+    // Take a Network action as far as a chosen route: every step here is a
+    // persisted intent that bumps `version` and broadcasts to BOTH seats.
+    const act = (event: Record<string, unknown> & { type: string }) =>
+      actInGame(host.token, current, creds.seatSecret, event)
+    expect((await act({ type: 'NETWORK' })).ok).toBe(true)
+    const own = ctxOf(
+      (await getGameView(host.token, current, creds.seatSecret))!,
+    )
+    const card = own.players[current]!.hand[0]!
+    expect((await act({ type: 'SELECT_CARD', cardId: card.id })).ok).toBe(true)
+    const link = { from: 'birmingham', to: 'coventry' }
+    expect((await act({ type: 'SELECT_LINK', ...link })).ok).toBe(true)
+
+    // The acting seat still sees its own picks.
+    const mine = ctxOf(
+      (await getGameView(host.token, current, creds.seatSecret))!,
+    )
+    expect(mine.selectedLink).toEqual(link)
+    expect(mine.selectedCard?.id).toBe(card.id)
+
+    // The opponent gets the same state node, with the selection redacted —
+    // no route to light up on their board, no card identity.
+    const theirs = ctxOf(
+      (await getGameView(host.token, other, otherCreds.seatSecret))!,
+    )
+    expect(theirs.selectedLink).toBeNull()
+    expect(theirs.selectedSecondLink).toBeNull()
+    expect(theirs.selectedLocation).toBeNull()
+    expect(theirs.selectedIndustryTile).toBeNull()
+    expect(theirs.selectedTilesForDevelop).toEqual([])
+    expect(theirs.pendingSale).toBeNull()
+    expect(theirs.chosenBeerSources).toEqual([])
+    expect(theirs.chosenIronSources).toEqual([])
+    expect(theirs.chosenCoalSources).toEqual([])
+    expect(theirs.pendingIronStep).toBeNull()
+    expect(theirs.pendingCoalStep).toBeNull()
+    expect(theirs.selectedCard?.id).toMatch(/^hidden-/)
+
+    // Wire-level: neither endpoint's id appears anywhere in the opponent's
+    // in-flight selection payload.
+    const wire = JSON.stringify(
+      (await getGameView(host.token, other, otherCreds.seatSecret))!.snapshot,
+    )
+    const wireCtx = (JSON.parse(wire) as { context: Ctx }).context
+    expect(JSON.stringify(selectionFieldsOf(wireCtx))).not.toContain('coventry')
   })
 
   test('unauthenticated view exposes lobby facts only — never a snapshot', async () => {


### PR DESCRIPTION
## The leak

Every step of a multiplayer action is a persisted intent that bumps `version` and broadcasts, but `filterSnapshotForSeat` (`src/server/mp/game.ts`) redacted only foreign **hands**, the **draw pile** and the **held card**. The in-progress *selection* rode out untouched — and both surfaces feed `selectedLocation`/`selectedLink` straight into `BoardMap`, so opponents watched the acting player's route/site picks light up on their own board, live. Confirmed in playtest by three players.

The file's own header comment already claimed it hid "in-flight selections". Now the code matches.

## The fix (server-side only)

For a foreign seat (`currentPlayerIndex !== seatId`) the whole selection zone is emptied, on top of the card fields that were already redacted:

`selectedLink`, `selectedSecondLink`, `selectedLocation`, `selectedIndustryTile`, `selectedTilesForDevelop`, `pendingSale`, `chosenBeerSources`, `chosenIronSources`, `chosenCoalSources`, `pendingIronStep`, `pendingCoalStep`.

Two deliberate calls:

- **Emptied, not shape-preserved.** Hand/deck lengths survive because bystanders render them and public guards need the counts; nothing renders or reads these, and a placeholder city id would light a *false* plate on the opponent's map — worse than nothing.
- **Safe against the machine.** Restoring a snapshot never re-runs the `always` chains — `StateMachine.start` only starts child actors, it does not macrostep — so the opponent's read-only client actor stays parked in its step with empty picks instead of falling through a choosing state.

Untouched by design: the acting player's own frame (filtering is per seat), `hover-highlight.ts`/`computeHoverCities` (shared with hotseat), spectators (`viewFor` already ships them no snapshot at all), and the AI driver (reads the real record, never a filtered view).

**No client changes** — nothing was needed.

## Before / after

The host is mid-Network action with **Belper — Derby** picked but not confirmed. This is the *opponent's* screen (1280px):

| Before — the opponent can see the route | After — nothing to see |
|---|---|
| ![before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-78-images/opponent-before.png) | ![after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-78-images/opponent-after.png) |

The acting player is unaffected — same moment, her own screen:

![actor](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-78-images/actor-after.png)

## Coverage

- `src/store/gameStore.multiplayer.test.ts` — new case: the current player drives a Network action to a chosen route; the acting seat's view still has `selectedLink`, the opponent's has every selection field emptied and neither endpoint id anywhere in the selection payload.
- `e2e/multiplayer.spec.ts` — the journey now leaves the host mid-route-pick before the existing raw-SSE read, and asserts the same redaction on the guest's actual stream bytes.

Both verified **red without the fix** (unit: `expect(theirs.selectedLink).toBeNull()`; e2e: same assertion on the wire), green with it.

`pnpm typecheck`, `pnpm lint`, `pnpm test` (74 files / 664 tests, incl. `egress.test.ts` and the existing hidden-info pins) and `pnpm exec playwright test e2e/multiplayer.spec.ts` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)