### PR TITLE
feat(ui): a Cmd+K command palette that spotlights places and industries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -628,16 +628,34 @@ What this means in practice:
   `theme.css`: dotted underline + `cursor:pointer`). Shared plumbing is
   `src/components/locate.tsx` (context +
   `CityName` + `useLocateCity`); each surface owns the state and feeds
-  BoardMap's `locatedCity` prop (`data-located` on the `g[data-city]`, teal
+  BoardMap's `locatedCities` prop (`data-located` on the `g[data-city]`, teal
   `LocateMark`, deliberately distinct from the brass legal pulse;
   reduced-motion drops the ping). Journal names resolve via `segmentPlaces`
-  (journal-model.ts) — by raw city ID, never display-name matching. The state
-  is ONE `cityId|null` on purpose.
+  (journal-model.ts) — by raw city ID, never display-name matching. HOVER is
+  still ONE `cityId|null`; the map-facing value is a SET because the command
+  palette shares the same spotlight (below).
+- COMMAND PALETTE (Cmd/Ctrl+K, 2026-07-23): `command-palette.tsx`, rendered in
+  both mastheads (`game.tsx` + `mp/mp-game.tsx`) — find a city or an industry;
+  picking one spotlights it (an industry lights EVERY location whose PRINTED
+  slots take it, `cityIndustrySlots`) for `SPOTLIGHT_MS` (5s, self-clearing)
+  and pans via the existing `focusCity` prop. It is a navigation aid ONLY: it
+  reads board data, never game state, sends no event and asks no guard, so it
+  behaves identically on both surfaces and on anyone's turn. Two pure halves,
+  both unit-tested: `palette-search.ts` (index + matcher, `shouldFilter`-free
+  by design — we own the ranking) and `locate-model.ts`
+  (`spotlightFor`/`mergeLocated`, the hover ∪ spotlight union feeding
+  `locatedCities`). Hand-rolled, NOT shadcn `command`: that is cmdk +
+  radix-dialog and this repo carries neither (only `ui/sonner.tsx`); it uses
+  the same `.bb2-curtain`/`.bb2-panel` shell as IncomeTrackModal. The hotkey
+  ignores keystrokes aimed at an input/textarea/contenteditable (mp chat), and
+  Cmd+K is RESERVED for this palette — other shortcut work must not claim it.
+  Pinned by `palette-search.test.ts`, `locate-model.test.ts` and
+  `e2e/command-palette.spec.ts`.
 - CARD-MAP-SYNC (2026-07-21): hovering a LOCATION card in the hand tray
   auto-pans the map (slight zoom-out, animated, debounced) when its city is
   off-viewport — BoardMap's `focusCity` prop, fed by `focusCityFor`
   (`hover-highlight.ts`) on both surfaces. DELIBERATE: separate from
-  `locatedCity` (name hover must never move the map); industry/wild cards
+  `locatedCities` (name hover must never move the map); industry/wild cards
   never pan; no snap-back on hover end; user gestures + board pick steps
   suppress it. Decision logic is pure in `board/pan-into-view.ts`
   (trigger/settle hysteresis — pinned by `pan-into-view.test.ts`); the

