### PR TITLE
feat(ui): develop directly on the player mat, with a scrap-flight animation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -530,6 +530,27 @@ What this means in practice:
   coal's near-black fill), slots bottom-align so piles rest on the mat surface.
   Do not reintroduce any count numeral on a mat tile; counts may appear only in
   the docked readout text / aria-label.
+- DEVELOP PICKS TILES ON THE MAT (2026-07-23): entering any develop tile step
+  (`developing.selectingTiles|choosingIronSource|confirmingDevelop`) auto-opens
+  `PlayerLedger` in develop mode on BOTH surfaces; `components/develop-mat.ts`
+  (`developMatView`) is the only machine seam — it asks `can()`/`explainRefusal`
+  and re-derives nothing. Staged picks live in MACHINE context
+  (`selectedTilesForDevelop`): `SELECT_TILES_FOR_DEVELOP` is guarded
+  (`canSelectTilesForDevelop`, tile legality ONLY — money/iron stay on CONFIRM,
+  the seam `gameStore.money.test.ts` pins) and is re-sendable from the iron and
+  confirm steps as a full-array replacement (reenter resets
+  `chosenIronSources`), so a mat click grows/shrinks the develop without cancel
+  and everything survives the MP round-trip. While the modal is open the DOCK
+  renders a pointer aside ONLY — the modal owns `cancel-action`/
+  `confirm-action`/`develop-lowest`/`iron-source`; rendering them in both
+  places would duplicate testids (Playwright strict mode) and leave the dock's
+  unreachable under the overlay. The armed (glowing) tile per track comes from
+  `stagedRemovals` — a preview-only mirror of `executeDevelopAction` (lowest
+  developable, lightbulbs skipped); the scrap-flight animation is decorative
+  and skipped under `prefers-reduced-motion`. Pinned by
+  `gameStore.developmat.test.ts` + `develop-mat.test.ts` +
+  `e2e/develop-mat.spec.ts`; `iron-source.spec` / `locate-city.spec` /
+  `mp-playthrough.spec` now drive develop THROUGH the modal.
 - The board is a custom SVG (`board/board-map.tsx`, geometry hand-tuned in
   `board-data.ts`) — NOT React Flow. Legal targets come from `state.can(...)`
   sets computed in `game.tsx`; the map dims illegal plates/routes and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,18 @@ What this means in practice:
   data (`canBuildInCanalEra`/`canBuildInRailEra`, incl. the L1-Pottery
   rail exception), never a level check. Pinned by
   `gameStore.railera.test.ts`.
+  DEVELOP HAS THE SAME LOWEST-TILE RULE (fixed 2026-07-23): Develop removes the
+  TRUE lowest tile of the chosen industry, and a lightbulb Pottery may never be
+  developed (rules p.7) — a lightbulb-lowest track blocks ALL of Develop until
+  it is BUILT away; never skip up to the next developable tile. Ask
+  `getDevelopableTileOnMat` (mirror of `getBuildableTileInEra`) and
+  `developableTileQuantity` (walks lowest-first, stops at the first lightbulb),
+  NOT "filter to developable then lowest of the remainder" — that inversion was
+  the captain's bug (Pottery II/IV offered while lightbulb I sat on the mat).
+  The guard/`refusal.ts`/executor/`stagedRemovals` preview all read those
+  helpers. The Gloucester develop-bonus (`developBonus.ts`) already did this.
+  Pinned by `gameStore.develop.test.ts`, `gameStore.developmat.test.ts`,
+  `develop-mat.test.ts`, `shared/developableTiles.test.ts`.
   Wild cards route through the full build flow: wild location picks
   industry then ANY city; wild industry picks industry then a network
   city. Regression tests: `gameStore.bugfixes.test.ts`, `e2e/bugfixes.spec.ts`.

--- a/e2e/bugfixes.spec.ts
+++ b/e2e/bugfixes.spec.ts
@@ -87,14 +87,17 @@ test('develop removes TWO tiles in one action through the UI', async ({
   await page.getByTestId('action-develop').click()
   await page.locator('button.bb2-card:not([disabled])').first().click()
 
-  // Pick two different industries (iron + coal), then confirm both steps.
-  await page.getByTestId('develop-iron').click()
-  await page.getByTestId('develop-coal').click()
+  // The player mat opens as the picking surface: tap the ARMED (glowing)
+  // tile of two different industries, then confirm once.
+  await page
+    .locator('[data-develop-armed][data-testid^="mat-slot-iron"]')
+    .click()
+  await expect(page.getByTestId('develop-staged-iron')).toBeVisible()
+  await page
+    .locator('[data-develop-armed][data-testid^="mat-slot-coal"]')
+    .click()
+  await expect(page.getByTestId('develop-staged-coal')).toBeVisible()
   await page.getByTestId('confirm-action').click() // "Scrap two tiles"
-  await expect(page.getByText(/Scrapping: .*coal, iron/)).toBeVisible()
-  await page.getByTestId('confirm-action').click() // confirm step
 
-  await expect(
-    page.getByText(/Eliza developed removed 2 tiles/),
-  ).toBeVisible()
+  await expect(page.getByText(/Eliza developed removed 2 tiles/)).toBeVisible()
 })

--- a/e2e/develop-mat.spec.ts
+++ b/e2e/develop-mat.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Develop on the player mat — choosing Develop opens the mat as the picking
+ * surface: the tile a pick would scrap glows (armed), tapping it stages the
+ * scrap in the tray, tapping a lightbulb Pottery explains the rulebook block,
+ * and CANCEL unwinds without consuming the action.
+ *
+ * Fixture: ?demo — Eliza to act with a full-ish mat (iron/coal/cotton armed;
+ * her pottery 3 is a lightbulb tile).
+ */
+import { expect, test } from '@playwright/test'
+
+async function openDevelopMat(page: import('@playwright/test').Page) {
+  await page.goto('/?demo')
+  await page.getByTestId('action-develop').click()
+  await page.locator('button.bb2-card:not([disabled])').first().click()
+  // Entering the tile step auto-opens the mat in develop mode.
+  await expect(page.getByTestId('develop-mat-bar')).toBeVisible()
+}
+
+test('the mat opens on the tile step and an armed tap stages the scrap', async ({
+  page,
+}) => {
+  await openDevelopMat(page)
+
+  // Only the lowest developable tile of each track is armed.
+  const armed = page.locator('[data-develop-armed]')
+  await expect(armed.first()).toBeVisible()
+
+  await page
+    .locator('[data-develop-armed][data-testid^="mat-slot-coal"]')
+    .click()
+  await expect(page.getByTestId('develop-staged-coal')).toBeVisible()
+  await expect(page.getByTestId('confirm-action')).toBeEnabled()
+
+  // Tapping the staged tile puts it back — the tray empties, nothing spent.
+  await page.getByTestId('develop-staged-coal').click()
+  await expect(page.getByTestId('develop-staged-coal')).toHaveCount(0)
+  await expect(page.getByTestId('develop-lowest')).toBeVisible()
+})
+
+test('a lightbulb Pottery tap explains the rulebook block', async ({
+  page,
+}) => {
+  await openDevelopMat(page)
+
+  const lightbulb = page.getByTestId('mat-slot-pottery_3')
+  await lightbulb.scrollIntoViewIfNeeded()
+  await expect(lightbulb).not.toHaveAttribute('data-develop-armed', 'true')
+  await lightbulb.click()
+  await expect(page.getByTestId('develop-pick-blocked')).toContainText(
+    /lightbulb/i,
+  )
+  // Nothing staged by the rejected tap.
+  await expect(page.locator('[data-testid^="develop-staged-"]')).toHaveCount(0)
+})
+
+test('CANCEL from the mat unwinds without consuming the action', async ({
+  page,
+}) => {
+  await openDevelopMat(page)
+  const treasuries = await page
+    .locator('[data-testid="treasury"]')
+    .allTextContents()
+
+  await page
+    .locator('[data-develop-armed][data-testid^="mat-slot-iron"]')
+    .click()
+  await expect(page.getByTestId('develop-staged-iron')).toBeVisible()
+
+  // First CANCEL: back to the tile step (staged cleared)…
+  await page.getByTestId('cancel-action').click()
+  await expect(page.locator('[data-testid^="develop-staged-"]')).toHaveCount(0)
+  await expect(page.getByTestId('develop-lowest')).toBeVisible()
+
+  // …then Close the mat: the dock offers the way back in, and cancels clean.
+  await page.getByRole('button', { name: 'Close' }).click()
+  await expect(page.getByTestId('open-develop-mat')).toBeVisible()
+  await page.getByTestId('cancel-action').click() // back to the card step
+  await page.getByTestId('cancel-action').click() // back to the chooser
+  await expect(page.getByText('Choose an action')).toBeVisible()
+  await expect(page.getByText(/developed removed/)).toHaveCount(0)
+  expect(
+    await page.locator('[data-testid="treasury"]').allTextContents(),
+  ).toEqual(treasuries)
+})
+
+test('closing the mat mid-flow and reopening from the dock keeps the staging', async ({
+  page,
+}) => {
+  await openDevelopMat(page)
+  await page
+    .locator('[data-develop-armed][data-testid^="mat-slot-cotton"]')
+    .click()
+  await expect(page.getByTestId('develop-staged-cotton')).toBeVisible()
+
+  await page.getByRole('button', { name: 'Close' }).click()
+  // The dock's confirm step still knows the staged pick and reopens the mat.
+  await expect(page.getByTestId('open-develop-mat')).toBeVisible()
+  await page.getByTestId('open-develop-mat').click()
+  await expect(page.getByTestId('develop-staged-cotton')).toBeVisible()
+
+  await page.getByTestId('confirm-action').click()
+  await expect(page.getByText(/Eliza developed removed 1 tile/)).toBeVisible()
+})

--- a/e2e/locate-city.spec.ts
+++ b/e2e/locate-city.spec.ts
@@ -95,6 +95,8 @@ test('the iron-source picker locates rival works; the market locates nothing', a
     page.locator(`g[data-city="${cityId}"][data-located="true"]`),
   ).toBeVisible()
 
-  await page.getByTestId('era-plate').hover()
+  // Moving the pointer off the source (onto the mat modal's cancel button —
+  // the picker now lives inside the develop-mode mat overlay) clears the mark.
+  await page.getByTestId('cancel-action').hover()
   await expect(page.locator('g[data-located="true"]')).toHaveCount(0)
 })

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -17,7 +17,6 @@ import {
   railNetworkCostView,
 } from '~/store/market/marketActions'
 import { pendingDevelopBonusChoice } from '~/store/shared/developBonus'
