### PR TITLE
fix(board): render the farm-brewery spur as rail in the rail era

### DIFF
--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -32,6 +32,7 @@ import {
   easeInOutCubic,
   planPanToCity,
 } from './pan-into-view'
+import { farmBrewerySpurStyle } from './route-style'
 
 /* ---------------- palette (mirrors theme.css) ---------------- */
 
@@ -869,15 +870,19 @@ export function BoardMap({
         {(() => {
           const mid = pointAt('kidderminster', 'worcester', 0.5)
           const fb = cityPos.farmBrewery2
-          const linked = builtLinks.has(linkKey('kidderminster', 'worcester'))
+          // Mirror the corridor's built type so a rail link reads rail (orange),
+          // a canal link canal (teal), and an unbuilt corridor the neutral
+          // potential hint — never a canal default in the rail era.
+          const kwBuilt = builtLinks.get(linkKey('kidderminster', 'worcester'))
+          const spur = farmBrewerySpurStyle(kwBuilt?.type ?? null)
           return (
             <path
               d={`M ${mid.x} ${mid.y} L ${fb.x} ${fb.y}`}
               fill="none"
-              stroke={linked ? '#4e9c96' : '#7a8b3d'}
-              strokeOpacity={linked ? 0.8 : 0.35}
-              strokeWidth={linked ? 3.5 : 2}
-              strokeDasharray={linked ? undefined : '4 5'}
+              stroke={spur.stroke}
+              strokeOpacity={spur.strokeOpacity}
+              strokeWidth={spur.strokeWidth}
+              strokeDasharray={spur.strokeDasharray}
               pointerEvents="none"
             />
           )

--- a/src/components/board/route-style.test.ts
+++ b/src/components/board/route-style.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { farmBrewerySpurStyle } from './route-style'
+
+describe('farmBrewerySpurStyle', () => {
+  it('paints a built rail link in the rail colour, not canal', () => {
+    // Regression: the spur used to hardcode the canal stroke (#4e9c96) whenever
+    // the corridor was linked, so a rail-era rail link rendered canal.
+    const style = farmBrewerySpurStyle('rail')
+    expect(style.stroke).toBe('#c2632f')
+    expect(style.stroke).not.toBe('#4e9c96')
+    expect(style.strokeDasharray).toBeUndefined()
+  })
+
+  it('paints a built canal link in the canal colour', () => {
+    const style = farmBrewerySpurStyle('canal')
+    expect(style.stroke).toBe('#4e9c96')
+    expect(style.strokeDasharray).toBeUndefined()
+  })
+
+  it('shows an era-neutral dashed potential hint when unbuilt', () => {
+    const style = farmBrewerySpurStyle(null)
+    expect(style.stroke).toBe('#7a8b3d')
+    // never a real canal / rail link graphic
+    expect(style.stroke).not.toBe('#4e9c96')
+    expect(style.stroke).not.toBe('#c2632f')
+    expect(style.strokeDasharray).toBe('4 5')
+  })
+})

--- a/src/components/board/route-style.ts
+++ b/src/components/board/route-style.ts
@@ -1,0 +1,50 @@
+// Pure styling for the southern Farm Brewery's implicit spur.
+//
+// farmBrewery2 has no connection edge of its own — the kidderminster–worcester
+// corridor connects all three locations (rules p.5, see
+// linkConnectedLocations in data/board.ts). The board draws a short visual
+// spur from that corridor to the brewery, and the spur MUST read with the same
+// era/type as the corridor it belongs to: a built rail link is orange, a built
+// canal link teal. It must never fall back to a canal graphic just because the
+// underlying edge supports canal — that was the rail-era bug where a built rail
+// link painted the spur canal-teal (#4e9c96 == the canal main stroke).
+
+export type RouteType = 'canal' | 'rail'
+
+export interface FarmSpurStyle {
+  stroke: string
+  strokeOpacity: number
+  strokeWidth: number
+  strokeDasharray?: string
+}
+
+// The route palette, shared with the corridor rendering in board-map.tsx.
+const CANAL_STROKE = '#4e9c96'
+const RAIL_STROKE = '#c2632f'
+// Unbuilt spur: an era-neutral olive "potential connection" hint, deliberately
+// distinct from any real (teal canal / orange rail) link graphic.
+const POTENTIAL_STROKE = '#7a8b3d'
+
+/**
+ * Stroke style for the farmBrewery2 spur, derived from the kidderminster–
+ * worcester corridor's BUILT type. A built link mirrors its own type's colour;
+ * an unbuilt corridor shows the era-neutral potential hint (never a canal
+ * graphic).
+ */
+export function farmBrewerySpurStyle(
+  builtType: RouteType | null,
+): FarmSpurStyle {
+  if (builtType) {
+    return {
+      stroke: builtType === 'canal' ? CANAL_STROKE : RAIL_STROKE,
+      strokeOpacity: 0.8,
+      strokeWidth: 3.5,
+    }
+  }
+  return {
+    stroke: POTENTIAL_STROKE,
+    strokeOpacity: 0.35,
+    strokeWidth: 2,
+    strokeDasharray: '4 5',
+  }
+}


### PR DESCRIPTION
## Bug
Captain-reported from play: in the **rail era**, the Kidderminster farm-brewery link renders with **canal** styling instead of rail.

## Confirmed cause
The southern Farm Brewery (`farmBrewery2`) has **no connection edge of its own** — the `kidderminster–worcester` corridor connects all three locations (rules p.5, `linkConnectedLocations`). `board-map.tsx` draws a short visual **spur** from that corridor to the brewery, and its *linked* stroke was hardcoded:

```tsx
stroke={linked ? '#4e9c96' : '#7a8b3d'}   // #4e9c96 == the canal main-stroke colour
```

So whenever the k–w corridor is built — **regardless of whether it's a canal or a rail link, and regardless of era** — the spur painted canal-teal. A rail link built there in the rail era therefore read as canal. The board data is *correct* (every relevant edge is `types: ['canal','rail']`); this was purely a rendering fallback to a canal default, not a legality/data bug.

The main corridor rendering (`renderType = built ? built.type : activeThisEra ? era : …`) was already correct — the bug lived only in the hand-rolled `farmBrewery2` spur.

## Reproduction
- Loaded `/?era=rail`; inspected the spur `path` ending `L 132 1030` (farmBrewery2 at 132,1030).
- **Unbuilt** spur renders olive `#7a8b3d` dashed (a "potential" hint) — fine.
- The **linked** branch is hardcoded `#4e9c96` (canal teal) — identical to the canal main stroke (`board-map.tsx:770`); rail is `#c2632f` (`board-map.tsx:796`). No reachable demo fixture builds that exact k–w link (it isn't a legal target in the rail fixture), so the linked case is pinned by a unit test rather than a fixture screenshot.

## Fix
Derive the spur's stroke from the corridor's **built type** via a new pure helper `farmBrewerySpurStyle` (`route-style.ts`):
- built **rail** → rail orange `#c2632f`
- built **canal** → canal teal `#4e9c96` (unchanged — no canal-era regression)
- unbuilt → era-neutral olive dashed hint (unchanged)

Engine/data untouched; marker-anchor placement (#80) untouched.

Invariant encoded: for a `['canal','rail']` edge, the rail era never renders the spur canal for a *built* link; an unbuilt corridor keeps a clearly-distinct olive hint (not a canal graphic).

## Tests
- New `src/components/board/route-style.test.ts` — asserts built-rail ≠ `#4e9c96`, built-canal = `#4e9c96`, unbuilt = olive dashed (fails on the old hardcoded logic).
- Live browser: unbuilt spur unchanged (olive) in **both** rail and canal era — no regression.
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test` (689 pass) ✓ · board e2e `coverage.spec.ts` + `bugfixes.spec.ts` (14 pass) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)