--- a/e2e/command-palette.spec.ts
+++ b/e2e/command-palette.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * The Cmd/Ctrl+K palette — find a city or an industry, and the board
+ * spotlights it (`data-located`) for ~5s. It is a navigation aid: it must
+ * never send a machine event, so the turn state it opens over is the turn
+ * state it closes over.
+ *
+ * Offline: runs on the demo fixture, no DB.
+ */
+import { expect, test } from '@playwright/test'
+
+const MODIFIER = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+test('the shortcut opens the palette; Escape closes it', async ({ page }) => {
+  await page.goto('/?demo')
+  await expect(page.getByTestId('palette-trigger')).toBeVisible()
+
+  await page.keyboard.press(`${MODIFIER}+KeyK`)
+  await expect(page.getByTestId('command-palette')).toBeVisible()
+  await expect(page.getByTestId('palette-input')).toBeFocused()
+
+  await page.keyboard.press('Escape')
+  await expect(page.getByTestId('command-palette')).toHaveCount(0)
+})
+
+test('picking a city spotlights that one plate, then clears itself', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  await page.getByTestId('palette-trigger').click()
+  await page.getByTestId('palette-input').fill('derby')
+
+  // The query narrows to the one city; Enter takes the highlighted row.
+  await expect(page.getByTestId('palette-result-city-derby')).toBeVisible()
+  await page.keyboard.press('Enter')
+  await expect(page.getByTestId('command-palette')).toHaveCount(0)
+
+  await expect(
+    page.locator('g[data-city="derby"][data-located="true"]'),
+  ).toBeVisible()
+  // ~5s later the spotlight releases on its own — nothing to dismiss.
+  await expect(page.locator('g[data-located="true"]')).toHaveCount(0, {
+    timeout: 9000,
+  })
+})
+
+test('picking an industry spotlights every location that can take it', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  await page.getByTestId('palette-trigger').click()
+  await page.getByTestId('palette-input').fill('pottery')
+  await page.getByTestId('palette-result-industry-pottery').click()
+
+  // The four printed pottery slots: Coventry, Stafford, Stoke, Belper.
+  await expect(page.locator('g[data-city][data-located="true"]')).toHaveCount(4)
+  for (const city of ['coventry', 'stafford', 'stoke', 'belper']) {
+    await expect(
+      page.locator(`g[data-city="${city}"][data-located="true"]`),
+    ).toBeVisible()
+  }
+})
+
+test('the palette never touches the game state it opens over', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  const round = await page.getByTestId('round-chip').textContent()
+  const deck = await page.getByTestId('deck-chip').textContent()
+  const journalBefore = await page.getByTestId('journal-entry').count()
+
+  await page.keyboard.press(`${MODIFIER}+KeyK`)
+  await page.getByTestId('palette-input').fill('birmingham')
+  await page.keyboard.press('Enter')
+
+  expect(await page.getByTestId('round-chip').textContent()).toBe(round)
+  expect(await page.getByTestId('deck-chip').textContent()).toBe(deck)
+  expect(await page.getByTestId('journal-entry').count()).toBe(journalBefore)
+})

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -201,11 +201,12 @@ export interface BoardMapProps {
   /** Cities spotlit while a hand card is hovered (soft preview hint). */
   hoverCities?: ReadonlySet<string> | null
   /**
-   * Hover-to-locate: the city whose NAME is hovered/focused somewhere in the
-   * UI right now (journal, pickers, ledger) — its plate gets the teal
-   * surveyor's mark so the player can find it on the map.
+   * The spotlit locations: the city whose NAME is hovered/focused somewhere in
+   * the UI right now (journal, pickers, ledger) plus anything the command
+   * palette is spotlighting — each plate gets the teal surveyor's mark so the
+   * player can find it on the map. Built by `mergeLocated` (`locate-model.ts`).
    */
-  locatedCity?: string | null
+  locatedCities?: ReadonlySet<string> | null
   /**
    * Card-hover map sync: the city a hovered hand card names (location cards
    * only). When it sits outside the current viewport the map pans — with a
@@ -251,7 +252,7 @@ export function BoardMap({
   networkCities = null,
   networkColor = null,
   hoverCities = null,
-  locatedCity = null,
+  locatedCities = null,
   focusCity = null,
   highlightPlayerId = null,
   vpAnnotations = null,
@@ -936,7 +937,7 @@ export function BoardMap({
               }
               inNetwork={networkCities?.has(id) ?? false}
               networkColor={networkColor}
-              located={locatedCity === id}
+              located={locatedCities?.has(id) ?? false}
               vp={vpAnnotations?.cities.get(id)}
               vpColor={vpColor}
             />
@@ -965,7 +966,7 @@ export function BoardMap({
                 highlighted={highlight?.cities.has(id) ?? false}
                 highlightColor={highlight?.color ?? null}
                 hoverHint={hoverCities?.has(id) ?? false}
-                located={locatedCity === id}
+                located={locatedCities?.has(id) ?? false}
                 vp={vpAnnotations?.cities.get(id)}
                 vpColor={vpColor}
                 onClick={() => {

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -1,0 +1,312 @@
+'use client'
+
+// Cmd/Ctrl+K — "where is that?" Type a city or an industry, pick it, and the
+// board spotlights it (an industry lights up EVERY location that can take it)
+// for ~5s while the map pans it into view.
+//
+// Strictly a navigation aid: it reads BOARD DATA only (`palette-search.ts`),
+// sends no machine event and never consults legality — so it behaves the same
+// on the hotseat and multiplayer surfaces, on any turn, for any seat.
+//
+// Hand-rolled rather than shadcn's `command`: that component is cmdk plus
+// radix-dialog, and this repo carries neither (its only ui/ entry is sonner);
+// every overlay here is the same `.bb2-curtain` + `.bb2-panel` shell used by
+// IncomeTrackModal and the player mat, which the palette follows.
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { IndustryType } from '~/data/cards'
+import { IndustryChip } from './icons'
+import { useLocateCity } from './locate'
+import {
+  type PaletteEntry,
+  matchPaletteEntries,
+  paletteEntries,
+} from './palette-search'
+
+/** True when a keystroke belongs to whatever the player is typing into. */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  const tag = target.tagName
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT'
+}
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false)
+  // Rendered only after mount so the shortcut hint can name the real modifier
+  // without risking a hydration mismatch.
+  const [isMac, setIsMac] = useState(false)
+  const restoreFocus = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    setIsMac(/mac|iphone|ipad/i.test(navigator.userAgent))
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'k' && e.key !== 'K') return
+      if (!e.metaKey && !e.ctrlKey) return
+      // Never steal the key from a chat box or any other field — except the
+      // palette's own input, where Cmd+K toggles back out.
+      const insidePalette =
+        e.target instanceof HTMLElement &&
+        e.target.closest('[data-command-palette]') !== null
+      if (!insidePalette && isTypingTarget(e.target)) return
+      e.preventDefault()
+      setOpen((prev) => !prev)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  const openPalette = () => {
+    restoreFocus.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+    setOpen(true)
+  }
+
+  const closePalette = () => {
+    setOpen(false)
+    restoreFocus.current?.focus()
+    restoreFocus.current = null
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="bb2-chip"
+        style={{ cursor: 'pointer' }}
+        onClick={openPalette}
+        data-testid="palette-trigger"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+      >
+        <SearchGlyph />
+        <span>Find</span>
+        <span
+          className="hidden sm:inline"
+          style={{ color: 'var(--bb-brass)', letterSpacing: '0.08em' }}
+        >
+          {isMac ? '⌘K' : 'Ctrl K'}
+        </span>
+      </button>
+      {open && <PaletteOverlay isMac={isMac} onClose={closePalette} />}
+    </>
+  )
+}
+
+function PaletteOverlay({
+  isMac,
+  onClose,
+}: {
+  isMac: boolean
+  onClose: () => void
+}) {
+  const { spotlightCities } = useLocateCity()
+  const [query, setQuery] = useState('')
+  const [active, setActive] = useState(0)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  const index = useMemo(() => paletteEntries(), [])
+  const results = useMemo(
+    () => matchPaletteEntries(query, index).slice(0, MAX_RESULTS),
+    [query, index],
+  )
+  const activeIndex = Math.min(active, Math.max(results.length - 1, 0))
+  const activeEntry = results[activeIndex]
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const choose = (entry: PaletteEntry | undefined) => {
+    if (!entry) return
+    spotlightCities(entry.cities)
+    onClose()
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+      return
+    }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (results.length === 0) return
+      const step = e.key === 'ArrowDown' ? 1 : -1
+      const next = (activeIndex + step + results.length) % results.length
+      setActive(next)
+      listRef.current
+        ?.querySelector(`[data-row="${next}"]`)
+        ?.scrollIntoView({ block: 'nearest' })
+      return
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      choose(activeEntry)
+    }
+  }
+
+  return (
+    <div
+      className="bb2-curtain fixed inset-0 z-[70] flex items-start justify-center p-4 pt-[12vh] sm:p-8 sm:pt-[14vh]"
+      style={{ background: 'rgba(10, 8, 6, 0.78)' }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="bb2-panel bb2-rise flex max-h-[70vh] w-full max-w-lg flex-col overflow-hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Find a place or industry"
+        data-command-palette
+        data-testid="command-palette"
+        onKeyDown={onKeyDown}
+      >
+        <div className="flex items-center gap-3 border-b px-4 py-3 [border-color:var(--bb-brass-hairline-soft)]">
+          <SearchGlyph />
+          <input
+            ref={inputRef}
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value)
+              setActive(0)
+            }}
+            placeholder="Find a city or industry…"
+            aria-label="Find a city or industry"
+            role="combobox"
+            aria-expanded="true"
+            aria-controls="bb2-palette-list"
+            aria-activedescendant={activeEntry ? rowId(activeEntry) : undefined}
+            autoComplete="off"
+            spellCheck={false}
+            data-testid="palette-input"
+            className="flex-1 bg-transparent text-[15px] outline-none placeholder:opacity-50"
+            style={{ color: 'var(--bb-parchment-bright)' }}
+          />
+          <button
+            type="button"
+            className="bb2-ghost-btn"
+            onClick={onClose}
+            data-testid="palette-close"
+          >
+            Esc
+          </button>
+        </div>
+
+        <div
+          ref={listRef}
+          id="bb2-palette-list"
+          role="listbox"
+          aria-label="Results"
+          className="flex flex-col gap-1 overflow-y-auto p-2"
+        >
+          {results.length === 0 && (
+            <p
+              className="px-2 py-6 text-center text-[13px]"
+              style={{ color: 'rgba(231,215,177,.55)' }}
+              data-testid="palette-empty"
+            >
+              Nothing on the board by that name.
+            </p>
+          )}
+          {results.map((entry, i) => (
+            <button
+              key={`${entry.kind}:${entry.id}`}
+              id={rowId(entry)}
+              type="button"
+              role="option"
+              aria-selected={i === activeIndex}
+              data-row={i}
+              data-active={i === activeIndex}
+              data-selected={i === activeIndex}
+              data-testid={`palette-result-${entry.kind}-${entry.id}`}
+              className="bb2-option"
+              onMouseEnter={() => setActive(i)}
+              onClick={() => choose(entry)}
+            >
+              <EntryMark entry={entry} />
+              <span className="flex-1">{entry.label}</span>
+              <span
+                className="text-[11px] uppercase tracking-[0.12em]"
+                style={{ color: 'rgba(231,215,177,.5)' }}
+              >
+                {entry.detail}
+              </span>
+            </button>
+          ))}
+        </div>
+
+        <p
+          className="border-t px-4 py-2 text-[11px] [border-color:var(--bb-brass-hairline-soft)]"
+          style={{ color: 'rgba(231,215,177,.45)' }}
+        >
+          ↑↓ to walk · Enter to spotlight on the map · {isMac ? '⌘K' : 'Ctrl K'}{' '}
+          to close
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/** Long lists are noise in a spotlight picker — the board has ~30 places. */
+const MAX_RESULTS = 40
+
+/** The map's surveyor's-mark teal (LocateMark), so a row reads as "a place". */
+const LOCATE_TEAL = '#8fd8cd'
+
+function rowId(entry: PaletteEntry): string {
+  return `bb2-palette-${entry.kind}-${entry.id}`
+}
+
+/** An industry row wears its own glyph; a location wears a survey pin. */
+function EntryMark({ entry }: { entry: PaletteEntry }) {
+  if (entry.kind === 'industry') {
+    return <IndustryChip type={entry.id as IndustryType} size={13} />
+  }
+  return <PinGlyph />
+}
+
+function SearchGlyph() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      aria-hidden="true"
+    >
+      <circle cx="7" cy="7" r="4.5" />
+      <path d="M10.5 10.5 L14 14" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function PinGlyph() {
+  return (
+    <span
+      className="inline-grid place-items-center"
+      style={{ width: 20, height: 20, color: LOCATE_TEAL }}
+    >
+      <svg
+        width="12"
+        height="12"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        aria-hidden="true"
+      >
+        <circle cx="8" cy="6.5" r="2.6" />
+        <path d="M8 9.5 V14" strokeLinecap="round" />
+      </svg>
+    </span>
+  )
+}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -40,6 +40,7 @@ import {
   getHandSelection,
 } from './action-dock'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from './board/board-map'
