### PR TITLE
fix(board): keep built-link markers clear of the city plates that hid them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -546,6 +546,18 @@ What this means in practice:
   manual path:
   `axi eval 'document.querySelector("[data-conn=\"belper|leek\"]").focus()'`
   then `axi press Enter`.
+- SVG Z-ORDER IS DOCUMENT ORDER (2026-07-23). Routes run city-centre to
+  city-centre, so 10 of the 39 route midpoints sit inside a plate or its name
+  ribbon — a built link's boat/locomotive marker painted there vanishes under
+  the plate (the Stoke-on-Trent playtest bug). Both halves of the fix live in
+  `board/marker-anchor.ts`: it owns plate sizing (`SLOT`/`PLATE_GRIDS`/
+  `plateRect` — moved off `board-map.tsx` so plates and markers measure the
+  SAME boxes) and `linkMarkerAnchor`, which slides a marker along its own
+  curve to the nearest point clearing every plate + ribbon. `board-map.tsx`
+  then paints the built-link marker layer AFTER all plates, because two hops
+  (stoke—stone, birmingham—redditch) have no clear point at all. Both are
+  needed; dropping either re-hides a marker. Any new on-board decoration near
+  a route midpoint has the same exposure — pin it in `marker-anchor.test.ts`.
 - Board candidates come from ONE shared module, `components/legal-targets.ts`
   (`legalCityTargets` / `legalLinkTargets`), used by both `game.tsx` and
   `mp/mp-game.tsx`. It enumerates and asks `can()`; it re-derives no rule. See

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -16,7 +16,16 @@ import { type IndustryType } from '~/data/cards'
 import { type Merchant, type Player } from '~/store/gameStore'
 import { GAME_ICONS } from '../gameicons-data'
 import { IndustryFragment } from '../icons'
-import { VIEW_H, VIEW_W, cityPos, linkKey, routeBow } from './board-data'
+import { VIEW_H, VIEW_W, cityPos, linkKey } from './board-data'
+import {
+  PLATE_PAD,
+  SLOT,
+  SLOT_GAP,
+  linkMarkerAnchor,
+  plateGrid,
+  pointAt,
+  routeCurve,
+} from './marker-anchor'
 import {
   FOCUS_PAN_ANIMATION_MS,
   FOCUS_PAN_DEBOUNCE_MS,
@@ -72,38 +81,6 @@ export function playerNetworkCities(player: Player): Set<CityId> {
     }
   }
   return network
-}
-
-const SLOT = 52
-const SLOT_GAP = 4
-const PLATE_PAD = 6
-
-/* ---------------- geometry helpers ---------------- */
-
-interface Pt {
-  x: number
-  y: number
-}
-
-function routePath(from: CityId, to: CityId): { d: string; mid: Pt } {
-  const a = cityPos[from]
-  const b = cityPos[to]
-  const bow = routeBow[linkKey(from, to)] ?? 0
-  const mx = (a.x + b.x) / 2
-  const my = (a.y + b.y) / 2
-  const dx = b.x - a.x
-  const dy = b.y - a.y
-  const len = Math.hypot(dx, dy) || 1
-  const cx = mx + (-dy / len) * bow
-  const cy = my + (dx / len) * bow
-  return {
-    d: `M ${a.x} ${a.y} Q ${cx} ${cy} ${b.x} ${b.y}`,
-    // quadratic bezier midpoint (t = 0.5)
-    mid: {
-      x: 0.25 * a.x + 0.5 * cx + 0.25 * b.x,
-      y: 0.25 * a.y + 0.5 * cy + 0.25 * b.y,
-    },
-  }
 }
 
 interface BuiltIndustry {
@@ -528,6 +505,48 @@ export function BoardMap({
     ]),
   )
 
