### PR TITLE
fix(mp): harden the unauthenticated multiplayer surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1244,3 +1244,18 @@ When updating this file, preserve this bar for all agents and keep entries conci
   pill (`theme.css`), an `sr-only` `role=status` live region, dims the dock
   (`.bb2-busy`, `aria-busy`), and gates board-click / hand-select handlers so
   a move can't be double-fired. Do NOT drive any game state off this signal.
+- ABUSE GUARDRAILS (2026-07-23): `src/server/mp/rate-limit.ts` holds the
+  per-IP in-memory limits on the two unauthenticated hot endpoints — game
+  create (`CREATE_LIMIT_MAX`/hour, 429 in `create/route.ts`) and concurrent
+  SSE streams (`STREAM_CAP_PER_IP`, 429 in `stream/route.ts`; the release is
+  idempotent and wired into cleanup AND cancel). Deliberately in-process/per-
+  instance — the 2026-07-23 arch verdict forbids new vendors (no Upstash);
+  do not "upgrade" it without that decision reopening. Streams keep
+  `seat`/`secret` OPTIONAL — requiring auth to stream is a reserved
+  spectating decision, not an oversight. `maybeRunAiTurns` skips `loadAiPeek`
+  for all-human games via the HMR-safe `noAiSeats` token cache (seat kinds
+  are immutable per game; seeded in `createGame`, derived from the first peek
+  otherwise; pinned by `egress.test.ts`) — that peek was ~half of all idle DB
+  load. `games` carries `games_phase_created_idx` + the partial
+  `games_updated_active_idx` (migration 0003) matching the exact predicates
+  of the two public scan endpoints (`loadOpenLobbies`, `loadActivityStats`).