+import { CommandPalette } from './command-palette'
 import { demoSnapshot } from './demo/demo-snapshot'
 import { demoSnapshotBeerChoice } from './demo/demo-snapshot-beer-choice'
 import { demoSnapshotDoubleBeer } from './demo/demo-snapshot-double-beer'
@@ -895,6 +896,7 @@ function GameInner({
           )}
 
           <div className="ml-auto flex items-center gap-3">
+            <CommandPalette />
             <NewGameButton onConfirm={onNewGame} />
           </div>
         </header>
@@ -936,8 +938,11 @@ function GameInner({
                       coalCandidateCities ??
                       hoverCities)
                 }
-                locatedCity={locateState.locatedCity}
-                focusCity={needsReveal ? null : focusCityFor(hoveredCard)}
+                locatedCities={locateState.locatedCities}
+                focusCity={
+                  locateState.spotlightFocus ??
+                  (needsReveal ? null : focusCityFor(hoveredCard))
+                }
                 highlightPlayerId={needsReveal ? null : hoveredPlayerId}
               />
             </div>

--- a/src/components/locate-model.test.ts
+++ b/src/components/locate-model.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NO_SPOTLIGHT,
+  SPOTLIGHT_MS,
+  mergeLocated,
+  spotlightFor,
+} from './locate-model'
+
+describe('spotlightFor', () => {
+  it('nothing to spotlight is the idle state itself', () => {
+    expect(spotlightFor([])).toBe(NO_SPOTLIGHT)
+  })
+
+  it('a single city spotlights and anchors the pan on itself', () => {
+    const s = spotlightFor(['derby'])
+    expect([...s.cities]).toEqual(['derby'])
+    expect(s.focus).toBe('derby')
+  })
+
+  it('many cities all spotlight; the first is the pan anchor', () => {
+    const s = spotlightFor(['dudley', 'cannock', 'belper'])
+    expect(s.cities.has('cannock')).toBe(true)
+    expect(s.cities.size).toBe(3)
+    expect(s.focus).toBe('dudley')
+  })
+
+  it('clears back to idle by returning NO_SPOTLIGHT', () => {
+    expect(NO_SPOTLIGHT.cities.size).toBe(0)
+    expect(NO_SPOTLIGHT.focus).toBeNull()
+  })
+
+  it('holds the spotlight for about five seconds', () => {
+    expect(SPOTLIGHT_MS).toBe(5000)
+  })
+})
+
+describe('mergeLocated (hover ∪ spotlight)', () => {
+  it('nothing hovered, nothing spotlit → an empty, identity-stable set', () => {
+    const a = mergeLocated(null, NO_SPOTLIGHT.cities)
+    const b = mergeLocated(null, NO_SPOTLIGHT.cities)
+    expect(a.size).toBe(0)
+    expect(a).toBe(b)
+  })
+
+  it('hover alone still marks exactly one city (unchanged behaviour)', () => {
+    expect([...mergeLocated('leek', NO_SPOTLIGHT.cities)]).toEqual(['leek'])
+  })
+
+  it('spotlight alone passes straight through', () => {
+    const spot = spotlightFor(['dudley', 'cannock'])
+    expect(mergeLocated(null, spot.cities)).toBe(spot.cities)
+  })
+
+  it('a hover during a spotlight adds to it', () => {
+    const spot = spotlightFor(['dudley'])
+    const merged = mergeLocated('leek', spot.cities)
+    expect([...merged].sort()).toEqual(['dudley', 'leek'])
+    expect(spot.cities.has('leek')).toBe(false) // the spotlight is untouched
+  })
+
+  it('hovering a city already spotlit changes nothing', () => {
+    const spot = spotlightFor(['dudley', 'cannock'])
+    expect(mergeLocated('dudley', spot.cities)).toBe(spot.cities)
+  })
+})