+  // Every route is derived once and rendered in two passes: the corridors
+  // under the plates, the built-link markers over them (see marker-anchor.ts).
+  const linkStates = connections.map((conn) => {
+    const key = linkKey(conn.from, conn.to)
+    const types = conn.types as readonly string[]
+    const activeThisEra = types.includes(era)
+    const built = builtLinks.get(key)
+    const linkVp =
+      vpAnnotations?.links.get(key) ??
+      vpAnnotations?.links.get(linkKey(conn.to, conn.from))
+    const isHighlighted =
+      highlight !== null && built?.player.id === highlightPlayerId
+    const isLegal =
+      legalLinks?.has(key) ??
+      legalLinks?.has(linkKey(conn.to, conn.from)) ??
+      false
+    const isSelected = selectedLinkKeys.has(key)
+    return {
+      conn,
+      key,
+      d: routeCurve(conn.from, conn.to).d,
+      anchor: linkMarkerAnchor(conn.from, conn.to),
+      activeThisEra,
+      built,
+      linkVp,
+      isLegal,
+      isSelected,
+      isHighlighted,
+      renderType: (built
+        ? built.type
+        : activeThisEra
+          ? era
+          : types.includes('canal')
+            ? 'canal'
+            : 'rail') as 'canal' | 'rail',
+      dimmed:
+        (pickingLink && !isLegal && !isSelected) ||
+        (vpAnnotations !== null && linkVp === undefined) ||
+        (highlight !== null && !isHighlighted),
+    }
+  })
+
   /* ---------------- render ---------------- */
 
   return (
@@ -696,33 +715,19 @@ export function BoardMap({
 
         {/* ------------ routes ------------ */}
         <g>
-          {connections.map((conn) => {
-            const key = linkKey(conn.from, conn.to)
-            const types = conn.types as readonly string[]
-            const activeThisEra = types.includes(era)
-            const built = builtLinks.get(key)
-            const { d, mid } = routePath(conn.from, conn.to)
-            const isLegal =
-              legalLinks?.has(key) ??
-              legalLinks?.has(linkKey(conn.to, conn.from)) ??
-              false
-            const isSelected = selectedLinkKeys.has(key)
-            const linkVp =
-              vpAnnotations?.links.get(key) ??
-              vpAnnotations?.links.get(linkKey(conn.to, conn.from))
-            const renderType: 'canal' | 'rail' = built
-              ? built.type
-              : activeThisEra
-                ? (era as 'canal' | 'rail')
-                : types.includes('canal')
-                  ? 'canal'
-                  : 'rail'
-            const isHighlighted =
-              highlight !== null && built?.player.id === highlightPlayerId
-            const dimmed =
-              (pickingLink && !isLegal && !isSelected) ||
-              (vpAnnotations !== null && linkVp === undefined) ||
-              (highlight !== null && !isHighlighted)
+          {linkStates.map((state) => {
+            const {
+              conn,
+              key,
+              d,
+              activeThisEra,
+              built,
+              isLegal,
+              isSelected,
+              isHighlighted,
+              renderType,
+              dimmed,
+            } = state
 
             return (
               <g key={key} opacity={dimmed ? 0.3 : 1}>
@@ -816,50 +821,6 @@ export function BoardMap({
                   />
                 )}
 
-                {/* built link marker — the player's tile on the route,
-                    stamped with the physical game's glyphs: a narrowboat
-                    for canals, a locomotive for rails */}
-                {built && (
-                  <g
-                    transform={`translate(${mid.x}, ${mid.y})`}
-                    pointerEvents="none"
-                  >
-                    <rect
-                      x="-16"
-                      y="-10"
-                      width="32"
-                      height="20"
-                      rx="3.5"
-                      fill={PLAYER_FILL[built.player.color]}
-                      stroke="#16130f"
-                      strokeWidth="1.4"
-                      filter="url(#bb2-plate-shadow)"
-                    />
-                    <g fill="#f2e6c8" stroke="none">
-                      {built.type === 'canal' ? (
-                        // bespoke narrowboat silhouette (no such icon exists
-                        // in any library — see bb-icon-research-f12)
-                        <path d="M-10.6 -5.2 h2.4 v3 h6.6 v-3.4 h1.8 v3.4 h1.4 v2 h-12.2 z M-13 1 h26 c-0.7 2.9 -3.2 4.6 -6.4 4.6 h-13.2 c-3.2 0 -5.7 -1.7 -6.4 -4.6 z" />
-                      ) : (
-                        // delapouite/steam-locomotive (game-icons.net CC BY 3.0)
-                        <g transform="translate(-12.5, -12.5) scale(0.04883)">
-                          <path d={GAME_ICONS.steamLocomotive.d} />
-                        </g>
-                      )}
-                    </g>
-                  </g>
-                )}
-
-                {/* game-end: what this route scored for the shown player */}
-                {linkVp !== undefined && (
-                  <g
-                    transform={`translate(${mid.x}, ${mid.y})`}
-                    data-vp-link={key}
-                  >
-                    <VpRoundel vp={linkVp} color={vpColor ?? '#e6bd63'} />
-                  </g>
-                )}
-
                 {/* fat invisible hit area */}
                 {(pickingLink || onLinkClick) && (
                   <path
@@ -905,7 +866,7 @@ export function BoardMap({
             kidderminster—worcester corridor (rules p.5 — one tile connects
             all three; no second tile may be placed, so no hit area) */}
         {(() => {
-          const { mid } = routePath('kidderminster', 'worcester')
+          const mid = pointAt('kidderminster', 'worcester', 0.5)
           const fb = cityPos.farmBrewery2
           const linked = builtLinks.has(linkKey('kidderminster', 'worcester'))
           return (
@@ -975,6 +936,59 @@ export function BoardMap({
               />
             )
           })}
+
+        {/* ------------ built-link markers ------------
+            Painted last on purpose: a route's marker can sit close enough to
+            a plate that the plate would swallow it (SVG z-order is document
+            order). `linkMarkerAnchor` already slides it into the gap between
+            plates where one exists; this pass keeps it visible where none
+            does — Stoke-on-Trent—Stone being the tightest hop on the board. */}
+        {linkStates.map(({ key, built, linkVp, anchor, dimmed }) =>
+          built || linkVp !== undefined ? (
+            <g key={key} opacity={dimmed ? 0.3 : 1}>
+              {built && (
+                <g
+                  transform={`translate(${anchor.x}, ${anchor.y})`}
+                  pointerEvents="none"
+                >
+                  <rect
+                    x="-16"
+                    y="-10"
+                    width="32"
+                    height="20"
+                    rx="3.5"
+                    fill={PLAYER_FILL[built.player.color]}
+                    stroke="#16130f"
+                    strokeWidth="1.4"
+                    filter="url(#bb2-plate-shadow)"
+                  />
+                  <g fill="#f2e6c8" stroke="none">
+                    {built.type === 'canal' ? (
+                      // bespoke narrowboat silhouette (no such icon exists
+                      // in any library — see bb-icon-research-f12)
+                      <path d="M-10.6 -5.2 h2.4 v3 h6.6 v-3.4 h1.8 v3.4 h1.4 v2 h-12.2 z M-13 1 h26 c-0.7 2.9 -3.2 4.6 -6.4 4.6 h-13.2 c-3.2 0 -5.7 -1.7 -6.4 -4.6 z" />
+                    ) : (
+                      // delapouite/steam-locomotive (game-icons.net CC BY 3.0)
+                      <g transform="translate(-12.5, -12.5) scale(0.04883)">
+                        <path d={GAME_ICONS.steamLocomotive.d} />
+                      </g>
+                    )}
+                  </g>
+                </g>
+              )}
+
+              {/* game-end: what this route scored for the shown player */}
+              {linkVp !== undefined && (
+                <g
+                  transform={`translate(${anchor.x}, ${anchor.y})`}
+                  data-vp-link={key}
+                >
+                  <VpRoundel vp={linkVp} color={vpColor ?? '#e6bd63'} />
+                </g>
+              )}
+            </g>
+          ) : null,
+        )}
       </svg>
 
       {/* prompt banner — the board's own instruction, high contrast */}
@@ -1126,41 +1140,8 @@ export function BoardMap({
 
 /* ================= city plate ================= */
 
-// Slot arrangement per city, matching the physical board's blocky cities:
-// Birmingham is THE big 2x2 square; Coventry, Stoke and Coalbrookdale are
-// compact 2+1 blocks. Everything else stays a horizontal strip (default).
-// Index order remains reading order (left→right, top→bottom) so slot
-// assignment and cityIndustrySlots stay untouched.
-const PLATE_GRIDS: Partial<Record<CityId, Array<[number, number]>>> = {
-  birmingham: [
-    [0, 0],
-    [1, 0],
-    [0, 1],
-    [1, 1],
-  ],
-  coventry: [
-    [0, 0],
-    [1, 0],
-    [0, 1],
-  ],
-  stoke: [
-    [0, 0],
-    [1, 0],
-    [0, 1],
-  ],
-  coalbrookdale: [
-    [0, 0],
-    [1, 0],
-    [0, 1],
-  ],
-}
-
-function plateGrid(cityId: CityId, slotCount: number): Array<[number, number]> {
-  return (
-    PLATE_GRIDS[cityId] ??
-    Array.from({ length: Math.max(slotCount, 1) }, (_, i) => [i, 0])
-  )
-}
+// Slot arrangement per city and plate sizing live in marker-anchor.ts, so
+// the link markers can be placed against the same boxes the plates occupy.
 
 /**
  * Hover-to-locate spotlight: a teal double ring with an outward ping,

--- a/src/components/board/marker-anchor.test.ts
+++ b/src/components/board/marker-anchor.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { type CityId, connections } from '~/data/board'
+import { linkKey } from './board-data'
+import {
+  type Rect,
+  linkMarkerAnchor,
+  markerBoxAt,
+  plateObstacles,
+  plateRect,
+  pointAt,
+  routeCurve,
+} from './marker-anchor'
+
+function overlaps(a: Rect, b: Rect) {
+  return (
+    a.x < b.x + b.w && a.x + a.w > b.x && a.y < b.y + b.h && a.y + a.h > b.y
+  )
+}
+
+function occludedBy(from: CityId, to: CityId, at: { x: number; y: number }) {
+  const box = markerBoxAt(at)
+  return plateObstacles().filter((r) => overlaps(box, r)).length
+}
+
+// The bug the captain hit: the boat on the Stoke—Stone canal sat under the
+// Stoke plate and its name ribbon.
+describe('link marker anchors', () => {
+  it('clears the plate that used to hide the Stoke-on-Trent boat', () => {
+    const mid = pointAt('stoke', 'stone', 0.5)
+    expect(occludedBy('stoke', 'stone', mid)).toBeGreaterThan(0)
+
+    const anchor = linkMarkerAnchor('stoke', 'stone')
+    const stoke = plateRect('stoke')
+    expect(overlaps(markerBoxAt(anchor), stoke)).toBe(false)
+  })
+
+  it('never leaves a marker worse placed than the plain midpoint', () => {
+    for (const conn of connections) {
+      const mid = pointAt(conn.from, conn.to, 0.5)
+      const anchor = linkMarkerAnchor(conn.from, conn.to)
+      expect(
+        occludedBy(conn.from, conn.to, anchor),
+        linkKey(conn.from, conn.to),
+      ).toBeLessThanOrEqual(occludedBy(conn.from, conn.to, mid))
+    }
+  })
+
+  it('finds a fully clear spot on all but the tightest routes', () => {
+    const blocked = connections.filter(
+      (c) => occludedBy(c.from, c.to, linkMarkerAnchor(c.from, c.to)) > 0,
+    )
+    // Short hops between two big plates leave no gap at all; those rely on
+    // the marker layer painting after the plates instead.
+    expect(blocked.map((c) => linkKey(c.from, c.to))).toStrictEqual([
+      'stoke|stone',
+      'birmingham|redditch',
+    ])
+  })
+
+  it('keeps every anchor on its own route', () => {
+    for (const conn of connections) {
+      const anchor = linkMarkerAnchor(conn.from, conn.to)
+      const { a, c, b } = routeCurve(conn.from, conn.to)
+      const near = Array.from({ length: 201 }, (_, i) => i / 200).some((t) => {
+        const u = 1 - t
+        const x = u * u * a.x + 2 * u * t * c.x + t * t * b.x
+        const y = u * u * a.y + 2 * u * t * c.y + t * t * b.y
+        return Math.hypot(x - anchor.x, y - anchor.y) < 1
+      })
+      expect(near, linkKey(conn.from, conn.to)).toBe(true)
+    }
+  })
+
+  it('stays within the middle of the route, never at a city centre', () => {
+    for (const conn of connections) {
+      const anchor = linkMarkerAnchor(conn.from, conn.to)
+      const lo = pointAt(conn.from, conn.to, 0.16)
+      const hi = pointAt(conn.from, conn.to, 0.84)
+      const span = Math.hypot(hi.x - lo.x, hi.y - lo.y)
+      const from = Math.hypot(anchor.x - lo.x, anchor.y - lo.y)
+      const to = Math.hypot(anchor.x - hi.x, anchor.y - hi.y)
+      expect(from + to, linkKey(conn.from, conn.to)).toBeLessThan(span + 2)
+    }
+  })
+})

--- a/src/components/board/marker-anchor.ts
+++ b/src/components/board/marker-anchor.ts
@@ -1,0 +1,215 @@
+// Where a built link's boat/locomotive marker sits on its route.
+//
+// Routes run city-centre to city-centre, so a route's midpoint can land on
+// (or under) a neighbouring city plate — the marker then paints before the
+// plates and disappears (Stoke-on-Trent, playtest 2026-07-22). Two layers fix
+// it, and both live here so they cannot drift apart:
+//   1. `linkMarkerAnchor` slides the marker along its own curve to the point
+//      nearest the midpoint that clears every plate and name ribbon;
+//   2. `board-map.tsx` paints the marker layer AFTER the plates, so even a
+//      route with no clear point (short hops between two big plates) stays
+//      visible. SVG z-order is document order, not CSS z-index.
+import {
+  type CityId,
+  FARM_BREWERIES,
+  cities,
+  cityIndustrySlots,
+} from '~/data/board'
+import { cityPos, linkKey, routeBow } from './board-data'
+
+export const SLOT = 52
+export const SLOT_GAP = 4
+export const PLATE_PAD = 6
+
+/** Plates whose slots stack into a grid instead of one row. */
+export const PLATE_GRIDS: Partial<Record<CityId, Array<[number, number]>>> = {
+  birmingham: [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+    [1, 1],
+  ],
+  coventry: [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+  ],
+  stoke: [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+  ],
+  coalbrookdale: [
+    [0, 0],
+    [1, 0],
+    [0, 1],
+  ],
+}
+
+export function plateGrid(
+  cityId: CityId,
+  slotCount: number,
+): Array<[number, number]> {
+  return (
+    PLATE_GRIDS[cityId] ??
+    Array.from({ length: Math.max(slotCount, 1) }, (_, i) => [i, 0])
+  )
+}
+
+export interface Rect {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface Pt {
+  x: number
+  y: number
+}
+
+/**
+ * The plate's own box, in board coordinates. Merchant plates are sized from
+ * the merchant entries they hold at render time; the pool never seats more
+ * than two per location, so the widest case is used here.
+ */
+export function plateRect(cityId: CityId): Rect {
+  const pos = cityPos[cityId]
+  let w: number
+  let h: number
+  if (cities[cityId].type === 'merchant') {
+    w = 2 * SLOT + SLOT_GAP + PLATE_PAD * 2
+    h = SLOT + PLATE_PAD * 2
+  } else {
+    const grid = plateGrid(cityId, (cityIndustrySlots[cityId] ?? []).length)
+    const cols = Math.max(...grid.map(([c]) => c)) + 1
+    const rows = Math.max(...grid.map(([, r]) => r)) + 1
+    w = cols * SLOT + (cols - 1) * SLOT_GAP + PLATE_PAD * 2
+    h = rows * SLOT + (rows - 1) * SLOT_GAP + PLATE_PAD * 2
+  }
+  return { x: pos.x - w / 2, y: pos.y - h / 2, w, h }
+}
+
+// The name ribbon hangs under every plate (baseline at plateH + 13) and is
+// routinely wider than the plate itself — it hid half the Stoke marker. SVG
+// gives no text metrics outside the DOM, so the box is estimated from the
+// glyph count at the ribbon's own type size (generous on purpose: a slightly
+// fat obstacle only nudges the marker a little further along the route).
+function labelRect(cityId: CityId): Rect {
+  const plate = plateRect(cityId)
+  const isFarm = FARM_BREWERIES.has(cityId)
+  const fontSize = isFarm ? 13 : 14.5
+  // uppercase + 0.1em tracking on city ribbons; italic lowercase on farms
+  const perChar = isFarm ? fontSize * 0.5 : fontSize * 0.68
+  const w = Math.max(cities[cityId].name.length * perChar, plate.w)
+  const baseline = plate.y + plate.h + 13
+  return {
+    x: plate.x + plate.w / 2 - w / 2,
+    y: baseline - fontSize * 0.8,
+    w,
+    h: fontSize * 1.15,
+  }
+}
+
+let obstacleCache: Rect[] | null = null
+
+/** Every box a link marker should try to keep clear of. */
+export function plateObstacles(): Rect[] {
+  if (obstacleCache) return obstacleCache
+  const out: Rect[] = []
+  for (const id of Object.keys(cities) as CityId[]) {
+    out.push(plateRect(id), labelRect(id))
+  }
+  obstacleCache = out
+  return out
+}
+
+/** Quadratic-bezier route from city centre to city centre. */
+export function routeCurve(
+  from: CityId,
+  to: CityId,
+): { a: Pt; c: Pt; b: Pt; d: string } {
+  const a = cityPos[from]
+  const b = cityPos[to]
+  const bow = routeBow[linkKey(from, to)] ?? 0
+  const mx = (a.x + b.x) / 2
+  const my = (a.y + b.y) / 2
+  const dx = b.x - a.x
+  const dy = b.y - a.y
+  const len = Math.hypot(dx, dy) || 1
+  const c = { x: mx + (-dy / len) * bow, y: my + (dx / len) * bow }
+  return { a, c, b, d: `M ${a.x} ${a.y} Q ${c.x} ${c.y} ${b.x} ${b.y}` }
+}
+
+export function pointAt(from: CityId, to: CityId, t: number): Pt {
+  const { a, c, b } = routeCurve(from, to)
+  const u = 1 - t
+  return {
+    x: u * u * a.x + 2 * u * t * c.x + t * t * b.x,
+    y: u * u * a.y + 2 * u * t * c.y + t * t * b.y,
+  }
+}
+
+// The marker plate is 32x20; keep a little air around it so it never kisses
+// a plate edge.
+const MARKER_W = 38
+const MARKER_H = 26
+
+function overlapArea(box: Rect, rects: Rect[]): number {
+  let total = 0
+  for (const r of rects) {
+    const ox = Math.min(box.x + box.w, r.x + r.w) - Math.max(box.x, r.x)
+    const oy = Math.min(box.y + box.h, r.y + r.h) - Math.max(box.y, r.y)
+    if (ox > 0 && oy > 0) total += ox * oy
+  }
+  return total
+}
+
+export function markerBoxAt(p: Pt): Rect {
+  return {
+    x: p.x - MARKER_W / 2,
+    y: p.y - MARKER_H / 2,
+    w: MARKER_W,
+    h: MARKER_H,
+  }
+}
+
+// Search window around the midpoint. Beyond ~0.35 the marker reads as
+// belonging to a city rather than to the route.
+const MAX_SHIFT = 0.34
+const STEP = 0.01
+
+const anchorCache = new Map<string, Pt>()
+
+/**
+ * The point on the route where the built-link marker is drawn: the sample
+ * nearest the midpoint that clears every plate and ribbon, or — when the two
+ * plates leave no gap — the least-occluded sample. Board geometry is static,
+ * so results are cached.
+ */
+export function linkMarkerAnchor(from: CityId, to: CityId): Pt {
+  const key = linkKey(from, to)
+  const cached = anchorCache.get(key)
+  if (cached) return cached
+
+  const obstacles = plateObstacles()
+  let best: Pt = pointAt(from, to, 0.5)
+  let bestOverlap = Number.POSITIVE_INFINITY
+
+  for (let shift = 0; shift <= MAX_SHIFT + 1e-9; shift += STEP) {
+    for (const t of shift === 0 ? [0.5] : [0.5 - shift, 0.5 + shift]) {
+      const p = pointAt(from, to, t)
+      const overlap = overlapArea(markerBoxAt(p), obstacles)
+      if (overlap === 0) {
+        anchorCache.set(key, p)
+        return p
+      }
+      if (overlap < bestOverlap) {
+        bestOverlap = overlap
+        best = p
+      }
+    }
+  }
+  anchorCache.set(key, best)
+  return best
+}


### PR DESCRIPTION
## The bug

A built canal link's boat marker at Stoke-on-Trent was invisible: routes run
city-centre to city-centre, so the Stoke—Stone midpoint lands inside Stoke's
plate and under its name ribbon. SVG z-order is **document order**, and the
route layer paints before the plates — so the plate swallowed the marker.

Not one city's bug: **10 of the board's 39 routes** have their marker box
overlapping a plate or ribbon —
`stoke|stone`, `stone|stafford`, `stone|burton`, `stafford|cannock`,
`burton|walsall`, `cannock|wolverhampton`, `wolverhampton|dudley`,
`worcester|gloucester`, `birmingham|redditch`, `birmingham|walsall`.
All five merchant locations (Warrington, Gloucester, Oxford, Nottingham,
Shrewsbury) were checked against their full 2-slot plate width — none of their
routes is occluded, so nothing to fix there.

## Before / after

Same game state, same viewport, only the code differs. Ten canal links were
injected into the `?demo` fixture's save (via localStorage — no committed
fixture was touched) so every occluded route shows a marker.

**Before** — no boat between Stoke and Stone; only a red sliver bleeds through
the "STOKE-ON-TRENT" ribbon:

![before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-80-images/before-stoke-crop.png)

**After** — the boat sits in the gap between ribbon and Stone's plate:

![after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-80-images/after-stoke-crop.png)

Phone width (390px), before then after:

![before phone](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-80-images/before-stoke-390-crop.png)
![after phone](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-80-images/after-stoke-390-crop.png)

Whole board after, desktop 1280 — all ten markers legible:

![after board](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-80-images/after-full-1280.png)

## The fix

New pure module `src/components/board/marker-anchor.ts` with two layers,
both needed:

1. **Anchor** — `linkMarkerAnchor(from, to)` slides a marker along its own
   quadratic curve to the sample nearest the midpoint whose 38×26 box clears
   every plate and ribbon. Board geometry is static, so results are cached;
   per-render cost is a map lookup.
2. **Paint order** — `board-map.tsx` now renders built-link markers (and the
   game-end link VP roundels) in a dedicated pass **after** all plates. Two
   hops — `stoke|stone` and `birmingham|redditch` — are short enough that
   the two plates leave no clear point at all, so the anchor alone cannot
   save them.

Plate sizing (`SLOT`/`SLOT_GAP`/`PLATE_PAD`/`PLATE_GRIDS`/`plateGrid`)
moved out of `board-map.tsx` into the same module, so plates and markers
measure the *same* boxes and cannot drift apart. Route geometry
(`routeCurve`/`pointAt`) moved with it; `routePath` is gone.

Rendering-only: no engine, no guard, no rule re-derived in the UI. The routes
map is derived once into `linkStates` and read by both passes, so the dim /
legal-pulse treatment is computed in exactly one place, as before.

## Verification

- `pnpm test` — 663 passed, 74 files. New pins: `marker-anchor.test.ts`
  (5 tests — the Stoke case, "never worse than the plain midpoint" over all 39
  routes, the exact list of routes with no clear point, anchors stay on their
  own curve and in the middle of the route).
- `pnpm typecheck`, `pnpm lint` — clean.
- E2E, all green: `atlas coverage locate-city bugfixes hand-tray card-first
  round-curtain` (37 passed) and `beer-source double-link-beer iron-source
  income-track` (6 passed).
- Browser, 1280px: **city click** — clicked the Stoke-on-Trent plate (the one
  now painted under a marker) during a Build; the dock's SITE step read
  "Stoke-on-Trent". **Route keyboard** — focused `[data-conn="leek|stoke"]`
  and pressed Enter; the Network flow advanced to the CONFIRM step showing
  "Leek — Stoke-on-Trent (canal)". Markers are `pointerEvents="none"`, so no
  hit area changed.