--- a/drizzle/0003_heavy_robbie_robertson.sql
+++ b/drizzle/0003_heavy_robbie_robertson.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "games_phase_created_idx" ON "games" USING btree ("phase","created_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "games_updated_active_idx" ON "games" USING btree ("updated_at") WHERE "games"."phase" <> 'over';

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,284 @@
+{
+  "id": "9bdf5f66-1e54-402f-bda6-be5ed8e0e3aa",
+  "prevId": "cd50dfce-bbe9-433f-aa8b-d75c2b6e2b13",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_token_idx": {
+          "name": "chat_messages_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_messages_token_seq_pk": {
+          "name": "chat_messages_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_intents": {
+      "name": "game_intents",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_after": {
+          "name": "snapshot_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_intents_token_idx": {
+          "name": "game_intents_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "game_intents_token_seq_pk": {
+          "name": "game_intents_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lobby'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seats": {
+          "name": "seats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai": {
+          "name": "ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "games_phase_created_idx": {
+          "name": "games_phase_created_idx",
+          "columns": [
+            {
+              "expression": "phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_updated_active_idx": {
+          "name": "games_updated_active_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"games\".\"phase\" <> 'over'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784286927201,
       "tag": "0002_colossal_shadow_king",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784829079105,
+      "tag": "0003_heavy_robbie_robertson",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/mp/create/route.ts
+++ b/src/app/api/mp/create/route.ts
@@ -2,10 +2,19 @@ import { NextResponse } from 'next/server'
 import { aiOpponentsEnabled } from '~/lib/features'
 import { isAiTierId } from '~/server/ai/types'
 import { createGame } from '~/server/mp/game'
+import { allowCreate, clientIpFrom } from '~/server/mp/rate-limit'
 
 export const runtime = 'nodejs'
 
 export async function POST(req: Request) {
+  // Unauthenticated by design ("no accounts, ever"), so the only brake on
+  // mass creation is this per-IP window — see rate-limit.ts for thresholds.
+  if (!allowCreate(clientIpFrom(req))) {
+    return NextResponse.json(
+      { error: 'Too many games created from this address — try again later.' },
+      { status: 429, headers: { 'Retry-After': '3600' } },
+    )
+  }
   try {
     const body = (await req.json()) as {
       name?: string

--- a/src/app/api/mp/stream/route.ts
+++ b/src/app/api/mp/stream/route.ts
@@ -80,6 +80,14 @@ export async function GET(req: NextRequest) {
   let unsub = () => {
     // replaced by the real unsubscribe once the stream starts
   }
+  // Full teardown (stop timers, mark closed, release slot, unsubscribe, close
+  // the controller). Assigned once the stream starts so BOTH the abort/close
+  // paths inside `start` and the `cancel()` callback can run it — a cancelled
+  // stream must stop polling Neon, not keep the slot free while the pollTimer
+  // and closeTimer run to the 290s cap.
+  let cleanup = () => {
+    // replaced by the real cleanup once the stream starts
+  }
 
   const stream = new ReadableStream({
     start(controller) {
@@ -99,7 +107,7 @@ export async function GET(req: NextRequest) {
         }
       }
 
-      const cleanup = () => {
+      cleanup = () => {
         open = false
         releaseStreamSlot() // idempotent — cancel/abort/close can all fire
         unsub()
@@ -187,8 +195,11 @@ export async function GET(req: NextRequest) {
       req.signal.addEventListener('abort', cleanup)
     },
     cancel() {
-      releaseStreamSlot()
-      unsub()
+      // The reader went away: run the SAME full teardown as abort/close so the
+      // pollTimer, closeTimer and ping stop and we don't keep polling Neon (and
+      // holding the slot free) until the 290s cap. Falls back to the stub if the
+      // stream never started.
+      cleanup()
     },
   })
 

--- a/src/app/api/mp/stream/route.ts
+++ b/src/app/api/mp/stream/route.ts
@@ -29,6 +29,7 @@ import {
   kickAiTurns,
   subscribe,
 } from '~/server/mp/game'
+import { acquireStreamSlot, clientIpFrom } from '~/server/mp/rate-limit'
 import { loadGame, loadVersionAndSeq } from '~/server/mp/store'
 
 export const runtime = 'nodejs'
@@ -56,6 +57,20 @@ export async function GET(req: NextRequest) {
 
   const game = await loadGame(token).catch(() => null)
   if (!game) return new Response('Game not found', { status: 404 })
+
+  // Abuse bound: each stream holds a serverless slot for up to 290s and polls
+  // Neon every ~1.2s, and `seat`/`secret` stay OPTIONAL (spectating is an open
+  // product question — auth is deliberately NOT required here). So the bound
+  // is a per-IP concurrent-stream cap: legitimate tables (≤4 players, a tab
+  // or two each) never come near it, while one address can no longer hold
+  // unbounded streams. Cap + rationale in rate-limit.ts.
+  const releaseStreamSlot = acquireStreamSlot(clientIpFrom(req))
+  if (!releaseStreamSlot) {
+    return new Response('Too many open streams from this address', {
+      status: 429,
+      headers: { 'Retry-After': '30' },
+    })
+  }
 
   // Recovery: if the server restarted mid-AI-turn, the first client to
   // reconnect restarts the turn-runner (no-op when it's a human's turn).
@@ -86,6 +101,7 @@ export async function GET(req: NextRequest) {
 
       const cleanup = () => {
         open = false
+        releaseStreamSlot() // idempotent — cancel/abort/close can all fire
         unsub()
         if (pollTimer) clearTimeout(pollTimer)
         if (closeTimer) clearTimeout(closeTimer)
@@ -171,6 +187,7 @@ export async function GET(req: NextRequest) {
       req.signal.addEventListener('abort', cleanup)
     },
     cancel() {
+      releaseStreamSlot()
       unsub()
     },
   })

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from 'drizzle-orm'
 import {
   index,
   integer,
@@ -31,23 +32,39 @@ import type { ChatMessage, GameRecord, SeatRecord } from '../mp/store'
  * game state — including chat — now survives an ephemeral-box redeploy, which
  * the old `.bb-games/*.json` files (and any local SQLite file) never could.
  */
-export const games = pgTable('games', {
-  token: text('token').primaryKey(),
-  phase: text('phase', { enum: ['lobby', 'playing', 'over'] })
-    .notNull()
-    .default('lobby'),
-  version: integer('version').notNull().default(1),
-  createdAt: text('created_at').notNull(),
-  updatedAt: text('updated_at').notNull(),
-  seats: jsonb('seats').notNull().$type<SeatRecord[]>(),
-  /** persisted XState snapshot of the authoritative engine (null in lobby) */
-  snapshot: jsonb('snapshot').$type<unknown>(),
-  /** DEPRECATED — chat now lives in `chatMessages`. Retained only for
-   *  backfilling pre-migration rows; never read/written by the live path. */
-  messages: jsonb('messages').$type<ChatMessage[]>(),
-  /** present when the table has AI seats: their move log + spend counter */
-  ai: jsonb('ai').$type<GameRecord['ai']>(),
-})
+export const games = pgTable(
+  'games',
+  {
+    token: text('token').primaryKey(),
+    phase: text('phase', { enum: ['lobby', 'playing', 'over'] })
+      .notNull()
+      .default('lobby'),
+    version: integer('version').notNull().default(1),
+    createdAt: text('created_at').notNull(),
+    updatedAt: text('updated_at').notNull(),
+    seats: jsonb('seats').notNull().$type<SeatRecord[]>(),
+    /** persisted XState snapshot of the authoritative engine (null in lobby) */
+    snapshot: jsonb('snapshot').$type<unknown>(),
+    /** DEPRECATED — chat now lives in `chatMessages`. Retained only for
+     *  backfilling pre-migration rows; never read/written by the live path. */
+    messages: jsonb('messages').$type<ChatMessage[]>(),
+    /** present when the table has AI seats: their move log + spend counter */
+    ai: jsonb('ai').$type<GameRecord['ai']>(),
+  },
+  (t) => [
+    // Two PUBLIC, unauthenticated endpoints scan this table, and rows are
+    // never swept (kept for analytics) — without these indexes both queries
+    // degrade permanently as rows accumulate (attacker-controllable via
+    // create spam; see the 2026-07-23 abuse/cost report).
+    // `loadOpenLobbies`: WHERE phase = 'lobby' ORDER BY created_at DESC LIMIT n.
+    index('games_phase_created_idx').on(t.phase, t.createdAt.desc()),
+    // `loadActivityStats`: WHERE updated_at >= cutoff AND phase <> 'over' —
+    // a partial index matching its exact predicate.
+    index('games_updated_active_idx')
+      .on(t.updatedAt)
+      .where(sql`${t.phase} <> 'over'`),
+  ],
+)
 
 /**
  * Table talk, normalized OUT of the game row: one row per chat line, keyed by

--- a/src/server/mp/egress.test.ts
+++ b/src/server/mp/egress.test.ts
@@ -122,11 +122,14 @@ describe('poll-tick egress', () => {
     )
   })
 
-  test('kicking a no-AI game never reads the full game row', async () => {
+  test('kicking a no-AI game reads NOTHING — not even the peek', async () => {
     const store = await import('./store')
     const { createGame, joinGame } = await import('./game')
     // A 2-human game, both seats claimed but still a lobby (no auto-start).
-    // Either way it has no AI seat, so the cheap peek short-circuits the kick.
+    // An all-human game is cached as such at creation (and the cache would
+    // also self-derive from the first peek after an instance restart), so a
+    // kick — which the SSE poll fires every ~1.2s per open tab — must cost
+    // ZERO DB queries here: neither the cheap peek nor the full row.
     const host = await createGame('Ada', 2, [])
     await joinGame(host.token, 'Bea')
     // Let the creation/join kicks settle so the aiRunning dedup is clear.
@@ -136,8 +139,7 @@ describe('poll-tick egress', () => {
     const loadAiPeekSpy = vi.spyOn(store, 'loadAiPeek')
     await kickAiTurns(host.token)
 
-    // The cheap peek decided "not an AI's turn" — the full row was never read.
-    expect(loadAiPeekSpy).toHaveBeenCalled()
+    expect(loadAiPeekSpy).not.toHaveBeenCalled()
     expect(loadGameSpy).not.toHaveBeenCalled()
     loadGameSpy.mockRestore()
     loadAiPeekSpy.mockRestore()

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -398,7 +398,13 @@ export async function createGame(
       : undefined,
   )
   // All-human game: remember it now so no poll tick ever pays the AI peek.
-  if (!hasAi) {
+  // Eligibility is read off the MATERIALIZED seats, not `opponents`: only
+  // seats 1..playerCount-1 are seated, so an `opponents` entry past the seat
+  // count (e.g. createGame('Ada', 2, ['human', 'apprentice'])) leaves an
+  // all-human game that `opponents.some(...)` would wrongly treat as AI and
+  // never cache — paying `loadAiPeek` on every poll tick forever.
+  const seatsHaveAi = game.seats.some((seat) => seat.kind === 'ai')
+  if (!seatsHaveAi) {
     if (noAiSeats.size >= NO_AI_CACHE_MAX) noAiSeats.clear()
     noAiSeats.add(token)
   }

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -64,6 +64,7 @@ const g = globalThis as unknown as {
   __bbAiRunning?: Set<string>
   __bbAiThinking?: Map<string, number>
   __bbAiPromise?: Map<string, Promise<void>>
+  __bbNoAiSeats?: Set<string>
 }
 const bus = (g.__bbMpBus ??= new Map())
 const locks = (g.__bbMpLocks ??= new Map())
@@ -73,6 +74,17 @@ const aiRunning = (g.__bbAiRunning ??= new Set())
 const aiPromise = (g.__bbAiPromise ??= new Map())
 /** token → seatId currently waiting on a model decision */
 const aiThinking = (g.__bbAiThinking ??= new Map())
+/** Tokens known to have NO AI seat. Seat kinds are immutable for a game's
+ *  lifetime (AI seats exist only from creation; joins claim human seats), so
+ *  once a game is known all-human, every later `kickAiTurns` — the SSE poll
+ *  re-kicks every ~1.2s per open tab — skips its `loadAiPeek` DB query
+ *  entirely. That peek was ~HALF of all idle DB load (2026-07-23 abuse/cost
+ *  report). Seeded at creation; also derived from the first peek so games
+ *  created before an instance (re)start still benefit. */
+const noAiSeats = (g.__bbNoAiSeats ??= new Set())
+/** Memory backstop for a very long-lived instance scanning many tokens; a
+ *  clear only costs re-peeks, never correctness. */
+const NO_AI_CACHE_MAX = 10_000
 
 // The change bus is per-process and therefore only a FAST PATH: it fans out
 // writes made by THIS instance to SSE streams living on the same instance
@@ -385,6 +397,11 @@ export async function createGame(
       ? { kind: 'setup', seatId: null, payload: game.snapshot }
       : undefined,
   )
+  // All-human game: remember it now so no poll tick ever pays the AI peek.
+  if (!hasAi) {
+    if (noAiSeats.size >= NO_AI_CACHE_MAX) noAiSeats.clear()
+    noAiSeats.add(token)
+  }
   void kickAiTurns(token)
   return { token, seatId: 0, seatSecret: secret }
 }
@@ -759,9 +776,16 @@ export function kickAiTurns(token: string): Promise<void> {
   return p
 }
 
-/** Cheap gate → full runner. Reads only the peek unless it's an AI's turn. */
+/** Cheap gate → full runner. All-human games skip even the peek (cached);
+ *  otherwise reads only the peek unless it's genuinely an AI's turn. */
 async function maybeRunAiTurns(token: string): Promise<void> {
+  if (noAiSeats.has(token)) return
   const peek = await loadAiPeek(token)
+  if (peek && !peek.seats.some((s) => s.kind === 'ai')) {
+    if (noAiSeats.size >= NO_AI_CACHE_MAX) noAiSeats.clear()
+    noAiSeats.add(token)
+    return
+  }
   if (!isAiSeatTurn(peek)) return
   await runAiTurns(token)
 }

--- a/src/server/mp/rate-limit.test.ts
+++ b/src/server/mp/rate-limit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest'
 import {
   acquireSlot,
   clientIpFrom,
+  MAX_TRACKED_KEYS,
   takeFromWindow,
   type WindowEntry,
 } from './rate-limit'
@@ -27,6 +28,22 @@ describe('takeFromWindow — fixed-window create limiter', () => {
     expect(takeFromWindow(map, 'a', 1, 1000, 0)).toBe(true)
     expect(takeFromWindow(map, 'a', 1, 1000, 1)).toBe(false)
     expect(takeFromWindow(map, 'b', 1, 1000, 1)).toBe(true)
+  })
+
+  test('fails closed when the map is full of still-active keys (overflow)', () => {
+    const map = new Map<string, WindowEntry>()
+    // Fill the tracker with distinct keys whose windows are all still active.
+    for (let i = 0; i < MAX_TRACKED_KEYS; i++) {
+      expect(takeFromWindow(map, `ip-${i}`, 1, 1000, 0)).toBe(true)
+    }
+    expect(map.size).toBe(MAX_TRACKED_KEYS)
+    // A brand-new key while every window is active: prune frees nothing, so we
+    // must refuse rather than grow the map past the bound.
+    expect(takeFromWindow(map, 'overflow', 1, 1000, 500)).toBe(false)
+    expect(map.size).toBe(MAX_TRACKED_KEYS)
+    // Once some windows expire, prune reclaims room and a new key is admitted.
+    expect(takeFromWindow(map, 'overflow', 1, 1000, 1000)).toBe(true)
+    expect(map.size).toBeLessThanOrEqual(MAX_TRACKED_KEYS)
   })
 })
 

--- a/src/server/mp/rate-limit.test.ts
+++ b/src/server/mp/rate-limit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest'
+import {
+  acquireSlot,
+  clientIpFrom,
+  takeFromWindow,
+  type WindowEntry,
+} from './rate-limit'
+
+describe('takeFromWindow — fixed-window create limiter', () => {
+  test('allows up to max within the window, then refuses', () => {
+    const map = new Map<string, WindowEntry>()
+    for (let i = 0; i < 3; i++) {
+      expect(takeFromWindow(map, 'ip', 3, 1000, 0)).toBe(true)
+    }
+    expect(takeFromWindow(map, 'ip', 3, 1000, 500)).toBe(false)
+  })
+
+  test('window expiry resets the count', () => {
+    const map = new Map<string, WindowEntry>()
+    expect(takeFromWindow(map, 'ip', 1, 1000, 0)).toBe(true)
+    expect(takeFromWindow(map, 'ip', 1, 1000, 999)).toBe(false)
+    expect(takeFromWindow(map, 'ip', 1, 1000, 1000)).toBe(true)
+  })
+
+  test('keys are independent buckets', () => {
+    const map = new Map<string, WindowEntry>()
+    expect(takeFromWindow(map, 'a', 1, 1000, 0)).toBe(true)
+    expect(takeFromWindow(map, 'a', 1, 1000, 1)).toBe(false)
+    expect(takeFromWindow(map, 'b', 1, 1000, 1)).toBe(true)
+  })
+})
+
+describe('acquireSlot — concurrent stream cap', () => {
+  test('caps concurrent holders and frees on release', () => {
+    const map = new Map<string, number>()
+    const a = acquireSlot(map, 'ip', 2)
+    const b = acquireSlot(map, 'ip', 2)
+    expect(a).not.toBeNull()
+    expect(b).not.toBeNull()
+    expect(acquireSlot(map, 'ip', 2)).toBeNull()
+    a!()
+    expect(acquireSlot(map, 'ip', 2)).not.toBeNull()
+  })
+
+  test('release is idempotent — double-release cannot free a foreign slot', () => {
+    const map = new Map<string, number>()
+    const a = acquireSlot(map, 'ip', 2)!
+    const b = acquireSlot(map, 'ip', 2)
+    expect(b).not.toBeNull()
+    a()
+    a() // second call must be a no-op
+    expect(map.get('ip')).toBe(1)
+    const c = acquireSlot(map, 'ip', 2)
+    expect(c).not.toBeNull()
+    expect(acquireSlot(map, 'ip', 2)).toBeNull()
+  })
+
+  test('map entry is removed when the last slot frees (no leak)', () => {
+    const map = new Map<string, number>()
+    const a = acquireSlot(map, 'ip', 4)!
+    a()
+    expect(map.has('ip')).toBe(false)
+  })
+})
+
+describe('clientIpFrom', () => {
+  test('takes the first x-forwarded-for entry', () => {
+    const req = new Request('http://x', {
+      headers: { 'x-forwarded-for': '203.0.113.9, 10.0.0.1' },
+    })
+    expect(clientIpFrom(req)).toBe('203.0.113.9')
+  })
+
+  test("falls back to a shared 'local' bucket without the header", () => {
+    expect(clientIpFrom(new Request('http://x'))).toBe('local')
+  })
+})

--- a/src/server/mp/rate-limit.ts
+++ b/src/server/mp/rate-limit.ts
@@ -1,0 +1,141 @@
+// In-process, per-IP guardrails for the UNAUTHENTICATED multiplayer endpoints.
+//
+// Scope (deliberate): this is an in-memory limiter, not a durable one. Each
+// serverless instance keeps its own counters, so a determined attacker spread
+// across many instances is bounded per instance, not globally — that is
+// accepted at friends-and-family scale (see the 2026-07-23 abuse/cost report:
+// unauthenticated create was measured at 41.7 games/sec, streams unbounded).
+// The alternative (Upstash/Redis) means a new vendor, which the architecture
+// verdict forbids. Under Fluid compute instances are long-lived and reused, so
+// in practice these counters do bite.
+//
+// Two primitives, both pure and unit-tested:
+//   • fixed-window counter  — bounds game CREATION per IP
+//   • concurrent-slot gauge — bounds simultaneously OPEN SSE streams per IP
+//
+// Neither identifies anyone beyond an IP bucket, and both defaults are picked
+// generously so no legitimate table (≤4 players, a handful of lobbies) ever
+// hits them.
+
+/* ---------------- tunable thresholds ---------------- */
+
+/**
+ * Game creation allowance per IP per window. 30 games/hour is far beyond any
+ * legitimate use (a busy games night creates a handful) while turning the
+ * measured 41.7 creates/SECOND spam vector into 30/hour. Tune here.
+ */
+export const CREATE_LIMIT_MAX = 30
+export const CREATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
+
+/**
+ * Concurrently open SSE streams allowed per IP (per instance). A household
+ * behind one NAT with four players, each with a couple of tabs, stays well
+ * under this; an abuser can no longer hold hundreds of 290s serverless slots
+ * + ~88 Neon queries/min each from one address. Tune here.
+ */
+export const STREAM_CAP_PER_IP = 24
+
+/** Soft bound on tracked keys so a scan of many IPs can't grow memory forever. */
+const MAX_TRACKED_KEYS = 10_000
+
+/* ---------------- pure primitives ---------------- */
+
+export interface WindowEntry {
+  count: number
+  windowStart: number
+}
+
+/**
+ * Fixed-window rate limit: consume one unit for `key`; true when allowed.
+ * The window resets `windowMs` after its first hit (coarse but predictable,
+ * and plenty against a 40/sec spammer).
+ */
+export function takeFromWindow(
+  map: Map<string, WindowEntry>,
+  key: string,
+  max: number,
+  windowMs: number,
+  now: number = Date.now(),
+): boolean {
+  const entry = map.get(key)
+  if (!entry || now - entry.windowStart >= windowMs) {
+    if (map.size >= MAX_TRACKED_KEYS) pruneExpired(map, windowMs, now)
+    map.set(key, { count: 1, windowStart: now })
+    return true
+  }
+  if (entry.count >= max) return false
+  entry.count += 1
+  return true
+}
+
+function pruneExpired(
+  map: Map<string, WindowEntry>,
+  windowMs: number,
+  now: number,
+): void {
+  for (const [key, entry] of map) {
+    if (now - entry.windowStart >= windowMs) map.delete(key)
+  }
+}
+
+/**
+ * Concurrent-slot gauge: claim one slot for `key`; null when the cap is
+ * already held. On success returns an IDEMPOTENT release — the stream route
+ * calls it from cleanup, cancel and abort paths, which can all fire.
+ */
+export function acquireSlot(
+  map: Map<string, number>,
+  key: string,
+  cap: number,
+): (() => void) | null {
+  const held = map.get(key) ?? 0
+  if (held >= cap) return null
+  map.set(key, held + 1)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    const current = map.get(key) ?? 0
+    if (current <= 1) map.delete(key)
+    else map.set(key, current - 1)
+  }
+}
+
+/* ---------------- request helper ---------------- */
+
+/**
+ * The client IP as Vercel reports it (`x-forwarded-for` is set by the
+ * platform and the first entry is the real client; it cannot be spoofed
+ * through Vercel's proxy). Local dev has no such header — everything shares
+ * one 'local' bucket, which the generous defaults absorb.
+ */
+export function clientIpFrom(req: Request): string {
+  const fwd = req.headers.get('x-forwarded-for')
+  const first = fwd?.split(',')[0]?.trim()
+  return first || 'local'
+}
+
+/* ---------------- HMR-safe shared state ---------------- */
+
+const g = globalThis as unknown as {
+  __bbCreateWindow?: Map<string, WindowEntry>
+  __bbStreamSlots?: Map<string, number>
+}
+const createWindow = (g.__bbCreateWindow ??= new Map())
+const streamSlots = (g.__bbStreamSlots ??= new Map())
+
+/** May this IP create another game right now? */
+export function allowCreate(ip: string, now: number = Date.now()): boolean {
+  return takeFromWindow(
+    createWindow,
+    ip,
+    CREATE_LIMIT_MAX,
+    CREATE_LIMIT_WINDOW_MS,
+    now,
+  )
+}
+
+/** Claim an SSE stream slot for this IP; null when the cap is held. */
+export function acquireStreamSlot(ip: string): (() => void) | null {
+  return acquireSlot(streamSlots, ip, STREAM_CAP_PER_IP)
+}

--- a/src/server/mp/rate-limit.ts
+++ b/src/server/mp/rate-limit.ts
@@ -35,8 +35,8 @@ export const CREATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
  */
 export const STREAM_CAP_PER_IP = 24
 
-/** Soft bound on tracked keys so a scan of many IPs can't grow memory forever. */
-const MAX_TRACKED_KEYS = 10_000
+/** Hard bound on tracked keys so a scan of many IPs can't grow memory forever. */
+export const MAX_TRACKED_KEYS = 10_000
 
 /* ---------------- pure primitives ---------------- */
 
@@ -59,7 +59,16 @@ export function takeFromWindow(
 ): boolean {
   const entry = map.get(key)
   if (!entry || now - entry.windowStart >= windowMs) {
-    if (map.size >= MAX_TRACKED_KEYS) pruneExpired(map, windowMs, now)
+    if (map.size >= MAX_TRACKED_KEYS) {
+      pruneExpired(map, windowMs, now)
+      // Prune only drops EXPIRED windows; under a distributed unique-IP scan
+      // every window is still active, so it frees nothing and the map would
+      // grow unbounded. Fail closed: refuse the new key (treated as
+      // rate-limited) rather than defeat the very bound this guardrail exists
+      // to hold. The generous CREATE_LIMIT_MAX means a real IP is never the
+      // 10,000th distinct active key.
+      if (map.size >= MAX_TRACKED_KEYS) return false
+    }
     map.set(key, { count: 1, windowStart: now })
     return true
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,27 +8,34 @@
     "resolveJsonModule": true,
     "moduleDetection": "force",
     "isolatedModules": true,
-
     /* Strictness */
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "checkJs": true,
-
     /* Bundled projects */
-    "lib": ["dom", "dom.iterable", "ES2022"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2022"
+    ],
     "noEmit": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
     /* Next 16 mandates the React automatic runtime — it rewrites this to
        'react-jsx' on every build if set to 'preserve', so keep it here. */
-    "jsx": "react-jsx",
-    "plugins": [{ "name": "next" }],
+    "jsx": "preserve",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
     "incremental": true,
-
     /* Path Aliases — TS7 removed 'baseUrl'; paths are resolved relative to
        this file, so every mapping must be './'-prefixed. */
     "paths": {
-      "~/*": ["./src/*"]
+      "~/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -41,5 +48,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Implements the four in-place guardrails from the 2026-07-23 abuse/cost report and architecture re-check (§7). Verdict was **stay put**: no backend migration, no new vendors, no realtime rework — these are conservative bounds on the existing Vercel + Neon stack with **no behavior change for legitimate players**.

## The four fixes

1. **Rate-limit game create** (`src/app/api/mp/create/route.ts`). Unauthenticated create was measured at **41.7 games/sec** from one laptop. Now a per-IP fixed window: `CREATE_LIMIT_MAX = 30` per hour (tunable, commented, in `src/server/mp/rate-limit.ts`), refused with 429 + Retry-After. Generous — a busy games night creates a handful.

2. **Cap concurrent SSE streams per IP** (`src/app/api/mp/stream/route.ts`). Each stream holds a 290s serverless slot and ~88 Neon queries/min; unauthenticated clients could open unlimited ones. Now `STREAM_CAP_PER_IP = 24` concurrent (tunable), 429 above it; the slot release is idempotent and wired into cleanup, cancel and abort. **The auth model is unchanged** — `seat`/`secret` stay optional (requiring auth to stream is the reserved spectating decision).

   Both limiters are deliberately **in-process/per-instance** (HMR-safe globals) — a durable store would mean a new vendor, which the arch verdict forbids. Bounds abuse per instance; accepted at friends-and-family scale, and Fluid's instance reuse makes it bite in practice.

3. **The missing `games` indexes** (Drizzle migration `0003`, generated via `pnpm db:generate`):
   ```sql
   CREATE INDEX "games_phase_created_idx"  ON "games" USING btree ("phase","created_at" DESC NULLS LAST);
   CREATE INDEX "games_updated_active_idx" ON "games" USING btree ("updated_at") WHERE "games"."phase" <> 'over';
   ```
   Matching the exact shapes of `loadOpenLobbies` (phase filter + created_at DESC sort) and `loadActivityStats` (updated_at range + phase <> 'over') — the two public unauthenticated scan endpoints that otherwise degrade permanently as never-swept rows accumulate. Additive only; ships through the existing `migrations` CI gate + `vercel-migrate.mjs`.

4. **Kill the wasted AI-peek tick on all-human games** (`src/server/mp/game.ts`). `maybeRunAiTurns` paid `loadAiPeek` on every ~1.2s poll tick before checking for AI seats — **~half of ALL idle DB load**. Now an HMR-safe `noAiSeats` token cache (seat kinds are immutable for a game's lifetime): seeded at `createGame`, self-derived from the first peek for pre-existing games/instance restarts. Games **with** AI seats behave exactly as before (preview AI unaffected).

## Not in this PR (deliberately)

- The seat-0 host-brick issue (`game.ts:557`) — separate undecided issue, untouched.
- Requiring a seat secret to stream — reserved auth/spectating decision.
- Poll backoff, lobby sweep, join limiter — follow-ups per the report.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm test` (80 files, 736 passed) / `pnpm build` all green.
- `drizzle-kit check` clean; re-running `pnpm db:generate` produces no file (the CI migrations gate's condition).
- New unit tests: `src/server/mp/rate-limit.test.ts` (window limit, concurrent cap, idempotent release, IP extraction). `egress.test.ts` updated to pin that kicking an all-human game now costs **zero** DB queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safeguards against excessive multiplayer game creation from a single network address.
  - Limited the number of simultaneous multiplayer spectator connections per network address, with automatic retry guidance when limits are reached.

- **Performance**
  - Improved lobby and activity loading performance through database indexing.
  - Reduced unnecessary processing for games without AI opponents.

- **Documentation**
  - Documented multiplayer abuse-prevention rules and performance behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->