--- a/src/components/locate-model.ts
+++ b/src/components/locate-model.ts
@@ -1,0 +1,58 @@
+// The pure half of hover-to-locate + the command palette's spotlight: which
+// cities the map should mark right now, and how a palette pick turns into one.
+//
+// The board's spotlight used to be exactly one city (the name under the
+// cursor). The command palette added a second, TIMED source that can name
+// MANY cities at once ("every location with a coal slot"), so the map-facing
+// value is now a SET — the union of the hovered name and the live spotlight.
+// Hover still writes a single `string | null`; nothing about it changed.
+//
+// Kept free of React so the transitions are unit-testable (vitest runs with
+// `environment: 'node'` — no testing-library here). The stateful half lives in
+// `locate.tsx`.
+
+/** How long a palette spotlight stays on the map before clearing itself. */
+export const SPOTLIGHT_MS = 5000
+
+export interface SpotlightState {
+  /** Cities the palette is spotlighting (empty = no spotlight). */
+  cities: ReadonlySet<string>
+  /** Pan target for the map's `focusCity`, or null when nothing to pan to. */
+  focus: string | null
+}
+
+const EMPTY_CITIES: ReadonlySet<string> = new Set<string>()
+
+/** The idle spotlight. Identity-stable so `===` means "nothing spotlit". */
+export const NO_SPOTLIGHT: SpotlightState = {
+  cities: EMPTY_CITIES,
+  focus: null,
+}
+
+/**
+ * A palette pick as spotlight state. The pan target is the FIRST city given:
+ * for a city pick that is the city itself; for an industry pick it is the
+ * first location carrying that industry (an arbitrary but deterministic
+ * anchor — the pan mechanism no-ops when it is already in view, which is the
+ * usual case at the full-board zoom).
+ */
+export function spotlightFor(cityIds: readonly string[]): SpotlightState {
+  if (cityIds.length === 0) return NO_SPOTLIGHT
+  return { cities: new Set(cityIds), focus: cityIds[0] ?? null }
+}
+
+/**
+ * The cities the map should mark: the hovered name plus the live spotlight.
+ * Returns an identity-stable empty set when there is nothing to mark, and the
+ * spotlight set itself when the hover adds nothing — so a re-render with the
+ * same inputs never churns the map's props.
+ */
+export function mergeLocated(
+  hovered: string | null,
+  spotlit: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (!hovered) return spotlit.size === 0 ? EMPTY_CITIES : spotlit
+  if (spotlit.size === 0) return new Set([hovered])
+  if (spotlit.has(hovered)) return spotlit
+  return new Set([...spotlit, hovered])
+}