-import { isDevelopable } from '~/store/shared/gameUtils'
 import {
   type BeerSource,
   type BeerSourceOption,
@@ -33,7 +32,6 @@ import {
 } from '~/store/shared/resourceSources'
 import { disabledActionReason } from './action-reason'
 import { CardChip, cardTitle } from './cards'
-import { blockedIndustries, developableIndustries } from './develop-block'
 import {
   doubleLinkDisabledReason,
   showsDoubleLinkOption,
@@ -228,6 +226,12 @@ interface ActionDockProps {
   legalSiteCount?: number | null
   /** Undo the first action of this turn (null = not available). */
   onUndo?: (() => void) | null
+  /**
+   * Develop picks tiles ON THE PLAYER MAT (the ledger modal). While the modal
+   * is open it owns the whole develop UI — the dock steps down to a pointer so
+   * the modal's confirm/cancel/iron controls stay the only ones on screen.
+   */
+  developMat?: { open: boolean; onOpen: () => void } | null
 }
 
 /* ----- hand-selection contract for the shell / HandTray ----- */
@@ -290,130 +294,6 @@ export function getHandSelection(
       return { hint: `Holding ${cardTitle(held)}`, selectedIds: [held.id] }
   }
   return null
-}
-
-/* ----- develop tile picker ----- */
-
-/**
- * Rules: a Develop action removes ONE or TWO tiles (1 iron each). Clicking
- * an industry cycles its count 0 → 1 → 2 → 0, capped at two tiles total
- * (the same industry may be picked twice — successive levels).
- */
-function DevelopTilePicker({
-  currentPlayer,
-  onCancel,
-  onPick,
-  onLowest,
-  held,
-}: {
-  currentPlayer: Player
-  onCancel: () => void
-  onPick: (types: IndustryType[]) => void
-  onLowest: () => void
-  held?: Card | null
-}) {
-  const [counts, setCounts] = useState<Partial<Record<IndustryType, number>>>(
-    {},
-  )
-  const developable = developableIndustries(currentPlayer.industryTilesOnMat)
-  const blocked = blockedIndustries(currentPlayer.industryTilesOnMat)
-  const available = (t: IndustryType) =>
-    (currentPlayer.industryTilesOnMat[t] || [])
-      .filter((tw) => isDevelopable(tw.tile))
-      .reduce((n, tw) => n + tw.quantityAvailable, 0)
-  const total = Object.values(counts).reduce((a, b) => a + (b ?? 0), 0)
-  const selection = developable.flatMap((t) =>
-    Array.from({ length: counts[t] ?? 0 }, () => t),
-  )
-
-  const cycle = (t: IndustryType) =>
-    setCounts((prev) => {
-      const current = prev[t] ?? 0
-      const others = total - current
-      const max = Math.min(2 - others, available(t))
-      const next = current >= max ? 0 : current + 1
-      return { ...prev, [t]: next }
-    })
-
-  return (
-    <Flow
-      action="Develop"
-      steps={['Card', 'Tiles', 'Confirm']}
-      active={1}
-      onCancel={onCancel}
-      held={held}
-    >
-      <Note>
-        Scrap one or <b>two</b> tiles from your mat — each consumes 1 iron. Tap
-        an industry again for a second tile of the same kind.
-      </Note>
-      <div className="grid grid-cols-3 gap-2">
-        {developable.map((t) => {
-          const n = counts[t] ?? 0
-          return (
-            <button
-              key={t}
-              type="button"
-              className="bb2-option relative flex-col !items-center gap-1.5 py-2.5"
-              data-selected={n > 0}
-              data-testid={`develop-${t}`}
-              onClick={() => cycle(t)}
-            >
-              <IndustryChip type={t} size={20} />
-              <span className="text-[10.5px] font-semibold uppercase tracking-[0.1em]">
-                {t === 'manufacturer' ? 'Goods' : t}
-              </span>
-              {n > 0 && (
-                <span
-                  className="absolute right-1.5 top-1.5 rounded-full px-1.5 text-[10px] font-bold"
-                  style={{
-                    background: 'var(--bb-brass)',
-                    color: '#241a08',
-                  }}
-                >
-                  ×{n}
-                </span>
-              )}
-            </button>
-          )
-        })}
-      </div>
-      {blocked.map(({ type, reason }) => (
-        <div key={type} className="flex flex-col gap-1">
-          <button
-            type="button"
-            className="bb2-option relative flex-col !items-center gap-1.5 py-2.5"
-            data-testid={`develop-blocked-${type}`}
-            disabled
-            title={reason}
-          >
-            <IndustryChip type={type} size={20} />
-            <span className="text-[10.5px] font-semibold uppercase tracking-[0.1em]">
-              {type === 'manufacturer' ? 'Goods' : type}
-            </span>
-          </button>
-          <p
-            className="text-[12.5px] leading-snug"
-            data-testid={`develop-blocked-reason-${type}`}
-            style={{ color: '#d68d80' }}
-          >
-            {reason}
-          </p>
-        </div>
-      ))}
-      <Confirm disabled={total === 0} onClick={() => onPick(selection)}>
-        Scrap {total === 2 ? 'two tiles' : total === 1 ? 'one tile' : 'tiles'}
-      </Confirm>
-      <button
-        type="button"
-        className="bb2-ghost-btn"
-        data-testid="develop-lowest"
-        onClick={onLowest}
-      >
-        Develop lowest available
-      </button>
-    </Flow>
-  )
 }
 
 /* ----- beer source picker ----- */
@@ -580,7 +460,7 @@ function ironSourceCaption(option: IronSourceOption): string {
  * not bookkeeping. Left untouched, the engine picks as it always has (works
  * in turn, then the market).
  */
-function IronSourcePicker({
+export function IronSourcePicker({
   options,
   required,
   picks,
@@ -820,6 +700,30 @@ function Flow({
   )
 }
 
+/**
+ * Shown while the develop-mode mat modal is open: the modal owns every
+ * control (confirm, cancel, iron picker), so the dock must not render its own
+ * — duplicate testids/controls behind an overlay would be unreachable anyway.
+ */
+function DevelopOnMatAside() {
+  return (
+    <div className="flex flex-col gap-2" data-testid="develop-on-mat">
+      <span
+        className="bb2-display text-[22px] font-bold leading-none"
+        style={{ color: 'var(--bb-brass-bright)' }}
+      >
+        Develop
+      </span>
+      <p
+        className="text-[14px] leading-relaxed"
+        style={{ color: 'rgba(231,215,177,.7)' }}
+      >
+        Picking tiles on your player mat…
+      </p>
+    </div>
+  )
+}
+
 function Note({ children }: { children: React.ReactNode }) {
   return (
     <p
@@ -988,6 +892,7 @@ export function ActionDock({
   actionsLeft = null,
   legalSiteCount = null,
   onUndo = null,
+  developMat = null,
 }: ActionDockProps) {
   const is = (path: string) => snapshot.matches(path as never)
   const can = (event: GameEvent) => snapshot.can(event)
@@ -1324,6 +1229,9 @@ export function ActionDock({
     is('playing.action.building.choosingIronSource') ||
     is('playing.action.developing.choosingIronSource')
   ) {
+    // A develop's iron question is asked INSIDE the open mat modal.
+    if (is('playing.action.developing.choosingIronSource') && developMat?.open)
+      return <DevelopOnMatAside />
     const choice = pendingIronChoice(c)
     const building = is('playing.action.building.choosingIronSource')
     return (
@@ -1579,19 +1487,45 @@ export function ActionDock({
     )
   }
   if (is('playing.action.developing.selectingTiles')) {
+    // The player mat IS the tile picker. While the modal is open the dock
+    // only points at it; when the player closed the modal mid-flow, the dock
+    // offers the way back in (plus the one-tap lowest shortcut and cancel).
+    if (developMat?.open) return <DevelopOnMatAside />
     return (
-      <DevelopTilePicker
-        currentPlayer={currentPlayer}
+      <Flow
+        action="Develop"
+        steps={devSteps}
+        active={1}
         onCancel={cancel}
-        onPick={(types) =>
-          send({ type: 'SELECT_TILES_FOR_DEVELOP', industryTypes: types })
-        }
-        onLowest={() => send({ type: 'CONFIRM' })}
         held={c.selectedCard}
-      />
+      >
+        <Note>
+          Scrap one or <b>two</b> tiles straight off your player mat — each
+          consumes 1 iron.
+        </Note>
+        {developMat && (
+          <button
+            type="button"
+            className="bb2-confirm"
+            data-testid="open-develop-mat"
+            onClick={developMat.onOpen}
+          >
+            Open your mat
+          </button>
+        )}
+        <button
+          type="button"
+          className="bb2-ghost-btn"
+          data-testid="develop-lowest"
+          onClick={() => send({ type: 'CONFIRM' })}
+        >
+          Develop lowest available
+        </button>
+      </Flow>
     )
   }
   if (is('playing.action.developing.confirmingDevelop')) {
+    if (developMat?.open) return <DevelopOnMatAside />
     return (
       <Flow
         action="Develop"
@@ -1607,6 +1541,16 @@ export function ActionDock({
           </b>{' '}
           — consumes iron.
         </Note>
+        {developMat && (
+          <button
+            type="button"
+            className="bb2-ghost-btn"
+            data-testid="open-develop-mat"
+            onClick={developMat.onOpen}
+          >
+            Back to the mat
+          </button>
+        )}
         <Confirm
           disabled={!can({ type: 'CONFIRM' })}
           onClick={() => send({ type: 'CONFIRM' })}

--- a/src/components/develop-block.ts
+++ b/src/components/develop-block.ts
@@ -9,20 +9,17 @@
 // EXPLAINS the block.
 import { type IndustryType, industryDisplayName } from '~/data/cards'
 import type { IndustryTileWithQuantity } from '~/data/industryTiles'
-import { isDevelopable } from '~/store/shared/gameUtils'
+import {
+  POTTERY_LIGHTBULB_REASON,
+  isDevelopable,
+} from '~/store/shared/gameUtils'
+
+export { POTTERY_LIGHTBULB_REASON }
 
 /** The player's mat, keyed by industry — the shape `Player.industryTilesOnMat`. */
 export type IndustryMat = Partial<
   Record<IndustryType, IndustryTileWithQuantity[]>
 >
-
-/**
- * Rulebook p.7, "Potteries and the Lightbulb Icon": the lightbulb Pottery
- * tiles (levels 1 and 3) may never be developed — they leave the mat only when
- * built over, and block the higher Pottery levels until they do.
- */
-export const POTTERY_LIGHTBULB_REASON =
-  'Pottery cannot be developed — the lightbulb tiles are removed only by building over them, which then unlocks the higher Pottery levels (rulebook p.7).'
 
 /** Tiles of this industry still on the mat (quantity remaining). */
 function heldTiles(

--- a/src/components/develop-mat.test.ts
+++ b/src/components/develop-mat.test.ts
@@ -188,14 +188,19 @@ describe('stagedRemovals — the preview of which tiles peel off', () => {
     ])
   })
 
-  test('lightbulb pottery is skipped — the pick lands on the level 2', () => {
-    expect(stagedRemovals(mat, ['pottery'])).toEqual([
-      { type: 'pottery', tileId: 'pottery_2', level: 2 },
-    ])
+  test('a lightbulb-lowest pottery track previews NO removal (never skips up)', () => {
+    // pottery_1 (lightbulb) is the lowest tile → the whole track is off-limits
+    // to Develop until it is built away. Peeling pottery_2 past it was the bug.
+    expect(stagedRemovals(mat, ['pottery'])).toEqual([])
   })
 
-  test('quantity is respected: a second pick of the same tile id needs stock', () => {
-    expect(stagedRemovals(mat, ['pottery', 'pottery'])).toEqual([
+  test('once the lightbulb bottom is gone, the pick lands on the new lowest', () => {
+    const built = {
+      pottery: mat.pottery.map((t) =>
+        t.tile.id === 'pottery_1' ? { ...t, quantityAvailable: 0 } : t,
+      ),
+    }
+    expect(stagedRemovals(built, ['pottery'])).toEqual([
       { type: 'pottery', tileId: 'pottery_2', level: 2 },
     ])
   })

--- a/src/components/develop-mat.test.ts
+++ b/src/components/develop-mat.test.ts
@@ -1,0 +1,202 @@
+// The develop-mode mat view — machine-driven, no DOM (vitest runs node env).
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import { gameStore } from '~/store/gameStore'
+import { developMatView, stagedRemovals } from './develop-mat'
+
+let activeActors: ReturnType<typeof createActor>[] = []
+
+afterEach(() => {
+  activeActors.forEach((actor) => {
+    try {
+      actor.stop()
+    } catch {
+      // Ignore errors during cleanup
+    }
+  })
+  activeActors = []
+})
+
+const setupGame = () => {
+  const actor = createActor(gameStore)
+  activeActors.push(actor)
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: [
+      {
+        id: '1',
+        name: 'Player 1',
+        color: 'red' as const,
+        character: 'Richard Arkwright' as const,
+        money: 17,
+        victoryPoints: 0,
+        income: 10,
+        industryTilesOnMat: {} as never,
+      },
+      {
+        id: '2',
+        name: 'Player 2',
+        color: 'blue' as const,
+        character: 'Eliza Tinsley' as const,
+        money: 17,
+        victoryPoints: 0,
+        income: 10,
+        industryTilesOnMat: {} as never,
+      },
+    ],
+  })
+  return actor
+}
+
+const snap = (actor: ReturnType<typeof createActor>) =>
+  actor.getSnapshot() as never as Parameters<typeof developMatView>[0]
+
+const enterTileStep = (actor: ReturnType<typeof createActor>) => {
+  const s = actor.getSnapshot() as never as Parameters<typeof developMatView>[0]
+  const card = s.context.players[s.context.currentPlayerIndex]!.hand[0]!
+  actor.send({ type: 'DEVELOP' })
+  actor.send({ type: 'SELECT_CARD', cardId: card.id })
+}
+
+describe('developMatView', () => {
+  test('null outside the develop tile steps', () => {
+    const actor = setupGame()
+    expect(developMatView(snap(actor))).toBeNull()
+    actor.send({ type: 'DEVELOP' })
+    // Card step: the hand tray is the surface, not the mat.
+    expect(developMatView(snap(actor))).toBeNull()
+  })
+
+  test('tile step: picks delegate to the guard, events carry staged + one', () => {
+    const actor = setupGame()
+    enterTileStep(actor)
+    const view = developMatView(snap(actor))!
+    expect(view.step).toBe('tiles')
+    expect(view.staged).toEqual([])
+    expect(view.canPick('coal')).toBe(true)
+    expect(view.pickEvent('coal')).toEqual({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['coal'],
+    })
+  })
+
+  test('a staged pick grows the next pick event; unstaging the last is a CANCEL', () => {
+    const actor = setupGame()
+    enterTileStep(actor)
+    actor.send({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['coal'],
+    })
+    // No iron works on a fresh board — the iron step auto-skips to confirm.
+    const view = developMatView(snap(actor))!
+    expect(view.step).toBe('confirm')
+    expect(view.staged).toEqual(['coal'])
+    expect(view.pickEvent('iron')).toEqual({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['coal', 'iron'],
+    })
+    expect(view.unstageEvent(0)).toEqual({ type: 'CANCEL' })
+    expect(view.canConfirm).toBe(true)
+
+    actor.send({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['coal', 'iron'],
+    })
+    const two = developMatView(snap(actor))!
+    expect(two.staged).toEqual(['coal', 'iron'])
+    // A third pick is refused by the machine, with the engine's reason.
+    expect(two.canPick('cotton')).toBe(false)
+    expect(two.pickReason('cotton')).toMatch(/at most two/i)
+    expect(two.unstageEvent(1)).toEqual({
+      type: 'SELECT_TILES_FOR_DEVELOP',
+      industryTypes: ['coal'],
+    })
+  })
+
+  test('a lightbulb-only pottery track is refused with the rulebook reason', () => {
+    const actor = setupGame()
+    const s0 = snap(actor)
+    const idx = s0.context.currentPlayerIndex
+    const mat = s0.context.players[idx]!.industryTilesOnMat
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx,
+      industryTilesOnMat: {
+        ...mat,
+        pottery: (mat.pottery ?? []).filter(
+          (t: { tile: { hasLightbulbIcon: boolean } }) =>
+            t.tile.hasLightbulbIcon,
+        ),
+      },
+    } as never)
+    enterTileStep(actor)
+    const view = developMatView(snap(actor))!
+    expect(view.canPick('pottery')).toBe(false)
+    expect(view.pickReason('pottery')).toMatch(/lightbulb/i)
+  })
+})
+
+describe('stagedRemovals — the preview of which tiles peel off', () => {
+  const mat = {
+    coal: [
+      {
+        tile: {
+          id: 'coal_1',
+          level: 1,
+          type: 'coal' as const,
+          hasLightbulbIcon: false,
+        },
+        quantityAvailable: 1,
+      },
+      {
+        tile: {
+          id: 'coal_2',
+          level: 2,
+          type: 'coal' as const,
+          hasLightbulbIcon: false,
+        },
+        quantityAvailable: 2,
+      },
+    ],
+    pottery: [
+      {
+        tile: {
+          id: 'pottery_1',
+          level: 1,
+          type: 'pottery' as const,
+          hasLightbulbIcon: true,
+        },
+        quantityAvailable: 1,
+      },
+      {
+        tile: {
+          id: 'pottery_2',
+          level: 2,
+          type: 'pottery' as const,
+          hasLightbulbIcon: false,
+        },
+        quantityAvailable: 1,
+      },
+    ],
+  }
+
+  test('two picks of one track walk up the levels, lowest first', () => {
+    expect(stagedRemovals(mat, ['coal', 'coal'])).toEqual([
+      { type: 'coal', tileId: 'coal_1', level: 1 },
+      { type: 'coal', tileId: 'coal_2', level: 2 },
+    ])
+  })
+
+  test('lightbulb pottery is skipped — the pick lands on the level 2', () => {
+    expect(stagedRemovals(mat, ['pottery'])).toEqual([
+      { type: 'pottery', tileId: 'pottery_2', level: 2 },
+    ])
+  })
+
+  test('quantity is respected: a second pick of the same tile id needs stock', () => {
+    expect(stagedRemovals(mat, ['pottery', 'pottery'])).toEqual([
+      { type: 'pottery', tileId: 'pottery_2', level: 2 },
+    ])
+  })
+})

--- a/src/components/develop-mat.ts
+++ b/src/components/develop-mat.ts
@@ -131,16 +131,15 @@ export function stagedRemovals(
     level: number
   }> = []
   for (const type of staged) {
-    const next = [...(mat[type] ?? [])]
+    // The TRUE lowest tile still on the mat is the only removal target — a
+    // lightbulb-lowest track scraps nothing (never skip up to a higher tile).
+    // Mirrors the executor's getDevelopableTileOnMat exactly.
+    const lowest = [...(mat[type] ?? [])]
       .sort((a, b) => a.tile.level - b.tile.level)
-      .find(
-        (t) =>
-          isDevelopable(t.tile) &&
-          t.quantityAvailable - (taken.get(t.tile.id) ?? 0) > 0,
-      )
-    if (!next) continue
-    taken.set(next.tile.id, (taken.get(next.tile.id) ?? 0) + 1)
-    removals.push({ type, tileId: next.tile.id, level: next.tile.level })
+      .find((t) => t.quantityAvailable - (taken.get(t.tile.id) ?? 0) > 0)
+    if (!lowest || !isDevelopable(lowest.tile)) continue
+    taken.set(lowest.tile.id, (taken.get(lowest.tile.id) ?? 0) + 1)
+    removals.push({ type, tileId: lowest.tile.id, level: lowest.tile.level })
   }
   return removals
 }

--- a/src/components/develop-mat.ts
+++ b/src/components/develop-mat.ts
@@ -1,0 +1,146 @@
+// The player mat as the Develop picking surface — the machine-facing half.
+//
+// When the machine sits in any `developing` tile step, both surfaces
+// (`game.tsx` hotseat and `mp/mp-game.tsx`) open the PlayerLedger in develop
+// mode and drive it from THIS view: which industries a mat click may pick,
+// which exact tile a pick would peel off, and what event each interaction
+// sends. Legality is never re-derived here — `canPick` asks the machine's own
+// `canSelectTilesForDevelop` guard via `can()`, and a rejected pick is
+// explained by `explainRefusal` (engine-owned legality, AGENTS.md).
+import type { IndustryType } from '~/data/cards'
+import type { GameEvent, GameStoreSnapshot } from '~/store/gameStore'
+import { isDevelopable } from '~/store/shared/gameUtils'
+import {
+  type IronChoice,
+  type IronSource,
+  pendingIronChoice,
+} from '~/store/shared/resourceSources'
+import { disabledActionReason } from './action-reason'
+
+export type DevelopStep = 'tiles' | 'iron' | 'confirm'
+
+/** The mat shape `Player.industryTilesOnMat` holds. */
+type IndustryMat = Partial<
+  Record<
+    IndustryType,
+    Array<{
+      tile: {
+        id: string
+        level: number
+        type: IndustryType
+        hasLightbulbIcon: boolean
+      }
+      quantityAvailable: number
+    }>
+  >
+>
+
+export interface DevelopMatView {
+  /** Which develop step the machine is on. */
+  step: DevelopStep
+  /** Tiles already staged for this develop, straight from machine context. */
+  staged: IndustryType[]
+  /** May a mat click add one more tile of this industry? Asks `can()`. */
+  canPick: (type: IndustryType) => boolean
+  /** The engine's reason a pick of this industry is refused. */
+  pickReason: (type: IndustryType) => string
+  /** The event a mat click sends: the staged picks plus one more. */
+  pickEvent: (type: IndustryType) => GameEvent
+  /**
+   * The event that removes one staged pick: a smaller re-pick, or a CANCEL
+   * back to the tile step when the last staged tile is returned.
+   */
+  unstageEvent: (index: number) => GameEvent
+  /** The open iron question, when the machine stopped to ask it. */
+  ironChoice: IronChoice | null
+  /** Iron sources already assigned this flow (feeds the picker's ×N tags). */
+  ironPicks: IronSource[]
+  /** CONFIRM legality + the engine's reason when refused. */
+  canConfirm: boolean
+  confirmReason: string
+}
+
+/**
+ * The develop-mode view of the machine, or null when the machine is not on a
+ * develop tile step (the card step keeps the hand tray as its surface).
+ */
+export function developMatView(
+  snapshot: GameStoreSnapshot,
+): DevelopMatView | null {
+  const at = (path: string) => snapshot.matches(path as never)
+  const step: DevelopStep | null = at(
+    'playing.action.developing.selectingTiles',
+  )
+    ? 'tiles'
+    : at('playing.action.developing.choosingIronSource')
+      ? 'iron'
+      : at('playing.action.developing.confirmingDevelop')
+        ? 'confirm'
+        : null
+  if (step === null) return null
+
+  const staged = snapshot.context.selectedTilesForDevelop
+  const pickEvent = (type: IndustryType): GameEvent => ({
+    type: 'SELECT_TILES_FOR_DEVELOP',
+    industryTypes: [...staged, type],
+  })
+
+  return {
+    step,
+    staged,
+    canPick: (type) => snapshot.can(pickEvent(type) as never),
+    pickReason: (type) =>
+      disabledActionReason(
+        snapshot,
+        pickEvent(type),
+        'That tile cannot be developed right now.',
+      ),
+    pickEvent,
+    unstageEvent: (index) => {
+      const rest = staged.filter((_, i) => i !== index)
+      return rest.length > 0
+        ? { type: 'SELECT_TILES_FOR_DEVELOP', industryTypes: rest }
+        : { type: 'CANCEL' }
+    },
+    ironChoice: step === 'iron' ? pendingIronChoice(snapshot.context) : null,
+    ironPicks: snapshot.context.chosenIronSources ?? [],
+    canConfirm: snapshot.can({ type: 'CONFIRM' } as never),
+    confirmReason: disabledActionReason(
+      snapshot,
+      { type: 'CONFIRM' },
+      'This develop cannot be completed.',
+    ),
+  }
+}
+
+/**
+ * Which exact tiles the staged picks would peel off the mat, in pick order —
+ * the presentation preview the ledger animates. Mirrors the executor
+ * (`executeDevelopAction`): each pick scraps the LOWEST developable tile of
+ * its track, counting earlier staged picks as already gone. Preview only;
+ * legality stays with the guard.
+ */
+export function stagedRemovals(
+  mat: IndustryMat,
+  staged: IndustryType[],
+): Array<{ type: IndustryType; tileId: string; level: number }> {
+  const taken = new Map<string, number>()
+  const removals: Array<{
+    type: IndustryType
+    tileId: string
+    level: number
+  }> = []
+  for (const type of staged) {
+    const next = [...(mat[type] ?? [])]
+      .sort((a, b) => a.tile.level - b.tile.level)
+      .find(
+        (t) =>
+          isDevelopable(t.tile) &&
+          t.quantityAvailable - (taken.get(t.tile.id) ?? 0) > 0,
+      )
+    if (!next) continue
+    taken.set(next.tile.id, (taken.get(next.tile.id) ?? 0) + 1)
+    removals.push({ type, tileId: next.tile.id, level: next.tile.level })
+  }
+  return removals
+}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -41,6 +41,7 @@ import {
 } from './action-dock'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from './board/board-map'
 import { demoSnapshot } from './demo/demo-snapshot'
+import { developMatView } from './develop-mat'
 import { demoSnapshotBeerChoice } from './demo/demo-snapshot-beer-choice'
 import { demoSnapshotDoubleBeer } from './demo/demo-snapshot-double-beer'
 import { demoSnapshotEraEnd } from './demo/demo-snapshot-era-end'
@@ -434,6 +435,10 @@ function GameInner({
   )
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
   const [incomeTrackOpen, setIncomeTrackOpen] = useState(false)
+  // Develop picks its tiles ON the player mat: entering the develop tile
+  // steps opens the ledger in develop mode (closable — the dock then offers
+  // the way back in), leaving them closes it.
+  const [developMatOpen, setDevelopMatOpen] = useState(false)
   const [panelCollapsed, togglePanel] = usePanelCollapsed()
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
   // Hover-a-name spotlight: the player whose rail mat is hovered/focused right
@@ -495,17 +500,38 @@ function GameInner({
 
   const is = (path: string) => state.matches(path as never)
 
+  // The machine-facing develop-mode view (null outside the tile steps).
+  const devView = developMatView(state as GameStoreSnapshot)
+  const inDevelopTileSteps = devView !== null
+  useEffect(() => {
+    setDevelopMatOpen(inDevelopTileSteps)
+  }, [inDevelopTileSteps])
+
   // Escape unwinds the in-flight action exactly like the Cancel button.
-  // An open ledger swallows the keypress — PlayerLedger closes itself.
+  // An open ledger swallows the keypress — PlayerLedger closes itself
+  // (in develop mode too: Escape shuts the mat, the flow stays put).
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || ledgerFor || incomeTrackOpen) return
+      if (
+        e.key !== 'Escape' ||
+        ledgerFor ||
+        incomeTrackOpen ||
+        (inDevelopTileSteps && developMatOpen)
+      )
+        return
       const snap = actorRef.getSnapshot()
       if (snap.can({ type: 'CANCEL' })) send({ type: 'CANCEL' })
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [ledgerFor, incomeTrackOpen, actorRef, send])
+  }, [
+    ledgerFor,
+    incomeTrackOpen,
+    inDevelopTileSteps,
+    developMatOpen,
+    actorRef,
+    send,
+  ])
 
   // ---------- undo (first action of the turn, hotseat) ----------
   // Snapshot the machine when a player's turn begins; while they still
@@ -974,11 +1000,23 @@ function GameInner({
                       pickingSite ? (legalCities?.size ?? 0) : null
                     }
                     onUndo={canUndo ? onUndo : null}
+                    developMat={
+                      devView
+                        ? {
+                            open: developMatOpen,
+                            onOpen: () => setDevelopMatOpen(true),
+                          }
+                        : null
+                    }
                   />
                 )}
                 {!needsReveal && (
                   <OpenMatButton
-                    onClick={() => setLedgerFor(currentPlayer.id)}
+                    onClick={() =>
+                      devView
+                        ? setDevelopMatOpen(true)
+                        : setLedgerFor(currentPlayer.id)
+                    }
                   />
                 )}
               </div>
@@ -1009,7 +1047,18 @@ function GameInner({
         )}
 
         {/* ---------- overlays ---------- */}
-        {ledgerPlayer && (
+        {/* Develop mode: the mat IS the tile picker. Takes the modal slot —
+            a plain ledger view never stacks on top of it. */}
+        {devView && developMatOpen && !needsReveal && (
+          <PlayerLedger
+            player={currentPlayer}
+            era={ctx.era}
+            isCurrent
+            onClose={() => setDevelopMatOpen(false)}
+            develop={{ view: devView, send }}
+          />
+        )}
+        {ledgerPlayer && !(devView && developMatOpen) && (
           <PlayerLedger
             player={ledgerPlayer}
             era={ctx.era}

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -22,6 +22,7 @@ import {
 import { explainRefusal } from '~/store/refusal'
 import { refreshEmbeddedTileStats } from '~/store/saveMigration'
 import { ActionDock, SELLABLE, getHandSelection } from '../action-dock'
+import { developMatView } from '../develop-mat'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
 import { HandTray } from '../hand-tray'
 import { computeHoverCities, focusCityFor } from '../hover-highlight'
@@ -910,6 +911,9 @@ function MpTable({
   applyView: (view: GameViewWire) => void
 }) {
   const [ledgerFor, setLedgerFor] = useState<string | null>(null)
+  // Develop-mode mat modal (see devView below) — open while the machine sits
+  // on a develop tile step of MY turn; closable, the dock reopens it.
+  const [developMatOpen, setDevelopMatOpen] = useState(false)
   const [panelCollapsed, togglePanel] = usePanelCollapsed()
   const [hoveredCard, setHoveredCard] = useState<Card | null>(null)
   // Hover-a-name spotlight: the player whose rail mat is hovered/focused right
@@ -989,6 +993,15 @@ function MpTable({
   const myTurn = !!ctx && ctx.currentPlayerIndex === you
   const currentPlayer: Player | undefined = ctx?.players[ctx.currentPlayerIndex]
   const me: Player | undefined = ctx?.players[you]
+
+  // Develop picks its tiles ON the player mat. The machine's state value is
+  // shared with every seat, so gate HARD on it being MY turn — a rival's
+  // develop must never open my mat.
+  const devView = state && myTurn ? developMatView(state) : null
+  const inDevelopTileSteps = devView !== null
+  useEffect(() => {
+    setDevelopMatOpen(inDevelopTileSteps)
+  }, [inDevelopTileSteps])
 
   // Surface engine errors from my own confirmed actions, then clear them.
   useEffect(() => {
@@ -1386,6 +1399,14 @@ function MpTable({
                       remaining: ctx.actionsRemaining,
                       max: maxActions,
                     }}
+                    developMat={
+                      devView
+                        ? {
+                            open: developMatOpen,
+                            onOpen: () => setDevelopMatOpen(true),
+                          }
+                        : null
+                    }
                   />
                 ) : aiTurn ? (
                   <div className="flex flex-col gap-2" data-testid="ai-panel">
@@ -1449,7 +1470,13 @@ function MpTable({
                   </div>
                 )}
                 {/* Always yours, never the seat that happens to be acting. */}
-                {me && <OpenMatButton onClick={() => setLedgerFor(me.id)} />}
+                {me && (
+                  <OpenMatButton
+                    onClick={() =>
+                      devView ? setDevelopMatOpen(true) : setLedgerFor(me.id)
+                    }
+                  />
+                )}
               </div>
               {view.ai && <AiMindPanel ai={view.ai} seats={view.seats} />}
               <MarketsPanel
@@ -1506,7 +1533,17 @@ function MpTable({
           panelCollapsed={panelCollapsed}
         />
 
-        {ledgerPlayer && (
+        {/* Develop mode: my mat as the tile picker (my turn only). */}
+        {devView && developMatOpen && me && (
+          <PlayerLedger
+            player={me}
+            era={ctx.era}
+            isCurrent
+            onClose={() => setDevelopMatOpen(false)}
+            develop={{ view: devView, send: send as never, busy: inFlight }}
+          />
+        )}
+        {ledgerPlayer && !(devView && developMatOpen) && (
           <PlayerLedger
             player={ledgerPlayer}
             era={ctx.era}

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -8,15 +8,22 @@
 // tile art. The per-tile facts (cost, resources, VP, income, links, beer,
 // develop) live in a docked readout that follows the highlighted tile —
 // progressive disclosure keeps the mat a clean, board-faithful overview.
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { type IndustryType } from '~/data/cards'
 import {
   canBuildTileInEra,
   getBuildableTileInEra,
   type IndustryTile,
 } from '~/data/industryTiles'
-import { type Player } from '~/store/gameStore'
+import { type GameEvent, type Player } from '~/store/gameStore'
+import {
+  POTTERY_LIGHTBULB_REASON,
+  isDevelopable,
+} from '~/store/shared/gameUtils'
+import { IronSourcePicker } from './action-dock'
 import { INDUSTRY_FILL, INDUSTRY_INK, PLAYER_FILL } from './board/board-map'
+import { type DevelopMatView, stagedRemovals } from './develop-mat'
 import {
   BeerSteinIcon,
   CanalIcon,
@@ -282,15 +289,23 @@ function LinkIcons({ n }: { n: number }) {
 }
 
 // One slot in an industry track: a tile, or an empty placeholder for a
-// depleted level. Tapping/hovering a tile drives the docked readout.
+// depleted level. Tapping/hovering a tile drives the docked readout. In
+// develop mode the ARMED tile (the one a pick would scrap) smoulders brass
+// and a tap peels it off; tapping any other tile explains why not.
 function TrackSlot({
   entry,
   selected,
   onSelect,
+  develop,
 }: {
   entry: SlotEntry
   selected: boolean
   onSelect: () => void
+  develop?: {
+    armed: boolean
+    onPick: (el: HTMLButtonElement) => void
+    onBlocked: () => void
+  } | null
 }) {
   if (entry.kind === 'empty') {
     return (
@@ -311,11 +326,25 @@ function TrackSlot({
       type="button"
       data-testid={`mat-slot-${tile.id}`}
       data-depth={count}
+      data-develop-armed={develop?.armed || undefined}
       aria-pressed={selected}
-      onClick={onSelect}
+      aria-label={
+        develop?.armed
+          ? `Scrap ${LABEL[tile.type]} ${ROMAN[tile.level] ?? tile.level}`
+          : undefined
+      }
+      onClick={(e) => {
+        onSelect()
+        if (develop) {
+          if (develop.armed) develop.onPick(e.currentTarget)
+          else develop.onBlocked()
+        }
+      }}
       onMouseEnter={onSelect}
       onFocus={onSelect}
-      className="relative shrink-0 rounded-md transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus:outline-none"
+      className={`relative shrink-0 rounded-md transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus:outline-none ${
+        develop?.armed ? 'bb2-develop-armed hover:-translate-y-1' : ''
+      }`}
       style={{ opacity: barred ? 0.42 : 1 }}
     >
       {/* Remaining quantity is the STACK itself — layered tile edges under
@@ -354,16 +383,55 @@ interface TileSlot {
 }
 type SlotEntry = TileSlot | { kind: 'empty'; level: number }
 
+/** What the surfaces hand the ledger to turn it into the Develop surface. */
+export interface DevelopMatProps {
+  view: DevelopMatView
+  send: (event: GameEvent) => void
+  /** An intent is on the wire (multiplayer) — swallow clicks meanwhile. */
+  busy?: boolean
+}
+
+/** A scrapped tile mid-flight from its pile to the tray (rects at click). */
+interface TileFlight {
+  key: number
+  type: IndustryType
+  tile: IndustryTile
+  from: { x: number; y: number; width: number }
+  to: { x: number; y: number }
+  /** The tray index this tile will occupy once the machine confirms it. */
+  targetIndex: number
+}
+
+let flightKey = 0
+
+/** The full tile a pick of this industry would scrap — the flyer's face. */
+function removalTile(
+  player: Player,
+  type: IndustryType,
+  staged: IndustryType[],
+): IndustryTile {
+  const next = stagedRemovals(player.industryTilesOnMat, [...staged, type])
+  const id = next[next.length - 1]?.tileId
+  const rows = player.industryTilesOnMat[type] ?? []
+  return (rows.find((r) => r.tile.id === id) ?? rows[0])!.tile
+}
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false)
+
 export function PlayerLedger({
   player,
   era,
   isCurrent,
   onClose,
+  develop = null,
 }: {
   player: Player
   era: 'canal' | 'rail'
   isCurrent: boolean
   onClose: () => void
+  develop?: DevelopMatProps | null
 }) {
   // Escape closes the ledger — promised by the a11y note on the backdrop.
   useEffect(() => {
@@ -374,15 +442,127 @@ export function PlayerLedger({
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onClose])
 
+  /* ----- develop mode: staged preview, armed tiles, flights, notices ----- */
+
+  const view = develop?.view ?? null
+  // Which exact tiles the staged picks peel off — drives BOTH the thinner
+  // piles (preview mat) and the scrap tray. Presentation preview only; every
+  // legality answer comes from the machine via the view.
+  const removals = useMemo(
+    () =>
+      view
+        ? stagedRemovals(player.industryTilesOnMat, view.staged).map((r) => ({
+            ...r,
+            tile: (player.industryTilesOnMat[r.type] ?? []).find(
+              (row) => row.tile.id === r.tileId,
+            )?.tile,
+          }))
+        : [],
+    [view, player.industryTilesOnMat],
+  )
+  const removedByTileId = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const r of removals) m.set(r.tileId, (m.get(r.tileId) ?? 0) + 1)
+    return m
+  }, [removals])
+  // The tile a pick of each industry would scrap NEXT (null = not pickable).
+  const armedTileIds = useMemo(() => {
+    if (!view) return new Map<IndustryType, string>()
+    const m = new Map<IndustryType, string>()
+    for (const type of INDUSTRY_TYPES) {
+      if (!view.canPick(type)) continue
+      const next = stagedRemovals(player.industryTilesOnMat, [
+        ...view.staged,
+        type,
+      ])
+      if (next.length === view.staged.length + 1) {
+        m.set(type, next[next.length - 1]!.tileId)
+      }
+    }
+    return m
+  }, [view, player.industryTilesOnMat])
+
+  const trayRef = useRef<HTMLDivElement | null>(null)
+  const [flights, setFlights] = useState<TileFlight[]>([])
+  const [landedTray, setLandedTray] = useState<ReadonlySet<number>>(new Set())
+  const [notice, setNotice] = useState<string | null>(null)
+  // A rejected tap's reason lingers briefly, then clears itself.
+  useEffect(() => {
+    if (notice === null) return
+    const t = setTimeout(() => setNotice(null), 5000)
+    return () => clearTimeout(t)
+  }, [notice])
+  // Leaving develop mode (confirm, cancel, close) drops any leftover motion.
+  useEffect(() => {
+    if (!view) {
+      setFlights([])
+      setLandedTray(new Set())
+      setNotice(null)
+    }
+  }, [view])
+
+  const pickTile = (type: IndustryType, el: HTMLButtonElement) => {
+    if (!develop || !view) return
+    if (develop.busy) return
+    if (!view.canPick(type)) {
+      setNotice(view.pickReason(type))
+      return
+    }
+    setNotice(null)
+    develop.send(view.pickEvent(type))
+    // The peel-off flight — decorative, skipped for reduced motion. Rects
+    // are measured now (viewport coords) and the clone rides a portal so no
+    // ancestor transform can re-anchor its fixed positioning.
+    const tray = trayRef.current
+    if (!prefersReducedMotion() && tray) {
+      const from = el.getBoundingClientRect()
+      const trayRect = tray.getBoundingClientRect()
+      const targetIndex = view.staged.length
+      setFlights((f) => [
+        ...f,
+        {
+          key: ++flightKey,
+          type,
+          tile: removalTile(player, type, view.staged),
+          from: { x: from.left, y: from.top, width: from.width },
+          to: {
+            x: trayRect.left + 10 + targetIndex * 52,
+            y: trayRect.top + (trayRect.height - 44) / 2,
+          },
+          targetIndex,
+        },
+      ])
+    }
+  }
+
+  const blockedTap = (type: IndustryType, tile: IndustryTile) => {
+    if (!develop || !view) return
+    // A lightbulb Pottery tile gets the rulebook's own sentence even while
+    // the rest of its track is developable — the player asked about THIS tile.
+    setNotice(
+      !isDevelopable(tile)
+        ? POTTERY_LIGHTBULB_REASON
+        : view.canPick(type)
+          ? 'Develop scraps the lowest tile of a pile first — tap the glowing tile.'
+          : view.pickReason(type),
+    )
+  }
+
   // Each industry as a track: a slot per level (empty when depleted), the
   // lowest remaining marked `next` (buildable this era) or `blocking` (the
   // lowest is barred, so it must be Developed away first).
   const tracks = useMemo(
     () =>
       INDUSTRY_TYPES.map((type) => {
-        const rows = [...(player.industryTilesOnMat[type] ?? [])].sort(
-          (a, b) => a.tile.level - b.tile.level,
-        )
+        const rows = [...(player.industryTilesOnMat[type] ?? [])]
+          .sort((a, b) => a.tile.level - b.tile.level)
+          .map((r) => ({
+            ...r,
+            // Staged develop picks preview as already gone: the pile thins
+            // the moment the tile flies to the tray.
+            quantityAvailable:
+              r.quantityAvailable - (removedByTileId.get(r.tile.id) ?? 0),
+          }))
         // The one tile in play, via the shared helper so this highlight
         // can't drift from the build/develop guards (null when barred).
         const buildableNext = getBuildableTileInEra(rows, era)
@@ -405,7 +585,7 @@ export function PlayerLedger({
         const remaining = rows.reduce((a, r) => a + r.quantityAvailable, 0)
         return { type, slots, remaining }
       }),
-    [player.industryTilesOnMat, era],
+    [player.industryTilesOnMat, era, removedByTileId],
   )
 
   // All selectable tiles, flat, in track/level order — the readout reads
@@ -486,15 +666,30 @@ export function PlayerLedger({
         <div className="-mr-2 flex-1 overflow-y-auto pr-2">
           {/* tile mat */}
           <div className="pt-4">
-            <span className="bb2-panel-title">Tiles on the mat</span>
+            <span className="bb2-panel-title">
+              {view ? 'Develop — scrap tiles off the mat' : 'Tiles on the mat'}
+            </span>
             <p
               className="pt-1.5 text-[12.5px]"
               style={{ color: 'rgba(231,215,177,.5)' }}
             >
-              Tiles build lowest level first — the brass-ringed tile is the next
-              one out, and a thicker pile means more copies remain. Hover or tap
-              any tile to read its full stats below. Greyed tiles cannot be
-              built in the {era} era.
+              {view ? (
+                <>
+                  Tap a{' '}
+                  <b style={{ color: 'var(--bb-brass-bright)' }}>
+                    glowing tile
+                  </b>{' '}
+                  to pull it off its pile — one or two per action, 1 iron each.
+                  Tap a scrapped tile below to put it back.
+                </>
+              ) : (
+                <>
+                  Tiles build lowest level first — the brass-ringed tile is the
+                  next one out, and a thicker pile means more copies remain.
+                  Hover or tap any tile to read its full stats below. Greyed
+                  tiles cannot be built in the {era} era.
+                </>
+              )}
             </p>
 
             {/* industry tracks — one row each, tiles left→right by level.
@@ -548,6 +743,18 @@ export function PlayerLedger({
                             if (slot.kind === 'tile')
                               setSelectedId(slot.tile.id)
                           }}
+                          develop={
+                            view && slot.kind === 'tile'
+                              ? {
+                                  armed:
+                                    armedTileIds.get(tr.type) === slot.tile.id,
+                                  onPick: (el) => pickTile(tr.type, el),
+                                  onBlocked: () =>
+                                    slot.kind === 'tile' &&
+                                    blockedTap(tr.type, slot.tile),
+                                }
+                              : null
+                          }
                         />
                       ))
                     )}
@@ -627,7 +834,281 @@ export function PlayerLedger({
             </div>
           </div>
         </div>
+
+        {/* Develop dock — pinned under the scroll so the scrap tray, the iron
+            question and confirm/cancel are always in reach (phones included). */}
+        {develop && view && (
+          <DevelopDock
+            view={view}
+            removals={removals}
+            trayRef={trayRef}
+            flights={flights}
+            landedTray={landedTray}
+            notice={notice}
+            busy={develop.busy ?? false}
+            send={develop.send}
+          />
+        )}
       </div>
+
+      {/* Scrap flights ride a body portal: fixed coords stay viewport-true
+          regardless of any transformed/animated ancestor. */}
+      {flights.length > 0 &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          flights.map((f) => (
+            <ScrapFlight
+              key={f.key}
+              flight={f}
+              onDone={() => {
+                setFlights((rest) => rest.filter((x) => x.key !== f.key))
+                setLandedTray((prev) => new Set(prev).add(f.targetIndex))
+              }}
+            />
+          )),
+          document.body,
+        )}
+    </div>
+  )
+}
+
+/* ----- develop dock: scrap tray, iron question, confirm ----- */
+
+function DevelopDock({
+  view,
+  removals,
+  trayRef,
+  flights,
+  landedTray,
+  notice,
+  busy,
+  send,
+}: {
+  view: DevelopMatView
+  removals: Array<{
+    type: IndustryType
+    tileId: string
+    level: number
+    tile: IndustryTile | undefined
+  }>
+  trayRef: React.MutableRefObject<HTMLDivElement | null>
+  flights: TileFlight[]
+  landedTray: ReadonlySet<number>
+  notice: string | null
+  busy: boolean
+  send: (event: GameEvent) => void
+}) {
+  const staged = view.staged
+  return (
+    <div
+      data-testid="develop-mat-bar"
+      className="mt-3 flex flex-col gap-2.5 rounded-md p-3"
+      aria-busy={busy}
+      style={{
+        border: '1px solid var(--bb-brass-hairline)',
+        background: 'linear-gradient(170deg,#2c2417,var(--bb-iron-panel))',
+        boxShadow: 'inset 0 1px 0 rgba(255,230,170,.08)',
+        opacity: busy ? 0.7 : 1,
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className="text-[11px] font-bold uppercase tracking-[0.16em]"
+          style={{ color: 'var(--bb-brass-bright)' }}
+        >
+          <DevelopIcon size={13} /> Scrapping{' '}
+          {staged.length === 0
+            ? view.step === 'tiles'
+              ? '— pick a tile'
+              : 'the lowest tile'
+            : staged.length === 1
+              ? 'one tile'
+              : 'two tiles'}
+        </span>
+        <button
+          type="button"
+          className="bb2-ghost-btn"
+          data-testid="cancel-action"
+          disabled={busy}
+          onClick={() => send({ type: 'CANCEL' })}
+        >
+          Cancel
+        </button>
+      </div>
+
+      {/* the scrap tray — where picked tiles land */}
+      <div
+        ref={trayRef}
+        data-testid="develop-tray"
+        className="flex min-h-[64px] items-center gap-3 rounded px-2.5 py-2"
+        aria-live="polite"
+        style={{
+          border: '1px dashed rgba(231,215,177,.22)',
+          background: 'rgba(0,0,0,.25)',
+        }}
+      >
+        {removals.length === 0 &&
+          (view.step === 'tiles' ? (
+            <span
+              className="text-[12.5px] italic"
+              style={{ color: 'rgba(231,215,177,.4)' }}
+            >
+              Nothing scrapped yet — tap a glowing tile above.
+            </span>
+          ) : (
+            // The "develop lowest" shortcut names no tile — the executor
+            // scraps the lowest available one at confirm.
+            <span
+              className="text-[12.5px] italic"
+              style={{ color: 'rgba(231,215,177,.55)' }}
+            >
+              Scrapping the lowest available tile.
+            </span>
+          ))}
+        {removals.map((r, i) => {
+          const inFlight = flights.some((f) => f.targetIndex === i)
+          const tile = r.tile
+          return (
+            <button
+              key={`${r.tileId}-${i}`}
+              type="button"
+              data-testid={`develop-staged-${r.type}`}
+              title="Put this tile back"
+              disabled={busy}
+              onClick={() => send(view.unstageEvent(i))}
+              className={`relative flex shrink-0 flex-col items-center gap-0.5 focus:outline-none focus-visible:-translate-y-0.5 ${
+                landedTray.has(i) ? 'bb2-tray-drop' : ''
+              }`}
+              style={{ visibility: inFlight ? 'hidden' : 'visible' }}
+            >
+              {tile ? (
+                <MatTileArt type={r.type} tile={tile} depth={1} size={40} />
+              ) : (
+                <IndustryChip type={r.type} size={22} />
+              )}
+              <span
+                className="text-[9px] font-bold uppercase tracking-[0.1em]"
+                style={{ color: 'rgba(231,215,177,.6)' }}
+              >
+                {r.type === 'manufacturer' ? 'goods' : r.type}{' '}
+                {ROMAN[r.level] ?? r.level} ✕
+              </span>
+            </button>
+          )
+        })}
+        {removals.length === 1 && (
+          <span
+            className="text-[12px] italic"
+            style={{ color: 'rgba(231,215,177,.35)' }}
+          >
+            …one more, or confirm.
+          </span>
+        )}
+      </div>
+
+      {notice && (
+        <p
+          data-testid="develop-pick-blocked"
+          role="status"
+          className="text-[12.5px] leading-snug"
+          style={{ color: '#d68d80' }}
+        >
+          {notice}
+        </p>
+      )}
+
+      {/* the iron question, asked right here when the machine stops on it */}
+      {view.step === 'iron' && view.ironChoice?.hasChoice && (
+        <IronSourcePicker
+          options={view.ironChoice.options}
+          required={view.ironChoice.required}
+          picks={view.ironPicks}
+          onPick={(source) => {
+            if (!busy) send({ type: 'SELECT_IRON_SOURCE', source })
+          }}
+        />
+      )}
+
+      {/* The closing control follows the STEP: on the tile step CONFIRM is
+          the "just scrap the lowest" shortcut; on the confirm step it seals
+          the develop; while the iron question is open there is nothing to
+          press — answering it advances the flow. */}
+      {view.step === 'confirm' && (
+        <div className="flex flex-col gap-1.5">
+          <button
+            type="button"
+            className="bb2-confirm"
+            data-testid="confirm-action"
+            disabled={busy || !view.canConfirm}
+            onClick={() => send({ type: 'CONFIRM' })}
+          >
+            Scrap{' '}
+            {staged.length === 2
+              ? 'two tiles'
+              : staged.length === 1
+                ? 'one tile'
+                : 'the tile'}
+          </button>
+          {!view.canConfirm && (
+            <p
+              className="text-[12.5px] leading-snug"
+              style={{ color: '#d68d80' }}
+            >
+              {view.confirmReason}
+            </p>
+          )}
+        </div>
+      )}
+      {view.step === 'tiles' && (
+        <button
+          type="button"
+          className="bb2-ghost-btn"
+          data-testid="develop-lowest"
+          disabled={busy}
+          onClick={() => send({ type: 'CONFIRM' })}
+        >
+          Develop lowest available
+        </button>
+      )}
+    </div>
+  )
+}
+
+/** A scrapped tile sailing from its pile to the tray — pure decoration. */
+function ScrapFlight({
+  flight,
+  onDone,
+}: {
+  flight: TileFlight
+  onDone: () => void
+}) {
+  const [airborne, setAirborne] = useState(false)
+  useEffect(() => {
+    // Double rAF: mount at the source rect first, then transition.
+    const raf = requestAnimationFrame(() =>
+      requestAnimationFrame(() => setAirborne(true)),
+    )
+    const timer = setTimeout(onDone, 640)
+    return () => {
+      cancelAnimationFrame(raf)
+      clearTimeout(timer)
+    }
+  }, [])
+  const dx = flight.to.x - flight.from.x
+  const dy = flight.to.y - flight.from.y
+  return (
+    <div
+      aria-hidden
+      className="bb2-dev-flyer"
+      style={{
+        left: flight.from.x,
+        top: flight.from.y,
+        transform: airborne
+          ? `translate(${dx}px, ${dy}px) rotate(7deg) scale(0.8)`
+          : 'translate(0, 0) rotate(0) scale(1)',
+      }}
+    >
+      <MatTileArt type={flight.type} tile={flight.tile} depth={1} size={48} />
     </div>
   )
 }

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -85,6 +85,15 @@ const STACK_PITCH = 5.2
 const STACK_JITTER = [0, 1.3, -0.9, 0.7, -0.5, 1] as const
 const STACK_PAD_X = 1.6
 
+// Deepest pile the mat can ever show — the largest per-level tile quantity in
+// `src/data/industryTiles.ts` (pinned by its test). The docked readout reserves
+// the tile-art footprint for THIS depth so switching the highlighted tile
+// (1 vs 2 vs 3 left) never reflows the box vertically. Rendered at size 52
+// (scale 1), so the art measures on the raw 52-unit grid.
+const MAX_MAT_STACK = 3
+const READOUT_ART_H = Math.ceil(52 + (MAX_MAT_STACK - 1) * STACK_PITCH) // 63
+const READOUT_ART_W = Math.ceil(52 + STACK_PAD_X * 2) // 56
+
 // The one resource a tile YIELDS when built (only one is ever non-zero).
 function producedOf(tile: IndustryTile) {
   if (tile.coalProduced > 0)
@@ -1147,14 +1156,23 @@ function TileReadout({
       }}
     >
       <div className="flex items-center gap-3">
-        <MatTileArt
-          type={tile.type}
-          tile={tile}
-          depth={count}
-          size={52}
-          next={next}
-          barred={barred}
-        />
+        {/* Fixed footprint for the pile art — the stack grows UPWARD off the
+            bottom edge (items-end) inside a box sized to the deepest possible
+            pile, so a shallow tile leaves whitespace above rather than shrinking
+            the header and jumping the whole readout. */}
+        <div
+          className="flex shrink-0 items-end justify-center"
+          style={{ height: READOUT_ART_H, width: READOUT_ART_W }}
+        >
+          <MatTileArt
+            type={tile.type}
+            tile={tile}
+            depth={count}
+            size={52}
+            next={next}
+            barred={barred}
+          />
+        </div>
         <div>
           <div
             className="bb2-display text-[18px] font-bold"
@@ -1249,10 +1267,13 @@ function TileReadout({
             )
           }
         />
-        {prod && (
-          <ReadoutCell
-            k="Produces"
-            v={
+        {/* Always rendered (like "To build"/"Beer to sell" above) so the grid
+            holds a constant 8 cells — a non-producing tile can't drop a cell
+            and re-wrap the rows, which would change the box height. */}
+        <ReadoutCell
+          k="Produces"
+          v={
+            prod ? (
               <span className="flex items-center gap-1">
                 {prod.kind === 'coal' ? (
                   <CoalIcon size={14} />
@@ -1263,9 +1284,11 @@ function TileReadout({
                 )}
                 ×{prod.n}
               </span>
-            }
-          />
-        )}
+            ) : (
+              <span style={{ color: 'rgba(231,215,177,.55)' }}>none</span>
+            )
+          }
+        />
       </div>
     </div>
   )

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -478,9 +478,7 @@ button.bb2-mat:hover {
 /* A stat value that doubles as a control (opens the income track). */
 .bb2-stat-tap {
   cursor: pointer;
-  transition:
-    background 0.12s ease,
-    box-shadow 0.12s ease;
+  transition: background 0.12s ease, box-shadow 0.12s ease;
 }
 .bb2-stat-tap:hover,
 .bb2-stat-tap:focus-visible {
@@ -1026,18 +1024,18 @@ button:focus-visible .bb2-locate-name {
 
 /* ---------------- develop on the mat ---------------- */
 
-/* The armed tile — the one a Develop click would scrap. A slow brass smoulder
-   around the whole pile, deliberately calmer than the board's legal pulse:
-   this is "you may pull this one off", not a map target. */
+/* The armed tile — the one a Develop click would scrap. A tight brass ring
+   that pulses in OPACITY only, deliberately calmer than the board's legal
+   pulse: this is "you may pull this one off", not a map target. No large blur
+   bloom — the soft halo washed over the stacked cardboard edges below the face
+   and made the pile depth hard to count while developing. */
 @keyframes bb2-develop-arm {
   0%,
   100% {
-    box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.65), 0 0 10px 2px
-      rgba(230, 189, 99, 0.22);
+    box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.55);
   }
   50% {
-    box-shadow: 0 0 0 3px rgba(230, 189, 99, 0.95), 0 0 18px 6px
-      rgba(230, 189, 99, 0.42);
+    box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.95);
   }
 }
 .bb2-develop-armed {
@@ -1086,8 +1084,7 @@ button:focus-visible .bb2-locate-name {
 @media (prefers-reduced-motion: reduce) {
   .bb2-develop-armed {
     animation: none;
-    box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.85), 0 0 10px 2px
-      rgba(230, 189, 99, 0.3);
+    box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.85);
   }
   .bb2-dev-flyer {
     transition: none;

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -1024,6 +1024,79 @@ button:focus-visible .bb2-locate-name {
   }
 }
 
+/* ---------------- develop on the mat ---------------- */
+
+/* The armed tile — the one a Develop click would scrap. A slow brass smoulder
+   around the whole pile, deliberately calmer than the board's legal pulse:
+   this is "you may pull this one off", not a map target. */
+@keyframes bb2-develop-arm {
+  0%,
+  100% {
+    box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.65), 0 0 10px 2px
+      rgba(230, 189, 99, 0.22);
+  }
+  50% {
+    box-shadow: 0 0 0 3px rgba(230, 189, 99, 0.95), 0 0 18px 6px
+      rgba(230, 189, 99, 0.42);
+  }
+}
+.bb2-develop-armed {
+  animation: bb2-develop-arm 1.5s ease-in-out infinite;
+  border-radius: 8px;
+}
+.bb2-develop-armed:hover,
+.bb2-develop-armed:focus-visible {
+  animation-duration: 0.8s;
+}
+
+/* A scrapped tile mid-flight from its pile to the scrap tray: one long arc
+   with a tumble, like cardboard tossed onto a discard pile. The transform is
+   set inline per flight (the two rects are only known at click time); this
+   class owns the easing and the lift shadow. */
+.bb2-dev-flyer {
+  position: fixed;
+  z-index: 80;
+  pointer-events: none;
+  transition: transform 0.52s cubic-bezier(0.3, 0.72, 0.3, 1.04), opacity 0.52s
+    ease;
+  will-change: transform;
+  filter: drop-shadow(0 14px 20px rgba(0, 0, 0, 0.55));
+}
+
+/* The tray tile settling where the flyer lands. */
+@keyframes bb2-tray-drop {
+  0% {
+    transform: scale(1.22) rotate(5deg);
+    opacity: 0.7;
+  }
+  70% {
+    transform: scale(0.95) rotate(-1.5deg);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1) rotate(0);
+    opacity: 1;
+  }
+}
+.bb2-tray-drop {
+  animation: bb2-tray-drop 0.34s ease-out both;
+}
+
+/* The flight is decorative; motion-sensitive players get the end state. */
+@media (prefers-reduced-motion: reduce) {
+  .bb2-develop-armed {
+    animation: none;
+    box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.85), 0 0 10px 2px
+      rgba(230, 189, 99, 0.3);
+  }
+  .bb2-dev-flyer {
+    transition: none;
+  }
+  .bb2-tray-drop {
+    animation: none;
+  }
+}
+
 @keyframes bb2-seal-pop {
   0% {
     transform: scale(0.6) rotate(-8deg);

--- a/src/data/industryTiles.ts
+++ b/src/data/industryTiles.ts
@@ -749,3 +749,19 @@ export function getBuildableTileInEra(
 export function canDevelopTile(tile: IndustryTile): boolean {
   return !tile.hasLightbulbIcon
 }
+
+/**
+ * The one tile a Develop can currently remove from this mat track, or null if
+ * none. Mirrors getBuildableTileInEra: Develop always takes the LOWEST-level
+ * tile still on the mat (rulebook p.7), and a lightbulb Pottery tile at the
+ * bottom blocks the whole track — the engine must NOT skip it to a higher
+ * developable tile (that would hand out a free Develop; it was the captain's
+ * reported bug). The lightbulb tile must be BUILT off the mat first.
+ */
+export function getDevelopableTileOnMat(
+  tilesWithQuantity: IndustryTileWithQuantity[],
+): IndustryTile | null {
+  const lowest = getLowestAvailableTile(tilesWithQuantity)
+  if (!lowest) return null
+  return canDevelopTile(lowest) ? lowest : null
+}

--- a/src/store/gameStore.develop.test.ts
+++ b/src/store/gameStore.develop.test.ts
@@ -1,7 +1,9 @@
 // Develop Actions Tests - Industry development and resource consumption
 import { afterEach, describe, expect, test } from 'vitest'
 import { createActor } from 'xstate'
+import type { IndustryType } from '~/data/cards'
 import { gameStore } from './gameStore'
+import { explainRefusal } from './refusal'
 
 // Track actors for cleanup
 let activeActors: ReturnType<typeof createActor>[] = []
@@ -390,10 +392,14 @@ describe('Game Store - Develop Actions', () => {
     // Test skipped - needs proper tile management implementation
   })
 
-  test('develop action - pottery with lightbulb icon cannot be developed', () => {
+  test('develop action - pottery whose lowest tile is a lightbulb cannot be developed at all', () => {
     // A fresh game already seeds every player with the full pottery set
-    // (pottery_1..5, with levels 1 and 3 flagged hasLightbulbIcon), so no
-    // special TEST_SET_PLAYER_STATE plumbing is needed.
+    // (pottery_1..5, with levels 1 and 3 flagged hasLightbulbIcon), so
+    // pottery_1 (lightbulb) is the LOWEST tile on the mat. Develop always
+    // removes the lowest tile, and a lightbulb Pottery may never be developed
+    // (rulebook p.7) — so the whole pottery track is off-limits until
+    // pottery_1 is BUILT away. The engine must NOT skip past it to the next
+    // non-lightbulb tile (that would be a free Develop — the captain's bug).
     const { actor } = setupGame()
 
     const potteryQuantity = (level: number) =>
@@ -406,30 +412,89 @@ describe('Game Store - Develop Actions', () => {
     expect(potteryQuantity(1)).toBe(1)
     expect(potteryQuantity(3)).toBe(1)
 
-    // Perform develop action
     actor.send({ type: 'DEVELOP' })
-
-    // Select a card to pay for the develop action
     const card = actor.getSnapshot().context.players[0]!.hand[0]!
     actor.send({ type: 'SELECT_CARD', cardId: card.id })
 
-    // Deliberately try to develop two pottery tiles - if unguarded, this
-    // would hit the lowest-level tile (pottery_1) first.
+    // The guard refuses a pottery develop, naming the lightbulb reason, and
+    // never offers levels II/IV while level I sits on the mat.
+    const one = {
+      type: 'SELECT_TILES_FOR_DEVELOP' as const,
+      industryTypes: ['pottery'] as IndustryType[],
+    }
+    const two = {
+      type: 'SELECT_TILES_FOR_DEVELOP' as const,
+      industryTypes: ['pottery', 'pottery'] as IndustryType[],
+    }
+    expect(actor.getSnapshot().can(one)).toBe(false)
+    expect(actor.getSnapshot().can(two)).toBe(false)
+    expect(explainRefusal(actor.getSnapshot() as never, one as never)).toMatch(
+      /lightbulb/i,
+    )
+
+    // Even if the (illegal) event is forced through, no pottery tile moves.
+    actor.send(two)
+    actor.send({ type: 'CONFIRM' })
+
+    expect(potteryQuantity(1)).toBe(1)
+    expect(potteryQuantity(2)).toBe(1)
+    expect(potteryQuantity(3)).toBe(1)
+    expect(potteryQuantity(4)).toBe(1)
+  })
+
+  test('develop action - after pottery I is gone, only II is developable; III (lightbulb) blocks a second pick', () => {
+    // Simulate pottery_1 having been built off the mat: level II becomes the
+    // lowest tile (developable), but level III is a lightbulb, so a two-tile
+    // pottery develop is refused — lowest-first still holds for the 2nd tile.
+    const { actor } = setupGame()
+    const idx = actor.getSnapshot().context.currentPlayerIndex
+    const mat = actor.getSnapshot().context.players[idx]!.industryTilesOnMat
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx,
+      industryTilesOnMat: {
+        ...mat,
+        pottery: (mat.pottery ?? []).map((t) =>
+          t.tile.level === 1 ? { ...t, quantityAvailable: 0 } : t,
+        ),
+      },
+    } as never)
+
+    const potteryQuantity = (level: number) =>
+      actor
+        .getSnapshot()
+        .context.players[idx]!.industryTilesOnMat.pottery.find(
+          (t) => t.tile.level === level,
+        )!.quantityAvailable
+
+    actor.send({ type: 'DEVELOP' })
+    const card = actor.getSnapshot().context.players[idx]!.hand[0]!
+    actor.send({ type: 'SELECT_CARD', cardId: card.id })
+
+    expect(
+      actor.getSnapshot().can({
+        type: 'SELECT_TILES_FOR_DEVELOP',
+        industryTypes: ['pottery'],
+      }),
+    ).toBe(true)
+    expect(
+      actor.getSnapshot().can({
+        type: 'SELECT_TILES_FOR_DEVELOP',
+        industryTypes: ['pottery', 'pottery'],
+      }),
+    ).toBe(false)
+
     actor.send({
       type: 'SELECT_TILES_FOR_DEVELOP',
-      industryTypes: ['pottery', 'pottery'],
+      industryTypes: ['pottery'],
     })
     actor.send({ type: 'CONFIRM' })
 
-    const snapshot = actor.getSnapshot()
-    expect(snapshot.context.lastError).toBeNull()
-
-    // Lightbulb tiles (levels 1 and 3) must remain untouched; the engine
-    // must skip past them to the next non-lightbulb tiles instead.
-    expect(potteryQuantity(1)).toBe(1)
-    expect(potteryQuantity(3)).toBe(1)
+    expect(actor.getSnapshot().context.lastError).toBeNull()
+    // Level II (the true lowest developable) was removed; III stays.
     expect(potteryQuantity(2)).toBe(0)
-    expect(potteryQuantity(4)).toBe(0)
+    expect(potteryQuantity(3)).toBe(1)
+    expect(potteryQuantity(4)).toBe(1)
   })
 
   test('develop action - can develop 1 or 2 tiles consuming 1 iron each', () => {

--- a/src/store/gameStore.developmat.test.ts
+++ b/src/store/gameStore.developmat.test.ts
@@ -98,14 +98,41 @@ describe('canSelectTilesForDevelop — the per-tile legality guard', () => {
     expect(s.can(pickEvent(['coal', 'iron', 'cotton']))).toBe(false)
   })
 
-  test('pottery with non-lightbulb tiles remaining is developable — twice', () => {
+  test('fresh-mat pottery is NOT developable — its lowest tile is a lightbulb', () => {
     const { actor } = setupGame()
     enterTileStep(actor)
-    // The fresh mat holds pottery 1 (lightbulb), 2, 3 (lightbulb), 4, 5 —
-    // three developable tiles, so one or two pottery picks are legal.
+    // The fresh mat holds pottery 1 (lightbulb), 2, 3 (lightbulb), 4, 5.
+    // Develop always removes the LOWEST tile, and pottery 1 is a lightbulb
+    // that may only be BUILT away (rulebook p.7) — so the whole track is
+    // off-limits to Develop and levels II/IV are never offered while I is
+    // still on the mat (the captain's reported bug).
+    const s = snap(actor)
+    expect(s.can(pickEvent(['pottery']))).toBe(false)
+    expect(s.can(pickEvent(['pottery', 'pottery']))).toBe(false)
+    expect(explainRefusal(s as never, pickEvent(['pottery']) as never)).toMatch(
+      /lightbulb/i,
+    )
+  })
+
+  test('once pottery I is built away, II is developable but III (lightbulb) caps it at one', () => {
+    const { actor } = setupGame()
+    const idx0 = snap(actor).context.currentPlayerIndex
+    const mat = snap(actor).context.players[idx0]!.industryTilesOnMat
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx0,
+      industryTilesOnMat: {
+        ...mat,
+        pottery: (mat.pottery ?? []).map(
+          (t: { tile: { level: number }; quantityAvailable: number }) =>
+            t.tile.level === 1 ? { ...t, quantityAvailable: 0 } : t,
+        ),
+      },
+    } as never)
+    enterTileStep(actor)
     const s = snap(actor)
     expect(s.can(pickEvent(['pottery']))).toBe(true)
-    expect(s.can(pickEvent(['pottery', 'pottery']))).toBe(true)
+    expect(s.can(pickEvent(['pottery', 'pottery']))).toBe(false)
   })
 
   test('an industry whose only remaining tiles are lightbulb pottery is refused, with the rulebook reason', () => {

--- a/src/store/gameStore.developmat.test.ts
+++ b/src/store/gameStore.developmat.test.ts
@@ -1,0 +1,318 @@
+// Develop-via-mat: the guard on SELECT_TILES_FOR_DEVELOP and the staged
+// re-pick that lets the player mat act as the picking surface.
+//
+// The event used to be unguarded — any industryTypes payload was accepted and
+// silently trimmed inside the assign. The mat UI needs the machine to answer
+// "may I pick this tile?" per candidate (engine-owned legality), and to accept
+// a REPLACEMENT pick while already sitting on the iron/confirm step so a
+// second mat click can grow a one-tile develop into a two-tile one without
+// cancelling. Money/iron affordability deliberately stays on CONFIRM
+// (pinned by gameStore.money.test.ts) — this guard owns tile legality only.
+import { afterEach, describe, expect, test } from 'vitest'
+import { createActor } from 'xstate'
+import type { IndustryType } from '~/data/cards'
+import { gameStore } from './gameStore'
+import { explainRefusal } from './refusal'
+
+let activeActors: ReturnType<typeof createActor>[] = []
+
+afterEach(() => {
+  activeActors.forEach((actor) => {
+    try {
+      actor.stop()
+    } catch {
+      // Ignore errors during cleanup
+    }
+  })
+  activeActors = []
+})
+
+const setupGame = () => {
+  const actor = createActor(gameStore)
+  activeActors.push(actor)
+  actor.start()
+  actor.send({
+    type: 'START_GAME',
+    players: [
+      {
+        id: '1',
+        name: 'Player 1',
+        color: 'red' as const,
+        character: 'Richard Arkwright' as const,
+        money: 17,
+        victoryPoints: 0,
+        income: 10,
+        industryTilesOnMat: {} as never,
+      },
+      {
+        id: '2',
+        name: 'Player 2',
+        color: 'blue' as const,
+        character: 'Eliza Tinsley' as const,
+        money: 17,
+        victoryPoints: 0,
+        income: 10,
+        industryTilesOnMat: {} as never,
+      },
+    ],
+  })
+  return { actor }
+}
+
+const snap = (actor: ReturnType<typeof createActor>) =>
+  actor.getSnapshot() as ReturnType<
+    ReturnType<typeof createActor<typeof gameStore>>['getSnapshot']
+  >
+
+/** Enter the develop tile step with a card already discarded. */
+const enterTileStep = (actor: ReturnType<typeof createActor>) => {
+  const s = snap(actor)
+  const idx = s.context.currentPlayerIndex
+  const card = s.context.players[idx]!.hand[0]!
+  actor.send({ type: 'DEVELOP' })
+  actor.send({ type: 'SELECT_CARD', cardId: card.id })
+  return idx
+}
+
+const pickEvent = (industryTypes: IndustryType[]) =>
+  ({ type: 'SELECT_TILES_FOR_DEVELOP', industryTypes }) as const
+
+const matQuantity = (
+  actor: ReturnType<typeof createActor>,
+  idx: number,
+  type: IndustryType,
+) =>
+  (snap(actor).context.players[idx]!.industryTilesOnMat[type] ?? []).reduce(
+    (n: number, t: { quantityAvailable: number }) => n + t.quantityAvailable,
+    0,
+  )
+
+describe('canSelectTilesForDevelop — the per-tile legality guard', () => {
+  test('a developable industry is accepted; empty and oversized picks are not', () => {
+    const { actor } = setupGame()
+    enterTileStep(actor)
+    const s = snap(actor)
+    expect(s.can(pickEvent(['coal']))).toBe(true)
+    expect(s.can(pickEvent(['coal', 'iron']))).toBe(true)
+    expect(s.can(pickEvent([]))).toBe(false)
+    expect(s.can(pickEvent(['coal', 'iron', 'cotton']))).toBe(false)
+  })
+
+  test('pottery with non-lightbulb tiles remaining is developable — twice', () => {
+    const { actor } = setupGame()
+    enterTileStep(actor)
+    // The fresh mat holds pottery 1 (lightbulb), 2, 3 (lightbulb), 4, 5 —
+    // three developable tiles, so one or two pottery picks are legal.
+    const s = snap(actor)
+    expect(s.can(pickEvent(['pottery']))).toBe(true)
+    expect(s.can(pickEvent(['pottery', 'pottery']))).toBe(true)
+  })
+
+  test('an industry whose only remaining tiles are lightbulb pottery is refused, with the rulebook reason', () => {
+    const { actor } = setupGame()
+    const s0 = snap(actor)
+    const idx = s0.context.currentPlayerIndex
+    const mat = s0.context.players[idx]!.industryTilesOnMat
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx,
+      industryTilesOnMat: {
+        ...mat,
+        pottery: (mat.pottery ?? []).filter(
+          (t: { tile: { hasLightbulbIcon: boolean } }) =>
+            t.tile.hasLightbulbIcon,
+        ),
+      },
+    } as never)
+    enterTileStep(actor)
+    const s = snap(actor)
+    const event = pickEvent(['pottery'])
+    expect(s.can(event)).toBe(false)
+    expect(explainRefusal(s as never, event as never)).toMatch(/lightbulb/i)
+  })
+
+  test('picking the same industry more times than it has developable tiles is refused, and says so', () => {
+    const { actor } = setupGame()
+    const s0 = snap(actor)
+    const idx = s0.context.currentPlayerIndex
+    const mat = s0.context.players[idx]!.industryTilesOnMat
+    // Leave exactly ONE developable cotton tile.
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx,
+      industryTilesOnMat: {
+        ...mat,
+        cotton: (mat.cotton ?? [])
+          .slice(0, 1)
+          .map((t: { quantityAvailable: number }) => ({
+            ...t,
+            quantityAvailable: 1,
+          })),
+      },
+    } as never)
+    enterTileStep(actor)
+    const s = snap(actor)
+    expect(s.can(pickEvent(['cotton']))).toBe(true)
+    const twice = pickEvent(['cotton', 'cotton'])
+    expect(s.can(twice)).toBe(false)
+    expect(explainRefusal(s as never, twice as never)).toMatch(/only .*1|one/i)
+  })
+
+  test('an industry with no tiles left on the mat is refused by name', () => {
+    const { actor } = setupGame()
+    const s0 = snap(actor)
+    const idx = s0.context.currentPlayerIndex
+    const mat = s0.context.players[idx]!.industryTilesOnMat
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: idx,
+      industryTilesOnMat: { ...mat, brewery: [] },
+    } as never)
+    enterTileStep(actor)
+    const s = snap(actor)
+    const event = pickEvent(['brewery'])
+    expect(s.can(event)).toBe(false)
+    expect(explainRefusal(s as never, event as never)).toMatch(/no brewery/i)
+  })
+})
+
+describe('staged re-pick — a mat click grows or shrinks the develop in place', () => {
+  test('a second pick from the confirm step replaces the staged tiles and both are scrapped on CONFIRM', () => {
+    const { actor } = setupGame()
+    const idx = enterTileStep(actor)
+    const coalBefore = matQuantity(actor, idx, 'coal')
+    const ironBefore = matQuantity(actor, idx, 'iron')
+
+    actor.send(pickEvent(['coal']) as never)
+    // No iron works on the board — the iron step auto-skips to the confirm.
+    expect(
+      snap(actor).matches({
+        playing: { action: { developing: 'confirmingDevelop' } },
+      } as never),
+    ).toBe(true)
+
+    // The second mat click: replace [coal] with [coal, iron] without cancel.
+    expect(snap(actor).can(pickEvent(['coal', 'iron']))).toBe(true)
+    actor.send(pickEvent(['coal', 'iron']) as never)
+    expect(snap(actor).context.selectedTilesForDevelop).toEqual([
+      'coal',
+      'iron',
+    ])
+    expect(
+      snap(actor).matches({
+        playing: { action: { developing: 'confirmingDevelop' } },
+      } as never),
+    ).toBe(true)
+
+    actor.send({ type: 'CONFIRM' })
+    expect(snap(actor).context.lastError).toBeNull()
+    expect(matQuantity(actor, idx, 'coal')).toBe(coalBefore - 1)
+    expect(matQuantity(actor, idx, 'iron')).toBe(ironBefore - 1)
+  })
+
+  test('a smaller re-pick unstages: [coal, iron] shrinks back to [iron]', () => {
+    const { actor } = setupGame()
+    enterTileStep(actor)
+    actor.send(pickEvent(['coal', 'iron']) as never)
+    actor.send(pickEvent(['iron']) as never)
+    expect(snap(actor).context.selectedTilesForDevelop).toEqual(['iron'])
+  })
+
+  test('re-picking while the iron question is open resets the chosen sources', () => {
+    const { actor } = setupGame()
+    const s0 = snap(actor)
+    const developerIndex = s0.context.currentPlayerIndex
+    const opponentIndex = developerIndex === 0 ? 1 : 0
+    const ironTile = {
+      id: 'iron_1',
+      type: 'iron' as const,
+      level: 1,
+      canBuildInCanalEra: true,
+      canBuildInRailEra: true,
+      incomeAdvancement: 2,
+      incomeSpaces: 2,
+      victoryPoints: 1,
+      cost: 5,
+      linkScoringIcons: 1,
+      coalRequired: 1,
+      ironRequired: 0,
+      beerRequired: 0,
+      beerProduced: 0,
+      coalProduced: 0,
+      ironProduced: 4,
+      hasLightbulbIcon: false,
+      quantity: 1,
+    }
+    const works = (location: string) => ({
+      location,
+      type: 'iron' as const,
+      level: 1,
+      flipped: false,
+      tile: ironTile,
+      coalCubesOnTile: 0,
+      ironCubesOnTile: 2,
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: developerIndex,
+      money: 30,
+      industries: [works('birmingham')],
+    } as never)
+    actor.send({
+      type: 'TEST_SET_PLAYER_STATE',
+      playerId: opponentIndex,
+      industries: [works('dudley')],
+    } as never)
+
+    const developerId = snap(actor).context.players[developerIndex]!.id
+    enterTileStep(actor)
+    actor.send(pickEvent(['cotton']) as never)
+    // Two unflipped works: the machine stops on the iron question.
+    expect(
+      snap(actor).matches({
+        playing: { action: { developing: 'choosingIronSource' } },
+      } as never),
+    ).toBe(true)
+    actor.send({
+      type: 'SELECT_IRON_SOURCE',
+      source: {
+        kind: 'ironworks',
+        ownerId: developerId,
+        location: 'birmingham',
+      },
+    } as never)
+
+    // Growing the develop reopens the question from scratch — a stale pick
+    // must not survive into a different iron requirement.
+    actor.send(pickEvent(['cotton', 'cotton']) as never)
+    const after = snap(actor)
+    expect(
+      after.matches({
+        playing: { action: { developing: 'choosingIronSource' } },
+      } as never),
+    ).toBe(true)
+    expect(after.context.chosenIronSources).toEqual([])
+    expect(after.context.selectedTilesForDevelop).toEqual(['cotton', 'cotton'])
+  })
+
+  test('CANCEL from the confirm step unwinds to the tile step consuming nothing', () => {
+    const { actor } = setupGame()
+    const idx = enterTileStep(actor)
+    const actionsBefore = snap(actor).context.actionsRemaining
+    const coalBefore = matQuantity(actor, idx, 'coal')
+
+    actor.send(pickEvent(['coal']) as never)
+    actor.send({ type: 'CANCEL' })
+    const s = snap(actor)
+    expect(
+      s.matches({
+        playing: { action: { developing: 'selectingTiles' } },
+      } as never),
+    ).toBe(true)
+    expect(s.context.selectedTilesForDevelop).toEqual([])
+    expect(s.context.actionsRemaining).toBe(actionsBefore)
+    expect(matQuantity(actor, idx, 'coal')).toBe(coalBefore)
+    // The held card is still in play — cancel did not eat it.
+    expect(s.context.selectedCard).not.toBeNull()
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -64,6 +64,7 @@ import {
   checkAndFlipIndustryTilesLogic,
   createLogEntry,
   debugLog,
+  developableTileQuantity,
   drawCards,
   findAvailableBreweries,
   findCardInHand,
@@ -3275,6 +3276,28 @@ export const gameStore = setup({
 
     hasSelectedSecondLink: ({ context }) => context.selectedSecondLink !== null,
 
+    /**
+     * A Develop pick names one or two industries (repeats allowed —
+     * successive tiles of the same track); each must still have that many
+     * developable tiles on the mat. Tile legality ONLY: iron and money are
+     * judged on CONFIRM (hasSelectedTilesForDevelop), the seam
+     * gameStore.money.test.ts pins. Also accepted mid-flow from the iron and
+     * confirm steps, so a mat click can grow or shrink the staged develop
+     * without cancelling.
+     */
+    canSelectTilesForDevelop: ({ context, event }) => {
+      if (event.type !== 'SELECT_TILES_FOR_DEVELOP') return false
+      const picks = event.industryTypes
+      if (picks.length < 1 || picks.length > 2) return false
+      const mat = getCurrentPlayer(context).industryTilesOnMat
+      const counts = new Map<IndustryType, number>()
+      for (const type of picks) counts.set(type, (counts.get(type) ?? 0) + 1)
+      for (const [type, n] of counts) {
+        if (developableTileQuantity(mat[type] ?? []) < n) return false
+      }
+      return true
+    },
+
     hasSelectedTilesForDevelop: ({ context }) => {
       const canAffordIron = (tileCount: number) => {
         const iron = consumeIronFromSources(
@@ -3721,6 +3744,7 @@ export const gameStore = setup({
                     SELECT_TILES_FOR_DEVELOP: {
                       target: 'choosingIronSource',
                       actions: 'selectTilesForDevelop',
+                      guard: 'canSelectTilesForDevelop',
                     },
                     CONFIRM: {
                       target: 'choosingIronSource',
@@ -3752,6 +3776,16 @@ export const gameStore = setup({
                         params: { resource: 'iron' },
                       },
                     },
+                    // A mat click while the iron question is open replaces the
+                    // staged pick and re-asks from scratch (reenter runs
+                    // enterDevelopIronStep, which drops any stale source pick
+                    // made against the old iron requirement).
+                    SELECT_TILES_FOR_DEVELOP: {
+                      target: 'choosingIronSource',
+                      reenter: true,
+                      actions: 'selectTilesForDevelop',
+                      guard: 'canSelectTilesForDevelop',
+                    },
                     CANCEL: {
                       target: 'selectingTiles',
                       actions: 'clearTilesForDevelop',
@@ -3764,6 +3798,15 @@ export const gameStore = setup({
                       target: '#brassGame.playing.actionComplete',
                       actions: 'executeDevelopAction',
                       guard: 'hasSelectedTilesForDevelop',
+                    },
+                    // The mat surface grows a one-tile develop into a two-tile
+                    // one (or shrinks it back) without cancelling: replace the
+                    // staged tiles and re-run the iron question for the new
+                    // count.
+                    SELECT_TILES_FOR_DEVELOP: {
+                      target: 'choosingIronSource',
+                      actions: 'selectTilesForDevelop',
+                      guard: 'canSelectTilesForDevelop',
                     },
                     CANCEL: {
                       target: 'selectingTiles',

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -26,10 +26,10 @@ import {
   canBuildTileInEra,
   decrementTileQuantity,
   getBuildableTileInEra,
+  getDevelopableTileOnMat,
   getInitialPlayerIndustryTiles,
   getInitialPlayerIndustryTilesWithQuantities,
   getLowestAvailableTile,
-  getLowestLevelTile,
 } from '../data/industryTiles'
 import {
   type ValidationResult,
@@ -71,7 +71,6 @@ import {
   getCardDescription,
   getCurrentPlayer,
   incomeAfterFlip,
-  isDevelopable,
   isFirstRound,
   isLocationInPlayerNetwork,
   removeCardFromHand,
@@ -1558,11 +1557,9 @@ export const gameStore = setup({
         ] as IndustryType[]) {
           const tilesWithQuantity =
             currentPlayer.industryTilesOnMat[industryType] || []
-          const developableTiles = tilesWithQuantity
-            .filter((t) => t.quantityAvailable > 0)
-            .map((t) => t.tile)
-            .filter(isDevelopable)
-          if (developableTiles.length > 0) {
+          // The lowest tile is the only develop target; a lightbulb-lowest
+          // track is not developable (rulebook p.7).
+          if (getDevelopableTileOnMat(tilesWithQuantity)) {
             availableTypes.push(industryType)
           }
         }
@@ -1612,21 +1609,16 @@ export const gameStore = setup({
       for (const industryType of selectedIndustryTypes) {
         const tilesWithQuantity = updatedIndustryTilesOnMat[industryType] || []
 
-        // Filter out pottery tiles with lightbulb and tiles with no quantity
-        const developableTiles = tilesWithQuantity
-          .filter((t) => t.quantityAvailable > 0)
-          .map((t) => t.tile)
-          .filter(isDevelopable)
-
-        if (developableTiles.length > 0) {
-          // Decrement quantity of the lowest level tile
-          const lowestTile = getLowestLevelTile(developableTiles)
-          if (lowestTile) {
-            updatedIndustryTilesOnMat[industryType] = decrementTileQuantity(
-              tilesWithQuantity,
-              lowestTile,
-            )
-          }
+        // Develop removes the TRUE lowest tile — never a higher one skipped
+        // past a lightbulb (rulebook p.7). For a two-tile pick of the same
+        // industry the loop recomputes the lowest of what remains, so the
+        // second tile is still lowest-first and still blocked by a lightbulb.
+        const lowestTile = getDevelopableTileOnMat(tilesWithQuantity)
+        if (lowestTile) {
+          updatedIndustryTilesOnMat[industryType] = decrementTileQuantity(
+            tilesWithQuantity,
+            lowestTile,
+          )
         }
       }
 
@@ -2517,18 +2509,13 @@ export const gameStore = setup({
       const currentPlayer = getCurrentPlayer(context)
       const validTiles: IndustryType[] = []
 
-      // Validate each selected industry type
+      // Validate each selected industry type. Only the lowest tile is a
+      // develop target, and a lightbulb-lowest track is off-limits (rulebook
+      // p.7); the guard owns full legality, this is the staging filter.
       for (const industryType of event.industryTypes) {
         const tilesWithQuantity =
           currentPlayer.industryTilesOnMat[industryType] || []
-
-        // Filter out pottery tiles with lightbulb icon and tiles with no quantity
-        const developableTiles = tilesWithQuantity
-          .filter((t) => t.quantityAvailable > 0)
-          .map((t) => t.tile)
-          .filter(isDevelopable)
-
-        if (developableTiles.length > 0) {
+        if (getDevelopableTileOnMat(tilesWithQuantity)) {
           validTiles.push(industryType)
         }
       }
@@ -3327,11 +3314,8 @@ export const gameStore = setup({
       ] as IndustryType[]) {
         const tilesWithQuantity =
           currentPlayer.industryTilesOnMat[industryType] || []
-        const developableTiles = tilesWithQuantity
-          .filter((t) => t.quantityAvailable > 0)
-          .map((t) => t.tile)
-          .filter(isDevelopable)
-        if (developableTiles.length > 0) {
+        // Only a developable-lowest track counts (rulebook p.7).
+        if (getDevelopableTileOnMat(tilesWithQuantity)) {
           // The auto-select fallback develops exactly one tile
           return canAffordIron(1)
         }

--- a/src/store/refusal.ts
+++ b/src/store/refusal.ts
@@ -26,7 +26,11 @@
 // CONTRACT: only call this when `can(event)` is already false. It answers "why
 // would this be refused", not "is this legal" — the machine owns legality.
 import { type CityId, connections, linkConnectedLocations } from '../data/board'
-import type { LocationCard } from '../data/cards'
+import {
+  type IndustryType,
+  type LocationCard,
+  industryDisplayName,
+} from '../data/cards'
 import { getBuildableTileInEra } from '../data/industryTiles'
 import {
   buildCompletionAt,
@@ -47,7 +51,11 @@ import {
   railNetworkCostView,
 } from './market/marketActions'
 import { getDevelopBonusOptions } from './shared/developBonus'
-import { getCurrentPlayer } from './shared/gameUtils'
+import {
+  POTTERY_LIGHTBULB_REASON,
+  developableTileQuantity,
+  getCurrentPlayer,
+} from './shared/gameUtils'
 import {
   beerSourceKey,
   canChooseBeerSource,
@@ -267,6 +275,40 @@ const explainSelectIndustryType = (
   return null
 }
 
+/**
+ * SELECT_TILES_FOR_DEVELOP — mirrors canSelectTilesForDevelop: tile legality
+ * only (money and iron are judged on CONFIRM). Calls the guard's own counter,
+ * `developableTileQuantity`, per named industry.
+ */
+const explainDevelopTilePick = (
+  context: GameState,
+  event: Extract<GameEvent, { type: 'SELECT_TILES_FOR_DEVELOP' }>,
+): string | null => {
+  const picks = event.industryTypes
+  if (picks.length === 0) return 'Pick at least one tile to develop.'
+  if (picks.length > 2) return 'A Develop removes at most two tiles.'
+  const mat = getCurrentPlayer(context).industryTilesOnMat
+  const counts = new Map<IndustryType, number>()
+  for (const type of picks) counts.set(type, (counts.get(type) ?? 0) + 1)
+  for (const [type, n] of counts) {
+    const tiles = mat[type] ?? []
+    const held = tiles.filter((t) => t.quantityAvailable > 0)
+    if (held.length === 0) {
+      return `You have no ${industryDisplayName(type)} tiles left on your mat.`
+    }
+    const developable = developableTileQuantity(tiles)
+    if (developable === 0) {
+      return type === 'pottery'
+        ? POTTERY_LIGHTBULB_REASON
+        : `No ${industryDisplayName(type)} tile on your mat can be developed.`
+    }
+    if (developable < n) {
+      return `Only ${developable === 1 ? 'one' : developable} ${industryDisplayName(type)} tile${developable === 1 ? '' : 's'} can still be developed.`
+    }
+  }
+  return null
+}
+
 /** CONFIRM on a develop — mirrors hasSelectedTilesForDevelop (iron sourceable
  * AND affordable; no tile named ⇒ the single lowest, count 1). */
 const explainDevelopConfirm = (context: GameState): string | null => {
@@ -455,6 +497,9 @@ export function explainRefusal(
       // offered (rules L119-121).
       return 'That coal mine is not one of the closest connected mines you may choose from.'
     }
+
+    case 'SELECT_TILES_FOR_DEVELOP':
+      return explainDevelopTilePick(context, event)
 
     case 'SELECT_DEVELOP_TILE': {
       const pending = context.pendingDevelopChoice

--- a/src/store/shared/developableTiles.test.ts
+++ b/src/store/shared/developableTiles.test.ts
@@ -1,0 +1,106 @@
+// Develop is lowest-first and a lightbulb Pottery blocks its whole track
+// (rulebook p.7). These pin the two pure helpers the guard/executor read —
+// counting or targeting a tile ABOVE a lightbulb was the captain's bug
+// (Pottery II/IV offered while the lightbulb Pottery I still sat on the mat).
+import { describe, expect, test } from 'vitest'
+import {
+  type IndustryTile,
+  type IndustryTileWithQuantity,
+  getDevelopableTileOnMat,
+} from '../../data/industryTiles'
+import { developableTileQuantity } from './gameUtils'
+
+const tile = (
+  type: IndustryTile['type'],
+  level: number,
+  hasLightbulbIcon = false,
+): IndustryTile =>
+  ({
+    id: `${type}_${level}`,
+    type,
+    level,
+    canBuildInCanalEra: true,
+    canBuildInRailEra: true,
+    incomeAdvancement: 0,
+    incomeSpaces: 0,
+    victoryPoints: 0,
+    cost: 0,
+    linkScoringIcons: 0,
+    coalRequired: 0,
+    ironRequired: 0,
+    beerRequired: 0,
+    beerProduced: 0,
+    coalProduced: 0,
+    ironProduced: 0,
+    hasLightbulbIcon,
+    quantity: 1,
+  }) as IndustryTile
+
+const held = (
+  t: IndustryTile,
+  quantityAvailable = 1,
+): IndustryTileWithQuantity => ({ tile: t, quantityAvailable })
+
+describe('developableTileQuantity — lowest-first, blocked by a lightbulb', () => {
+  test('a track with no lightbulbs sums all held quantity', () => {
+    expect(
+      developableTileQuantity([
+        held(tile('coal', 1), 2),
+        held(tile('coal', 2)),
+      ]),
+    ).toBe(3)
+  })
+
+  test('a lightbulb at the bottom makes the whole track non-developable', () => {
+    // Pottery I (lightbulb) present → 0, even with II/IV above it.
+    expect(
+      developableTileQuantity([
+        held(tile('pottery', 1, true)),
+        held(tile('pottery', 2)),
+        held(tile('pottery', 3, true)),
+        held(tile('pottery', 4)),
+      ]),
+    ).toBe(0)
+  })
+
+  test('once the lightbulb bottom is gone, count stops at the next lightbulb', () => {
+    // I built away; II developable, III (lightbulb) blocks IV → exactly 1.
+    expect(
+      developableTileQuantity([
+        held(tile('pottery', 1, true), 0),
+        held(tile('pottery', 2)),
+        held(tile('pottery', 3, true)),
+        held(tile('pottery', 4)),
+      ]),
+    ).toBe(1)
+  })
+})
+
+describe('getDevelopableTileOnMat — the single develop target', () => {
+  test('returns the true lowest of a clean track', () => {
+    expect(
+      getDevelopableTileOnMat([
+        held(tile('cotton', 2)),
+        held(tile('cotton', 1)),
+      ])?.level,
+    ).toBe(1)
+  })
+
+  test('returns null when the lowest tile is a lightbulb (never skips up)', () => {
+    expect(
+      getDevelopableTileOnMat([
+        held(tile('pottery', 1, true)),
+        held(tile('pottery', 2)),
+      ]),
+    ).toBeNull()
+  })
+
+  test('returns the new lowest after the lightbulb bottom is removed', () => {
+    expect(
+      getDevelopableTileOnMat([
+        held(tile('pottery', 1, true), 0),
+        held(tile('pottery', 2)),
+      ])?.level,
+    ).toBe(2)
+  })
+})

--- a/src/store/shared/gameUtils.ts
+++ b/src/store/shared/gameUtils.ts
@@ -29,6 +29,33 @@ export function isDevelopable(
 }
 
 /**
+ * The sentence shown wherever a lightbulb-Pottery develop is refused — the
+ * dock's blocked list, the mat picker and `explainRefusal` all share it so
+ * the wording cannot drift between surfaces.
+ */
+export const POTTERY_LIGHTBULB_REASON =
+  'Pottery cannot be developed — the lightbulb tiles are removed only by building over them, which then unlocks the higher Pottery levels (rulebook p.7).'
+
+/**
+ * How many tiles of this industry a Develop may still remove — the sum of
+ * remaining quantity over developable tiles. The Develop executor skips
+ * lightbulb tiles and scraps the lowest developable one per pick
+ * (executeDevelopAction), so a pick of the same industry N times is legal
+ * exactly when this count is ≥ N. Shared by the SELECT_TILES_FOR_DEVELOP
+ * guard and its refusal explainer.
+ */
+export function developableTileQuantity(
+  tiles: Array<{
+    tile: Pick<IndustryTile, 'type' | 'hasLightbulbIcon'>
+    quantityAvailable: number
+  }>,
+): number {
+  return tiles
+    .filter((t) => isDevelopable(t.tile))
+    .reduce((n, t) => n + t.quantityAvailable, 0)
+}
+
+/**
  * Marker movement for a FLIPPED tile: advance by the tile's printed
  * SPACES; the level is the coin beside the landing space (audited
  * 2026-07-15). The single source for every flip path — round-end checks,

--- a/src/store/shared/gameUtils.ts
+++ b/src/store/shared/gameUtils.ts
@@ -37,22 +37,32 @@ export const POTTERY_LIGHTBULB_REASON =
   'Pottery cannot be developed — the lightbulb tiles are removed only by building over them, which then unlocks the higher Pottery levels (rulebook p.7).'
 
 /**
- * How many tiles of this industry a Develop may still remove — the sum of
- * remaining quantity over developable tiles. The Develop executor skips
- * lightbulb tiles and scraps the lowest developable one per pick
- * (executeDevelopAction), so a pick of the same industry N times is legal
- * exactly when this count is ≥ N. Shared by the SELECT_TILES_FOR_DEVELOP
- * guard and its refusal explainer.
+ * How many tiles of this industry a Develop may still remove. Develop ALWAYS
+ * removes the LOWEST-level tile on the mat (rulebook p.7, "Develop Action"),
+ * and a lightbulb Pottery tile may never be developed — it blocks the whole
+ * track until it is BUILT away. So we walk the held tiles from the lowest
+ * level up and count removable quantity until a lightbulb tile stops us;
+ * everything ABOVE a lightbulb is inaccessible to Develop (counting the
+ * higher tiles regardless was the captain's bug — it let Pottery II/IV be
+ * developed while the lightbulb Pottery I still sat on the mat). A pick of
+ * the same industry N times is legal exactly when this count is ≥ N. Shared
+ * by the SELECT_TILES_FOR_DEVELOP guard and its refusal explainer.
  */
 export function developableTileQuantity(
   tiles: Array<{
-    tile: Pick<IndustryTile, 'type' | 'hasLightbulbIcon'>
+    tile: Pick<IndustryTile, 'type' | 'hasLightbulbIcon' | 'level'>
     quantityAvailable: number
   }>,
 ): number {
-  return tiles
-    .filter((t) => isDevelopable(t.tile))
-    .reduce((n, t) => n + t.quantityAvailable, 0)
+  const heldLowestFirst = tiles
+    .filter((t) => t.quantityAvailable > 0)
+    .sort((a, b) => a.tile.level - b.tile.level)
+  let count = 0
+  for (const t of heldLowestFirst) {
+    if (!isDevelopable(t.tile)) break
+    count += t.quantityAvailable
+  }
+  return count
 }
 
 /**


### PR DESCRIPTION
## Develop happens on the player mat

Choosing **Develop** now opens the player mat as the picking surface. The lowest developable tile of each track smoulders brass; tapping it peels the tile off its pile and sails it into a **scrap tray** at the bottom of the mat (a cardboard-toss flight, skipped under `prefers-reduced-motion`). Piles visibly thin as you pick. A second tap stages a second tile; tapping a trayed tile puts it back. Confirm, cancel, the `Develop lowest available` shortcut and the **iron-source picker** all live in the mat modal's footer, so the whole action completes without leaving the mat. Works identically in hotseat and multiplayer (the mp-playthrough e2e drives it over the wire).

| Mat opens on the tile step (1280px) | Two tiles staged |
|---|---|
| ![mat open](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-81-images/mat-open-1280.png) | ![two staged](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-81-images/two-staged-1280.png) |

| Lightbulb Pottery tap → rulebook reason | Iron question asked in the mat |
|---|---|
| ![lightbulb reason](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-81-images/lightbulb-reason-1280.png) | ![iron picker](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-81-images/iron-picker-1280.png) |

| 390px | 390px, one staged |
|---|---|
| ![mobile](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-81-images/mat-open-390.png) | ![mobile staged](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-81-images/staged-390.png) |

## Engine (TDD first)

- `SELECT_TILES_FOR_DEVELOP` gains the **`canSelectTilesForDevelop`** guard — one or two picks, each industry must still hold that many developable tiles (lightbulb semantics mirror `executeDevelopAction` via the shared `developableTileQuantity`). **Tile legality only**: money/iron affordability deliberately stays on CONFIRM — that guard-vs-execution seam is pinned by `gameStore.money.test.ts` and left untouched.
- The event is now also accepted **mid-flow** from `choosingIronSource` and `confirmingDevelop` as a full-array replacement, so a second mat click grows a one-tile develop into a two-tile one (or shrinks it) without cancelling. Re-entering the iron step resets stale `chosenIronSources`.
- `explainRefusal` explains rejected picks: no tiles left, only-lightbulbs (the rulebook p.7 sentence, now shared from `gameUtils` so the dock, the mat and the server refusal all say the same words), or not enough developable copies.
- No new event types — `SELECT_TILES_FOR_DEVELOP` was already in the mp `ALLOWED_EVENTS` whitelist; a forged illegal pick is now refused by the guard with the exact reason.

## UI

- `components/develop-mat.ts` (`developMatView` + `stagedRemovals`) is the **only machine seam**: it asks `can()` / `explainRefusal` per candidate and re-derives no rule (per the AGENTS.md engine-owned-legality principle). Staged picks live in machine context, so they survive the MP intent→broadcast→rebuild round-trip and closing/reopening the modal.
- While the modal is open the dock steps down to a small "Picking tiles on your player mat…" aside — the modal owns `cancel-action` / `confirm-action` / `develop-lowest` / `iron-source`, so there are no duplicate testids and no controls stranded under the overlay. Closing the mat mid-flow leaves the dock with an "Open your mat" way back in.
- The old dock `DevelopTilePicker` grid is removed. The Gloucester develop-**bonus** flow (`SELECT_DEVELOP_TILE` during a sale) is untouched.
- No count numerals anywhere on the mat — quantity stays the physical stack; the preview just thins the pile.

## Tests

- New: `gameStore.developmat.test.ts` (guard + staged re-pick + CANCEL consumes nothing), `develop-mat.test.ts` (view seam + removal preview), `e2e/develop-mat.spec.ts` (armed pick, unstage, lightbulb reason, cancel unwind, close/reopen keeps staging).
- Updated: `bugfixes.spec.ts` two-tile develop now drives the mat path; `locate-city.spec.ts` hovers a modal control instead of the era-plate the overlay now covers (same assertion).
- `pnpm test` 76 files / 679 passed; `pnpm lint` + `pnpm typecheck` clean; **full Playwright suite 34/34** including the DB-backed `mp-playthrough` (two real browsers complete a develop with the iron picker through the new modal).

Note: a subset-filtered `vitest run src/store …` shows 10 failures in `gameUtils.industrySlots.test.ts`/`buildValidation.test.ts` that reproduce identically on a clean `e1b1330` checkout — pre-existing, unrelated, and green under the full `pnpm test` CI command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a player-mat interface for selecting tiles during Develop actions.
  * Added clear visual feedback for selectable, staged, blocked, and scrapped tiles.
  * Enabled reopening the mat without losing staged selections.
  * Added support for updating tile choices mid-action and resetting iron-source selections.

* **Bug Fixes**
  * Enforced lowest-tile development rules, including lightbulb Pottery restrictions.
  * Improved refusal messages for invalid Develop selections.
  * Added reduced-motion support for Develop animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->