--- a/src/components/locate.tsx
+++ b/src/components/locate.tsx
@@ -7,15 +7,22 @@
 // owns the `locatedCity` state (so it can feed the map directly) and provides
 // it through this context; name-bearing UI reads only the setter.
 //
-// The state is deliberately a plain "one city id or null" value. Note:
-// card-map-sync (auto-pan to a hovered card's city) landed as a SEPARATE
+// HOVER is still a plain "one city id or null" value. The map-facing value is
+// a SET (`locatedCities`) because a SECOND source shares this spotlight: the
+// command palette, which can light up many locations at once ("every location
+// with a coal slot") and clears itself after SPOTLIGHT_MS. The union and the
+// pick→spotlight transition are pure in `locate-model.ts`.
+//
+// Note: card-map-sync (auto-pan to a hovered card's city) landed as a SEPARATE
 // BoardMap prop (`focusCity`, fed from the hovered card) on purpose —
-// name-hover highlights must never move the map, card hover may.
+// name-hover highlights must never move the map. A palette pick DOES pan, and
+// does it through that same prop (`spotlightFocus`).
 import {
   type Dispatch,
   type ReactNode,
   type SetStateAction,
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -23,19 +30,37 @@ import {
   useState,
 } from 'react'
 import { type CityId, cities } from '~/data/board'
+import {
+  NO_SPOTLIGHT,
+  SPOTLIGHT_MS,
+  type SpotlightState,
+  mergeLocated,
+  spotlightFor,
+} from './locate-model'
 
 export interface LocateCityState {
-  locatedCity: string | null
+  /** Every city the map should mark: the hovered name plus any spotlight. */
+  locatedCities: ReadonlySet<string>
   setLocatedCity: Dispatch<SetStateAction<string | null>>
+  /** Palette: spotlight these cities for ~5s (first one is the pan anchor). */
+  spotlightCities: (cityIds: readonly string[]) => void
+  /** Pan target owned by the live spotlight; null while idle. */
+  spotlightFocus: string | null
 }
+
+const NO_CITIES: ReadonlySet<string> = new Set<string>()
 
 // Default is a no-op so name components render fine outside a provider
 // (setup screen, unit renders) — they just locate nothing.
 const LocateCityContext = createContext<LocateCityState>({
-  locatedCity: null,
+  locatedCities: NO_CITIES,
   setLocatedCity: () => {
     // no provider mounted — locating is a no-op
   },
+  spotlightCities: () => {
+    // no provider mounted — spotlighting is a no-op
+  },
+  spotlightFocus: null,
 })
 
 export const LocateCityProvider = LocateCityContext.Provider
@@ -43,7 +68,39 @@ export const LocateCityProvider = LocateCityContext.Provider
 /** Surface-side state holder — call in game.tsx / mp-game.tsx, feed the map. */
 export function useLocateCityState(): LocateCityState {
   const [locatedCity, setLocatedCity] = useState<string | null>(null)
-  return useMemo(() => ({ locatedCity, setLocatedCity }), [locatedCity])
+  const [spotlight, setSpotlight] = useState<SpotlightState>(NO_SPOTLIGHT)
+  const expiry = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (expiry.current) clearTimeout(expiry.current)
+    }
+  }, [])
+
+  // Re-picking restarts the countdown rather than stacking timers.
+  const spotlightCities = useCallback((cityIds: readonly string[]) => {
+    if (expiry.current) clearTimeout(expiry.current)
+    setSpotlight(spotlightFor(cityIds))
+    expiry.current = setTimeout(() => {
+      expiry.current = null
+      setSpotlight(NO_SPOTLIGHT)
+    }, SPOTLIGHT_MS)
+  }, [])
+
+  const locatedCities = useMemo(
+    () => mergeLocated(locatedCity, spotlight.cities),
+    [locatedCity, spotlight],
+  )
+
+  return useMemo(
+    () => ({
+      locatedCities,
+      setLocatedCity,
+      spotlightCities,
+      spotlightFocus: spotlight.focus,
+    }),
+    [locatedCities, spotlightCities, spotlight.focus],
+  )
 }
 
 export interface LocateHandlers {
@@ -59,7 +116,7 @@ export interface LocateHandlers {
  * own city, so interleaved hovers never wipe a fresher highlight.
  */
 export function useLocateCity() {
-  const { setLocatedCity } = useContext(LocateCityContext)
+  const { setLocatedCity, spotlightCities } = useContext(LocateCityContext)
   return useMemo(() => {
     const locate = (cityId: string) => setLocatedCity(cityId)
     const unlocate = (cityId: string) =>
@@ -77,8 +134,8 @@ export function useLocateCity() {
         onBlur: leave,
       }
     }
-    return { locate, unlocate, handlersFor }
-  }, [setLocatedCity])
+    return { locate, unlocate, handlersFor, spotlightCities }
+  }, [setLocatedCity, spotlightCities])
 }
 
 /**

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -23,6 +23,7 @@ import { explainRefusal } from '~/store/refusal'
 import { refreshEmbeddedTileStats } from '~/store/saveMigration'
 import { ActionDock, SELLABLE, getHandSelection } from '../action-dock'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
+import { CommandPalette } from '../command-palette'
 import { HandTray } from '../hand-tray'
 import { computeHoverCities, focusCityFor } from '../hover-highlight'
 import { legalCityTargets, legalLinkTargets } from '../legal-targets'
@@ -1297,6 +1298,7 @@ function MpTable({
             </span>
           </span>
           <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2 lg:flex-nowrap lg:gap-3">
+            <CommandPalette />
             {inFlight && (
               <span className="bb2-sync-pill" data-testid="mp-syncing">
                 <span className="bb2-sync-dot" />
@@ -1351,8 +1353,10 @@ function MpTable({
                 networkCities={me ? playerNetworkCities(me) : null}
                 networkColor={me ? PLAYER_FILL[me.color] : null}
                 hoverCities={hoverCities}
-                locatedCity={locateState.locatedCity}
-                focusCity={focusCityFor(hoveredCard)}
+                locatedCities={locateState.locatedCities}
+                focusCity={
+                  locateState.spotlightFocus ?? focusCityFor(hoveredCard)
+                }
                 highlightPlayerId={hoveredPlayerId}
               />
             </div>

--- a/src/components/palette-search.test.ts
+++ b/src/components/palette-search.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest'
+import { cities, cityIndustrySlots } from '~/data/board'
+import {
+  type PaletteEntry,
+  locationsWithIndustry,
+  matchPaletteEntries,
+  normalizeQuery,
+  paletteEntries,
+} from './palette-search'
+
+const ALL = paletteEntries()
+
+function find(kind: PaletteEntry['kind'], id: string): PaletteEntry {
+  const entry = ALL.find((e) => e.kind === kind && e.id === id)
+  if (!entry) throw new Error(`no ${kind} entry ${id}`)
+  return entry
+}
+
+function ids(entries: PaletteEntry[]): string[] {
+  return entries.map((e) => `${e.kind}:${e.id}`)
+}
+
+describe('paletteEntries (the index)', () => {
+  it('lists every board location plus the six industries', () => {
+    const cityIds = Object.keys(cities)
+    expect(ALL.filter((e) => e.kind === 'city')).toHaveLength(cityIds.length)
+    expect(ALL.filter((e) => e.kind === 'industry')).toHaveLength(6)
+  })
+
+  it('a city entry spotlights only itself', () => {
+    expect(find('city', 'derby').cities).toEqual(['derby'])
+    expect(find('city', 'derby').label).toBe('Derby')
+  })
+
+  it('marks merchants and the two farm breweries apart', () => {
+    expect(find('city', 'oxford').detail).toBe('Merchant')
+    expect(find('city', 'farmBrewery1').detail).toContain('north')
+    expect(find('city', 'farmBrewery2').detail).toContain('south')
+  })
+
+  it('an industry entry spotlights every location with that slot', () => {
+    const coal = find('industry', 'coal')
+    expect(coal.cities).toEqual(locationsWithIndustry('coal'))
+    expect(coal.cities).toContain('dudley')
+    expect(coal.cities).not.toContain('worcester') // two cotton slots only
+    expect(coal.detail).toBe(`${coal.cities.length} locations`)
+  })
+
+  it('reads the industry locations off the printed slots', () => {
+    for (const id of locationsWithIndustry('pottery')) {
+      expect(cityIndustrySlots[id].some((s) => s.includes('pottery'))).toBe(
+        true,
+      )
+    }
+    expect(locationsWithIndustry('pottery')).toEqual([
+      'coventry',
+      'stafford',
+      'stoke',
+      'belper',
+    ])
+  })
+
+  it('never offers a merchant as an industry location', () => {
+    for (const entry of ALL.filter((e) => e.kind === 'industry')) {
+      for (const id of entry.cities) {
+        expect(cities[id as keyof typeof cities].type).toBe('city')
+      }
+    }
+  })
+})
+
+describe('normalizeQuery', () => {
+  it('lowercases and turns punctuation into word breaks', () => {
+    expect(normalizeQuery('Stoke-on-Trent')).toBe('stoke on trent')
+    expect(normalizeQuery('  Iron   Works ')).toBe('iron works')
+    expect(normalizeQuery('')).toBe('')
+    expect(normalizeQuery('   ')).toBe('')
+  })
+})
+
+describe('matchPaletteEntries', () => {
+  it('an empty query lists everything, index order', () => {
+    expect(matchPaletteEntries('', ALL)).toEqual(ALL)
+    expect(matchPaletteEntries('   ', ALL)).toEqual(ALL)
+  })
+
+  it('matches a city by display name, prefix first', () => {
+    const hits = matchPaletteEntries('birm', ALL)
+    expect(hits[0]).toBe(find('city', 'birmingham'))
+  })
+
+  it('matches a hyphenated name by any of its words', () => {
+    expect(ids(matchPaletteEntries('trent', ALL))).toEqual(
+      expect.arrayContaining(['city:stoke', 'city:burton']),
+    )
+    expect(matchPaletteEntries('stoke on', ALL)[0]).toBe(find('city', 'stoke'))
+  })
+
+  it('matches an industry by label and by alias', () => {
+    expect(matchPaletteEntries('coal', ALL)[0]).toBe(find('industry', 'coal'))
+    expect(matchPaletteEntries('mine', ALL)[0]).toBe(find('industry', 'coal'))
+    expect(matchPaletteEntries('beer', ALL)[0]).toBe(
+      find('industry', 'brewery'),
+    )
+  })
+
+  it('matches a city by its raw id too', () => {
+    expect(ids(matchPaletteEntries('farmbrewery1', ALL))).toEqual([
+      'city:farmBrewery1',
+    ])
+  })
+
+  it('returns nothing for a query that matches nothing', () => {
+    expect(matchPaletteEntries('zzzz', ALL)).toEqual([])
+  })
+
+  it('is deterministic: same query, same order', () => {
+    expect(ids(matchPaletteEntries('co', ALL))).toEqual(
+      ids(matchPaletteEntries('CO', ALL)),
+    )
+  })
+
+  it('puts an exact industry ahead of a merely-containing city', () => {
+    const hits = matchPaletteEntries('iron', ALL)
+    expect(hits[0]).toBe(find('industry', 'iron'))
+  })
+})

--- a/src/components/palette-search.ts
+++ b/src/components/palette-search.ts
@@ -1,0 +1,144 @@
+// The command palette's searchable index and its matcher — the pure half of
+// `command-palette.tsx` (which owns only the overlay, the keys and focus).
+//
+// Two kinds of entry, both derived from BOARD DATA only:
+//  - a city (or merchant) — spotlights that one location;
+//  - an industry — spotlights EVERY location whose printed slots can take it
+//    (`cityIndustrySlots`), i.e. "where can a coal mine go?".
+// Nothing here reads game state: the palette is a navigation aid and must
+// never see, let alone touch, the machine.
+
+import { type CityId, cities, cityIndustrySlots } from '~/data/board'
+import type { IndustryType } from '~/data/cards'
+
+export interface PaletteEntry {
+  kind: 'city' | 'industry'
+  /** CityId for a city entry, IndustryType for an industry entry. */
+  id: string
+  label: string
+  /** Secondary line: the location's kind, or how many locations an industry has. */
+  detail: string
+  /** Cities to spotlight when this entry is chosen (first = pan anchor). */
+  cities: readonly string[]
+  /** Everything the query is matched against (raw; normalized on compare). */
+  keywords: readonly string[]
+}
+
+/** Full industry names as they read on the board (the mat says "Coal Mine"). */
+const INDUSTRY_LABEL: Record<IndustryType, string> = {
+  cotton: 'Cotton Mill',
+  coal: 'Coal Mine',
+  iron: 'Iron Works',
+  manufacturer: 'Manufacturer',
+  pottery: 'Pottery',
+  brewery: 'Brewery',
+}
+
+const INDUSTRY_ORDER: IndustryType[] = [
+  'coal',
+  'iron',
+  'cotton',
+  'manufacturer',
+  'pottery',
+  'brewery',
+]
+
+/** Extra words a player may reach for that the label does not contain. */
+const INDUSTRY_ALIASES: Record<IndustryType, string[]> = {
+  cotton: ['mill'],
+  coal: ['mine'],
+  iron: ['works', 'foundry'],
+  manufacturer: ['manufactured goods', 'goods'],
+  pottery: ['potteries', 'kiln'],
+  brewery: ['beer', 'barrel'],
+}
+
+/** Locations whose printed slots can take `type`, in board order. */
+export function locationsWithIndustry(type: IndustryType): CityId[] {
+  return (Object.keys(cityIndustrySlots) as CityId[]).filter((id) =>
+    cityIndustrySlots[id].some((slot) => slot.includes(type)),
+  )
+}
+
+function cityDetail(id: CityId): string {
+  if (cities[id].type === 'merchant') return 'Merchant'
+  // The two Farm Breweries share a display name — say which is which, since
+  // the palette lists them as two separate rows.
+  if (id === 'farmBrewery1') return 'Farm Brewery · north'
+  if (id === 'farmBrewery2') return 'Farm Brewery · south'
+  return 'City'
+}
+
+/** The full index: every industry, then every location. */
+export function paletteEntries(): PaletteEntry[] {
+  const industries: PaletteEntry[] = INDUSTRY_ORDER.map((type) => {
+    const locations = locationsWithIndustry(type)
+    return {
+      kind: 'industry',
+      id: type,
+      label: INDUSTRY_LABEL[type],
+      detail: `${locations.length} locations`,
+      cities: locations,
+      keywords: [INDUSTRY_LABEL[type], type, ...INDUSTRY_ALIASES[type]],
+    }
+  })
+  const places: PaletteEntry[] = (Object.keys(cities) as CityId[]).map(
+    (id) => ({
+      kind: 'city',
+      id,
+      label: cities[id].name,
+      detail: cityDetail(id),
+      cities: [id],
+      keywords: [cities[id].name, id, cityDetail(id)],
+    }),
+  )
+  return [...industries, ...places]
+}
+
+/** Lowercase, punctuation to spaces — "Stoke-on-Trent" → "stoke on trent". */
+export function normalizeQuery(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+}
+
+/** 3 = keyword starts with the query, 2 = a later word does, 1 = anywhere. */
+function scoreKeyword(keyword: string, query: string): number {
+  if (keyword.startsWith(query)) return 3
+  if (keyword.includes(` ${query}`)) return 2
+  return keyword.includes(query) ? 1 : 0
+}
+
+function scoreEntry(entry: PaletteEntry, query: string): number {
+  let best = 0
+  for (const keyword of entry.keywords) {
+    best = Math.max(best, scoreKeyword(normalizeQuery(keyword), query))
+    if (best === 3) break
+  }
+  return best
+}
+
+/**
+ * Entries matching `query`, best first. An empty query lists everything in
+ * index order (industries, then locations); otherwise ties break on kind
+ * (industries first — there are only six and they are the coarser filter)
+ * and then alphabetically, so the order never depends on the input's history.
+ */
+export function matchPaletteEntries(
+  query: string,
+  entries: readonly PaletteEntry[] = paletteEntries(),
+): PaletteEntry[] {
+  const q = normalizeQuery(query)
+  if (!q) return [...entries]
+  const scored = entries
+    .map((entry) => ({ entry, score: scoreEntry(entry, q) }))
+    .filter((row) => row.score > 0)
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score
+    if (a.entry.kind !== b.entry.kind)
+      return a.entry.kind === 'industry' ? -1 : 1
+    return a.entry.label.localeCompare(b.entry.label)
+  })
+  return scored.map((row) => row.entry)
+}


### PR DESCRIPTION
## What

`Cmd+K` (`Ctrl+K` elsewhere), or the masthead **FIND** chip, opens a spotlight
palette. Type a city or an industry:

- a **city** → that plate lights up;
- an **industry** → *every* location whose printed slots can take it lights up
  (`cityIndustrySlots`), i.e. "where can a coal mine even go?".

The highlight holds ~5s and clears itself (re-picking restarts the clock); the
map pans the target into view. Works on the hotseat surface and the networked
one. Escape closes; the shortcut never fires while you are typing in an input
(mp chat keeps its keys).

## Reuses what already existed — no second highlight system

- **Spotlight = the hover-to-locate mark.** `locate.tsx`'s hover state is still
  one `cityId | null`. What the map consumes is now a SET, because an industry
  pick names many locations at once — so BoardMap's prop is `locatedCities`.
  The union and the pick→spotlight transition are pure in `locate-model.ts`.
  Hover-to-locate behaviour is unchanged (`e2e/locate-city.spec.ts` green).
- **Pan = the card-hover `focusCity` prop**, so `pan-into-view.ts`'s
  trigger/settle hysteresis and its `prefers-reduced-motion` instant jump apply
  as-is. Nothing in that module changed.

## Read-only over game state

The palette reads BOARD DATA only (`palette-search.ts` over `cities` +
`cityIndustrySlots`). It sends no machine event, asks no guard, re-derives no
rule — so legality stays engine-owned and the palette behaves identically on
any turn, for any seat. `e2e/command-palette.spec.ts` pins that the round, the
deck and the journal are untouched across an open→pick→close.

## Not shadcn `command`

That component is cmdk + radix-dialog, and this repo carries neither (its only
`ui/` entry is `sonner`). The overlay is the same `.bb2-curtain` / `.bb2-panel`
shell as `IncomeTrackModal`, with combobox/listbox roles, `aria-activedescendant`
and arrow-key walking.

## Tests

- `src/components/palette-search.test.ts` — index, aliases, ranking, determinism
- `src/components/locate-model.test.ts` — spotlight + hover∪spotlight transitions
- `e2e/command-palette.spec.ts` — shortcut, Escape, city vs industry spotlight,
  self-clear, and the no-state-change guarantee

`pnpm test` (688), `pnpm typecheck`, `pnpm lint` green; the offline e2e suite
(atlas, coverage, locate-city, hand-tray, card-first, beer/iron source,
round-curtain, income-track, bugfixes, double-link-beer) green.

## Screenshots

Baseline is the same board before the palette is opened — the feature is
purely additive, so "before" is simply the board with no spotlight.

### Board before (1280px)
![baseline](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-79-images/board-baseline-1280.png)

### Palette open (1280px)
![palette](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-79-images/palette-open-1280.png)

### City pick — Derby spotlit (1280px)
![city](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-79-images/spotlight-city-1280.png)

### Industry pick — all 13 coal locations spotlit (1280px)
![industry](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-79-images/spotlight-industry-1280.png)

### Multiplayer surface — pottery's four locations spotlit (1280px)
![mp](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-79-images/mp-spotlight-1280.png)

### Phone (390px) — trigger chip and the palette
![phone-closed](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-79-images/phone-closed-390.png)
![phone-open](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-79-images/palette-open-390.png)
