### PR TITLE
feat(mp): randomize start player, online-default setup, named + private lobbies

### DIFF
--- a/drizzle/0004_whole_roughhouse.sql
+++ b/drizzle/0004_whole_roughhouse.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "games" ADD COLUMN "name" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "games" ADD COLUMN "visibility" text DEFAULT 'public' NOT NULL;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,298 @@
+{
+  "id": "80e882c8-9354-437b-b5e8-c5a7c5dc7275",
+  "prevId": "9bdf5f66-1e54-402f-bda6-be5ed8e0e3aa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_token_idx": {
+          "name": "chat_messages_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_messages_token_seq_pk": {
+          "name": "chat_messages_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_intents": {
+      "name": "game_intents",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_after": {
+          "name": "snapshot_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_intents_token_idx": {
+          "name": "game_intents_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "game_intents_token_seq_pk": {
+          "name": "game_intents_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lobby'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seats": {
+          "name": "seats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai": {
+          "name": "ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "games_phase_created_idx": {
+          "name": "games_phase_created_idx",
+          "columns": [
+            {
+              "expression": "phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_updated_active_idx": {
+          "name": "games_updated_active_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"games\".\"phase\" <> 'over'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1784829079105,
       "tag": "0003_heavy_robbie_robertson",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1784833786840,
+      "tag": "0004_whole_roughhouse",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/atlas.spec.ts
+++ b/e2e/atlas.spec.ts
@@ -25,8 +25,10 @@ test('fresh game: setup charter → Loan action end-to-end → pass gate', async
 }) => {
   await page.goto('/?fresh=1')
 
-  // Setup charter: pick 2 players, name player 1, start.
+  // Setup charter: pick the local hotseat mode (online is the default now),
+  // 2 players, name player 1, start.
   await expect(page.getByText('Company charter')).toBeVisible()
+  await page.getByTestId('mode-local').click()
   await page.getByRole('button', { name: '2', exact: true }).click()
   await page.getByPlaceholder('Eliza').fill('Ada')
   await page.getByRole('button', { name: 'Open the ledger' }).click()

--- a/e2e/hand-tray.spec.ts
+++ b/e2e/hand-tray.spec.ts
@@ -96,6 +96,7 @@ test.describe('phone: fit + tap-to-peek', () => {
   test('a full 8-card opening hand fits a 375px viewport', async ({ page }) => {
     // A fresh game deals the worst case: 8 cards (the ?demo hand holds 5).
     await page.goto('/?fresh=1')
+    await page.getByTestId('mode-local').tap()
     await page.getByRole('button', { name: '2', exact: true }).tap()
     await page.getByRole('button', { name: 'Open the ledger' }).tap()
 

--- a/e2e/round-curtain.spec.ts
+++ b/e2e/round-curtain.spec.ts
@@ -36,6 +36,8 @@ test('round end: curtain reports spends and switches the turn order', async ({
   page,
 }) => {
   await page.goto('/?fresh=1')
+  // "Play online" is the default mode now — pick the local hotseat charter.
+  await page.getByTestId('mode-local').click()
   await page.getByRole('button', { name: '2', exact: true }).click()
   await page.getByPlaceholder('Eliza').fill('Ada')
   await page.getByRole('button', { name: 'Open the ledger' }).click()
@@ -84,6 +86,7 @@ test('round curtain: any key dismisses it and it does not return', async ({
   page,
 }) => {
   await page.goto('/?fresh=1')
+  await page.getByTestId('mode-local').click()
   await page.getByRole('button', { name: '2', exact: true }).click()
   await page.getByRole('button', { name: 'Open the ledger' }).click()
 

--- a/src/app/api/mp/create/route.ts
+++ b/src/app/api/mp/create/route.ts
@@ -18,6 +18,10 @@ export async function POST(req: Request) {
   try {
     const body = (await req.json()) as {
       name?: string
+      /** optional short table name shown in the lobby browser + masthead */
+      gameName?: string
+      /** 'private' hides the table from the public lobby list */
+      visibility?: unknown
       playerCount?: number
       /** seats 1..n-1: 'human' or an AI tier id */
       opponents?: unknown[]
@@ -25,6 +29,7 @@ export async function POST(req: Request) {
     const opponents = (body.opponents ?? []).map((o) =>
       isAiTierId(o) ? o : ('human' as const),
     )
+    const visibility = body.visibility === 'private' ? 'private' : 'public'
     if (
       opponents.some((o) => o !== 'human') &&
       !aiOpponentsEnabled(process.env.VERCEL_ENV)
@@ -38,6 +43,7 @@ export async function POST(req: Request) {
       String(body.name ?? ''),
       Number(body.playerCount ?? 0),
       opponents,
+      { name: String(body.gameName ?? ''), visibility },
     )
     return NextResponse.json(result)
   } catch (e) {

--- a/src/components/mp/lobby-browser.tsx
+++ b/src/components/mp/lobby-browser.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 interface LobbyWire {
   token: string
+  name: string
   host: string | null
   capacity: number
   claimed: number
@@ -120,7 +121,11 @@ export function LobbyBrowser() {
                   className="text-[15px] font-semibold"
                   style={{ color: 'var(--bb-parchment-bright)' }}
                 >
-                  {l.host ? `${l.host}’s table` : 'A table'}
+                  {l.name?.trim()
+                    ? l.name
+                    : l.host
+                      ? `${l.host}’s table`
+                      : 'A table'}
                 </span>
                 <span
                   className="text-[12px]"

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -90,6 +90,8 @@ interface ChatMessageWire {
 interface GameViewWire {
   token: string
   phase: 'lobby' | 'playing' | 'over'
+  /** table name, or '' when unnamed */
+  name?: string
   version: number
   you: number | null
   /** seat currently holding host powers (usually 0; transfers if 0 is vacated) */
@@ -559,7 +561,7 @@ function LobbyScreen({
         className="bb2-display text-5xl font-black"
         style={{ color: 'var(--bb-parchment-bright)' }}
       >
-        Waiting to begin
+        {view.name?.trim() ? view.name : 'Waiting to begin'}
       </h1>
       <ShareLink />
       <div
@@ -1297,7 +1299,7 @@ function MpTable({
               className="bb2-display text-[13px] italic"
               style={{ color: 'rgba(231,215,177,.55)' }}
             >
-              Birmingham · online
+              {view.name?.trim() ? view.name : 'Birmingham · online'}
             </span>
           </div>
           <span

--- a/src/components/setup-screen.tsx
+++ b/src/components/setup-screen.tsx
@@ -39,9 +39,15 @@ export function SetupScreen({
   onStart: (players: SetupPlayer[]) => void
 }) {
   const router = useRouter()
-  const [mode, setMode] = useState<'local' | 'online' | 'ai'>('local')
+  // Default to opening an online table — most sessions here are networked, so
+  // "Play online" is the primary path. The other modes stay one tap away.
+  const [mode, setMode] = useState<'local' | 'online' | 'ai'>('online')
   const [count, setCount] = useState(3)
   const [names, setNames] = useState<string[]>(DEFAULT_NAMES)
+  // Online-table metadata: an optional short name shown in the lobby browser +
+  // masthead, and whether the table is listed publicly or invite-link only.
+  const [gameName, setGameName] = useState('')
+  const [visibility, setVisibility] = useState<'public' | 'private'>('public')
   // Default rival: haiku — fast and nearly as cheap as the budget tier
   // (the Clerk reasons for ~a minute per decision).
   const [tiers, setTiers] = useState<AiTierId[]>([
@@ -78,6 +84,8 @@ export function SetupScreen({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: names[0]?.trim() || DEFAULT_NAMES[0],
+          gameName: gameName.trim(),
+          visibility,
           playerCount: count,
           ...(mode === 'ai' ? { opponents: tiers.slice(0, count - 1) } : {}),
         }),
@@ -277,14 +285,55 @@ export function SetupScreen({
               </div>
             ))}
           {mode === 'online' && (
-            <p
-              className="text-[12px]"
-              style={{ color: 'rgba(231,215,177,.5)' }}
-            >
-              You&rsquo;ll get a link to share — the other{' '}
-              {count - 1 === 1 ? 'player claims' : 'players claim'} their seats
-              by opening it. No accounts, ever.
-            </p>
+            <>
+              <input
+                value={gameName}
+                onChange={(e) => setGameName(e.target.value)}
+                placeholder="Table name (optional)"
+                maxLength={40}
+                data-testid="game-name"
+                className="w-full rounded border bg-transparent px-3 py-2 text-[14px] outline-none transition-colors"
+                style={{
+                  borderColor: 'rgba(231,215,177,.2)',
+                  color: 'var(--bb-parchment-bright)',
+                }}
+              />
+              <div className="grid grid-cols-2 gap-2">
+                <button
+                  type="button"
+                  className="bb2-option justify-center py-2"
+                  data-selected={visibility === 'public'}
+                  data-testid="visibility-public"
+                  onClick={() => setVisibility('public')}
+                >
+                  <span className="text-[11px] font-bold uppercase tracking-[0.12em]">
+                    Public
+                  </span>
+                </button>
+                <button
+                  type="button"
+                  className="bb2-option justify-center py-2"
+                  data-selected={visibility === 'private'}
+                  data-testid="visibility-private"
+                  onClick={() => setVisibility('private')}
+                >
+                  <span className="text-[11px] font-bold uppercase tracking-[0.12em]">
+                    Private
+                  </span>
+                </button>
+              </div>
+              <p
+                className="text-[12px]"
+                style={{ color: 'rgba(231,215,177,.5)' }}
+              >
+                You&rsquo;ll get a link to share — the other{' '}
+                {count - 1 === 1 ? 'player claims' : 'players claim'} their
+                seats by opening it. No accounts, ever.{' '}
+                {visibility === 'public'
+                  ? 'This table is listed on the open-tables page.'
+                  : 'Private tables are reachable by link only — not listed publicly.'}
+              </p>
+            </>
           )}
           {mode === 'ai' && (
             <p

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -39,6 +39,17 @@ export const games = pgTable(
     phase: text('phase', { enum: ['lobby', 'playing', 'over'] })
       .notNull()
       .default('lobby'),
+    /** optional short table name captured at create; '' when the host left it
+     *  blank (the lobby browser then falls back to "<host>'s table"). Additive,
+     *  safe default so existing rows read as unnamed. */
+    name: text('name').notNull().default(''),
+    /** 'public' tables are advertised by the lobby browser; 'private' tables
+     *  are reachable by invite link only and never returned by
+     *  `loadOpenLobbies`. Additive with a 'public' default so existing rows
+     *  keep their current (listed) behaviour. */
+    visibility: text('visibility', { enum: ['public', 'private'] })
+      .notNull()
+      .default('public'),
     version: integer('version').notNull().default(1),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -194,6 +194,8 @@ export interface AiView {
 export interface GameView {
   token: string
   phase: GameRecord['phase']
+  /** the table's name, or '' when unnamed (public metadata) */
+  name: string
   version: number
   you: number | null
   /** the seat that currently holds host powers (start the game, release seats).
@@ -344,6 +346,7 @@ export function viewFor(
   return {
     token: game.token,
     phase: game.phase,
+    name: game.name,
     version: game.version,
     you: authed ? seatId : null,
     hostSeatId: effectiveHostSeat(game)?.seatId ?? null,
@@ -359,12 +362,19 @@ export function viewFor(
 
 /* ---------------- lifecycle ---------------- */
 
+/** Longest table name we store; anything longer is trimmed at create. */
+export const GAME_NAME_MAX_LENGTH = 40
+
 export async function createGame(
   hostName: string,
   playerCount: number,
   /** seats 1..n-1: 'human' keeps the seat open for a join; a tier id
    *  seats an AI opponent driven by the server */
   opponents: Array<'human' | AiTierId> = [],
+  /** optional table metadata captured at create. `name` is trimmed/capped and
+   *  defaults to '' (unnamed); `visibility` defaults to 'public' so nothing
+   *  about existing behaviour changes unless a private table is requested. */
+  options: { name?: string; visibility?: 'public' | 'private' } = {},
 ): Promise<{ token: string; seatId: number; seatSecret: string }> {
   await sweepStaleGames()
   if (playerCount < 2 || playerCount > 4) throw new Error('2–4 players')
@@ -414,6 +424,8 @@ export async function createGame(
   const game: GameRecord = {
     token,
     phase: 'lobby',
+    name: (options.name ?? '').trim().slice(0, GAME_NAME_MAX_LENGTH),
+    visibility: options.visibility === 'private' ? 'private' : 'public',
     createdAt: now,
     updatedAt: now,
     version: 1,
@@ -460,8 +472,16 @@ export async function listLobbies(): Promise<LobbySummary[]> {
 function startEngine(game: GameRecord): void {
   const actor = createActor(gameStore)
   actor.start()
+  // Randomize the starting player ONCE, server-side, at game start (Brass
+  // deals a random first-player marker). The chosen index is fed into
+  // START_GAME and thus baked into the persisted snapshot, so it is
+  // deterministic per game and every client reads the same turn order — never
+  // re-randomized per render or per client. Default (no index) would always
+  // seat 0 (the host) first.
+  const startingPlayerIndex = Math.floor(Math.random() * game.seats.length)
   actor.send({
     type: 'START_GAME',
+    startingPlayerIndex,
     players: game.seats.map((s) => ({
       id: String(s.seatId + 1),
       name: s.name ?? `Player ${s.seatId + 1}`,

--- a/src/server/mp/store.stats.test.ts
+++ b/src/server/mp/store.stats.test.ts
@@ -58,6 +58,8 @@ async function seedGame(opts: {
   await saveGame({
     token,
     phase: opts.phase ?? 'playing',
+    name: '',
+    visibility: 'public',
     createdAt: stamp,
     updatedAt: stamp,
     version: 1,
@@ -127,7 +129,10 @@ describe('loadActivityStats', () => {
   })
 
   test('excludes a finished game even when it was just touched', async () => {
-    await seedGame({ phase: 'over', seats: [seat(0, 'Ada'), seat(1, 'Brunel')] })
+    await seedGame({
+      phase: 'over',
+      seats: [seat(0, 'Ada'), seat(1, 'Brunel')],
+    })
     expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
       activeGames: 0,
       activePlayers: 0,

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -57,6 +57,11 @@ export interface ChatMessage {
 export interface GameRecord {
   token: string
   phase: 'lobby' | 'playing' | 'over'
+  /** optional short table name (capped/trimmed at create); '' when unnamed */
+  name: string
+  /** 'public' games are advertised in the lobby browser; 'private' ones are
+   *  invite-link only and never returned by `loadOpenLobbies` */
+  visibility: 'public' | 'private'
   createdAt: string
   updatedAt: string
   version: number
@@ -81,6 +86,8 @@ function rowToRecord(row: GameRow): GameRecord {
   return {
     token: row.token,
     phase: row.phase,
+    name: row.name,
+    visibility: row.visibility,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     version: row.version,
@@ -98,6 +105,8 @@ function recordToRow(game: GameRecord): GameRow {
   return {
     token: game.token,
     phase: game.phase,
+    name: game.name,
+    visibility: game.visibility,
     createdAt: game.createdAt,
     updatedAt: game.updatedAt,
     version: game.version,
@@ -259,6 +268,8 @@ export async function loadActivityStats(
  *  least one human seat is still unclaimed. */
 export interface LobbySummary {
   token: string
+  /** the table's name, or '' when the host left it blank */
+  name: string
   host: string | null
   capacity: number
   claimed: number
@@ -275,16 +286,22 @@ export interface LobbySummary {
  * waiting on the host to start) is not joinable, so it does not belong on a
  * "join a game" list. AI-only opponent seats never count as open (they are
  * claimed at creation and cannot be joined off the wire).
+ *
+ * PRIVATE games are excluded at the SQL level: a `private` table is reachable
+ * only by its invite link, so its token must never appear on this public list
+ * (that is also a small security win — private tokens stay off the public
+ * endpoint). `public` is the default, so existing rows keep showing.
  */
 export async function loadOpenLobbies(limit = 50): Promise<LobbySummary[]> {
   const rows = await db
     .select({
       token: games.token,
+      name: games.name,
       seats: games.seats,
       createdAt: games.createdAt,
     })
     .from(games)
-    .where(eq(games.phase, 'lobby'))
+    .where(and(eq(games.phase, 'lobby'), eq(games.visibility, 'public')))
     .orderBy(desc(games.createdAt))
     .limit(limit)
   return rows
@@ -292,6 +309,7 @@ export async function loadOpenLobbies(limit = 50): Promise<LobbySummary[]> {
       const humanOpen = row.seats.some((s) => s.kind !== 'ai' && !s.claimed)
       return {
         token: row.token,
+        name: row.name,
         host: row.seats[0]?.name ?? null,
         capacity: row.seats.length,
         claimed: row.seats.filter((s) => s.claimed).length,

--- a/src/store/gameStore.multiplayer.test.ts
+++ b/src/store/gameStore.multiplayer.test.ts
@@ -760,3 +760,94 @@ describe('multiplayer: concurrent-write protection', () => {
     expect(settled!.updatedAt).toBe(first.updatedAt)
   })
 })
+
+describe('multiplayer: the starting player is randomized server-side', () => {
+  // Bucket B item 1: Brass deals a random first-player marker. The mp service
+  // supplies a random startingPlayerIndex at start, baked into the persisted
+  // snapshot — so it is deterministic per game and identical for every client,
+  // never the host (seat 0) every time.
+  const startedCtx = async (token: string) => {
+    const g = await loadGame(token)
+    return (
+      g!.snapshot as {
+        context: { currentPlayerIndex: number; turnOrder: string[] }
+      }
+    ).context
+  }
+
+  test('a forced non-zero draw makes a non-host seat lead, order rotated', async () => {
+    // floor(0.75 * 2) === 1 → seat 1 leads a 2-player table.
+    const spy = vi.spyOn(Math, 'random').mockReturnValue(0.75)
+    try {
+      const { host } = await freshGame()
+      const ctx = await startedCtx(host.token)
+      expect(ctx.currentPlayerIndex).toBe(1)
+      // turnOrder rotated to begin at the starting player; both seats present.
+      expect(ctx.turnOrder[0]).toBe('2')
+      expect([...ctx.turnOrder].sort()).toEqual(['1', '2'])
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  test('the chosen order is stable — reloading a game yields the same leader', async () => {
+    const { host } = await freshGame()
+    const a = await startedCtx(host.token)
+    const b = await startedCtx(host.token)
+    expect(b.currentPlayerIndex).toBe(a.currentPlayerIndex)
+    expect(b.turnOrder).toEqual(a.turnOrder)
+  })
+
+  test('over many games the first player is not always seat 0', async () => {
+    // Real randomness over many 2-player games: the leader must vary (it was
+    // ALWAYS seat 0 before this change). With 20 fair coin flips, "all the
+    // same" has probability 2·2⁻²⁰ ≈ 2e-6 — effectively never, no retries.
+    const leaders = new Set<number>()
+    for (let n = 0; n < 20; n++) {
+      const { host } = await freshGame()
+      leaders.add((await startedCtx(host.token)).currentPlayerIndex)
+    }
+    expect(leaders.size).toBeGreaterThan(1)
+  })
+})
+
+describe('multiplayer: table names and private/public visibility', () => {
+  // Bucket B items 3 + 4: an optional table name captured at create and shown
+  // in the lobby list; a visibility flag that keeps private tables off the
+  // public list (default public → existing games keep showing).
+  test('a named public game appears in the lobby list with its name', async () => {
+    const host = await createGame('Ada', 3, [], {
+      name: '  Ada’s ironworks  ',
+      visibility: 'public',
+    })
+    const lobbies = await loadOpenLobbies()
+    const mine = lobbies.find((l) => l.token === host.token)
+    // trimmed at create
+    expect(mine?.name).toBe('Ada’s ironworks')
+  })
+
+  test('an over-long name is capped at create', async () => {
+    const host = await createGame('Ada', 2, [], { name: 'x'.repeat(200) })
+    const g = await loadGame(host.token)
+    expect(g!.name.length).toBe(40)
+  })
+
+  test('a private game is reachable by token but never listed publicly', async () => {
+    const host = await createGame('Ada', 3, [], { visibility: 'private' })
+    // still loadable directly (invite-link flow)
+    const g = await loadGame(host.token)
+    expect(g!.visibility).toBe('private')
+    // but absent from the public list
+    const lobbies = await loadOpenLobbies()
+    expect(lobbies.find((l) => l.token === host.token)).toBeUndefined()
+  })
+
+  test('visibility defaults to public — an unnamed game still lists', async () => {
+    const host = await createGame('Ada', 3)
+    const g = await loadGame(host.token)
+    expect(g!.visibility).toBe('public')
+    expect(g!.name).toBe('')
+    const lobbies = await loadOpenLobbies()
+    expect(lobbies.find((l) => l.token === host.token)).toBeTruthy()
+  })
+})

--- a/src/store/gameStore.startingplayer.test.ts
+++ b/src/store/gameStore.startingplayer.test.ts
@@ -1,0 +1,72 @@
+// Starting-player randomization (bucket B item 1). Brass deals a random
+// first-player marker; the mp service supplies a random `startingPlayerIndex`
+// to START_GAME so the host (seat 0) is not always first. The engine bakes the
+// choice into the persisted snapshot — deterministic per game, identical for
+// every client — and must keep `currentPlayerIndex` and `turnOrder` in
+// lockstep so the round engine still cycles through every seat.
+import { describe, expect, it } from 'vitest'
+import { createActor } from 'xstate'
+import { gameStore } from './gameStore'
+
+const PLAYERS = [
+  { id: '1', name: 'P1', color: 'red', character: 'A' },
+  { id: '2', name: 'P2', color: 'blue', character: 'B' },
+  { id: '3', name: 'P3', color: 'green', character: 'C' },
+  { id: '4', name: 'P4', color: 'yellow', character: 'D' },
+].map((p) => ({
+  ...p,
+  money: 17,
+  victoryPoints: 0,
+  income: 0,
+  industryTilesOnMat: {},
+}))
+
+type Snap = {
+  context: { currentPlayerIndex: number; turnOrder: string[] }
+}
+
+const startWith = (startingPlayerIndex?: number) => {
+  const a = createActor(gameStore)
+  a.start()
+  a.send({
+    type: 'START_GAME',
+    players: PLAYERS,
+    ...(startingPlayerIndex !== undefined ? { startingPlayerIndex } : {}),
+  } as never)
+  return a.getSnapshot() as unknown as Snap
+}
+
+describe('starting player', () => {
+  it('defaults to seat 0 when no index is given (hotseat + existing behaviour)', () => {
+    const snap = startWith()
+    expect(snap.context.currentPlayerIndex).toBe(0)
+    expect(snap.context.turnOrder).toEqual(['1', '2', '3', '4'])
+  })
+
+  it('starts at the supplied index and rotates the turn order to match', () => {
+    const snap = startWith(2)
+    expect(snap.context.currentPlayerIndex).toBe(2)
+    // Rotated so turnOrder[0] is the starting player; every seat still appears
+    // exactly once, so the round engine cycles through all four.
+    expect(snap.context.turnOrder).toEqual(['3', '4', '1', '2'])
+  })
+
+  it('clamps an out-of-range index to seat 0', () => {
+    expect(startWith(9).context.currentPlayerIndex).toBe(0)
+    expect(startWith(-1).context.currentPlayerIndex).toBe(0)
+  })
+
+  it('the rotated order is a permutation of all seats (no seat dropped)', () => {
+    const { turnOrder } = startWith(3).context
+    expect([...turnOrder].sort()).toEqual(['1', '2', '3', '4'])
+  })
+
+  it('every seat leads the round for some index; the round still cycles all seats', () => {
+    for (let s = 0; s < PLAYERS.length; s++) {
+      const snap = startWith(s)
+      expect(snap.context.currentPlayerIndex).toBe(s)
+      expect(snap.context.turnOrder[0]).toBe(PLAYERS[s]!.id)
+      expect(snap.context.turnOrder).toHaveLength(PLAYERS.length)
+    }
+  })
+})

--- a/src/store/gameStore.ts
+++ b/src/store/gameStore.ts
@@ -329,6 +329,15 @@ type GameEvent =
         > &
           Partial<Pick<Player, 'incomeSpace'>>
       >
+      // Optional index (into `players`) of the player who takes the first
+      // turn. Omitted → seat 0 leads (hotseat default, and every existing
+      // test). The mp service passes a server-chosen RANDOM index so the
+      // starting player is not always the host; the choice is baked into the
+      // persisted snapshot, so it is deterministic per game and identical for
+      // every client. The initial `turnOrder` is rotated to begin at this
+      // player, keeping `currentPlayerIndex`/`turnOrder` in lockstep so the
+      // round engine cycles through all seats correctly.
+      startingPlayerIndex?: number
     }
   | {
       type: 'JOIN_GAME'
@@ -726,9 +735,24 @@ export const gameStore = setup({
         industries: [],
       }))
 
+      // Starting player: default seat 0, or a caller-supplied index (the mp
+      // service randomizes this). Rotate the initial turn order to begin at
+      // that player so `currentPlayerIndex` and `turnOrder[0]` agree — the
+      // round engine walks `turnOrder`, so a mismatch would drop players from
+      // the first round.
+      const rawStart = event.startingPlayerIndex ?? 0
+      const startIndex =
+        Number.isInteger(rawStart) && rawStart >= 0 && rawStart < playerCount
+          ? rawStart
+          : 0
+      const initialTurnOrder = players
+        .map((p) => p.id)
+        .slice(startIndex)
+        .concat(players.map((p) => p.id).slice(0, startIndex))
+
       return {
         players,
-        currentPlayerIndex: 0,
+        currentPlayerIndex: startIndex,
         era: 'canal' as const,
         round: 1,
         actionsRemaining: GAME_CONSTANTS.FIRST_ROUND_ACTIONS,
@@ -766,7 +790,7 @@ export const gameStore = setup({
         selectedCardsForScout: [],
         spentMoney: 0,
         playerSpending: {},
-        turnOrder: players.map((p) => p.id), // Initial turn order
+        turnOrder: initialTurnOrder, // Initial turn order (starts at startIndex)
         roundSummary: null,
         isFinalRound: false,
         selectedLink: null,

--- a/src/test/db-schema.test.ts
+++ b/src/test/db-schema.test.ts
@@ -29,6 +29,12 @@ describe('isBenignSchemaRace', () => {
     expect(isBenignSchemaRace(pgError({ code: '42710' }))).toBe(true)
   })
 
+  it('accepts duplicate_column (42701) — an additive ADD COLUMN re-run/raced', () => {
+    // Re-running `ALTER TABLE games ADD COLUMN name …` over a branch that
+    // already has the column, or a parallel worker adding it a hair earlier.
+    expect(isBenignSchemaRace(pgError({ code: '42701' }))).toBe(true)
+  })
+
   // The regression this file exists for. Two DB suites run in parallel workers
   // against ONE fresh ephemeral branch; both find `chat_messages` absent and
   // issue CREATE TABLE at the same instant. The loser does NOT get a polite

--- a/src/test/db-schema.ts
+++ b/src/test/db-schema.ts
@@ -16,9 +16,10 @@ import { db } from '~/server/db'
  *
  * Two shapes, both benign:
  *
- *  - The object EXISTS ALREADY (42P07 duplicate_table / 42710 duplicate_object,
- *    or an "already exists" message when no code surfaces). Re-running the
- *    shipped migrations over a populated branch.
+ *  - The object EXISTS ALREADY (42P07 duplicate_table / 42710 duplicate_object /
+ *    42701 duplicate_column for an additive `ALTER TABLE … ADD COLUMN`, or an
+ *    "already exists" message when no code surfaces). Re-running the shipped
+ *    migrations over a populated branch.
  *
  *  - The object was created CONCURRENTLY, a hair before us. vitest runs the DB
  *    suites in parallel workers against ONE database; when the branch is missing
@@ -40,7 +41,7 @@ export function isBenignSchemaRace(err: unknown): boolean {
       message?: string
       schema?: string
     }
-    if (code === '42P07' || code === '42710') return true
+    if (code === '42P07' || code === '42710' || code === '42701') return true
     if (code === '23505' && schema === 'pg_catalog') return true
     // Only trust the message when no code pinned the failure — an unrelated
     // error carrying these words shouldn't slip through.


### PR DESCRIPTION
Bucket B **lobby & entry** bundle — four tightly-related multiplayer/lobby items. Base: `main` (already has #87 guardrails + #88 seat-0 recovery).

## ⚠️ Behavior changes
1. **Randomized starting player.** Online games always seated the host (seat 0) first. `START_GAME` gains an optional `startingPlayerIndex`; the mp service (`startEngine`) chooses it **randomly once at game start**, baked into the persisted snapshot — so it's **deterministic per game and identical for every client**, never re-randomized per render/client. The engine rotates the initial `turnOrder` to begin at that player, keeping `currentPlayerIndex`/`turnOrder` in lockstep so the round engine still cycles every seat. Hotseat and every existing caller omit the index → seat 0 leads exactly as before.
2. **"Play online" is the default setup mode** (was local hotseat). Other modes stay one tap away.

## New features
3. **Table names.** Optional short name captured at create (`gameName`, trimmed + capped at 40), shown in the lobby browser and the in-game masthead / lobby screen. Empty → falls back to "<host>'s table".
4. **Public vs private visibility.** A toggle at create. `private` tables are invite-link only and excluded from `loadOpenLobbies` **at the SQL level** — private tokens never reach the public endpoint (a small security win). Default `public`, so existing games keep listing.

## Schema
Items 3+4 share **one additive migration** (`0004_whole_roughhouse.sql`):
```sql
ALTER TABLE "games" ADD COLUMN "name" text DEFAULT '' NOT NULL;
ALTER TABLE "games" ADD COLUMN "visibility" text DEFAULT 'public' NOT NULL;
```
Non-destructive with safe defaults for the existing ~199 prod rows. `drizzle-kit check` and the CI generate-clean gate pass.

Test-harness fix: `isBenignSchemaRace` now also accepts `42701` (duplicate_column) — the column analog of the documented `42P07` — so the additive `ADD COLUMN` is idempotent across parallel workers / re-runs.

## Tests
- `gameStore.startingplayer.test.ts` — engine rotation, default seat-0, clamping, full-permutation.
- `gameStore.multiplayer.test.ts` — server randomization (forced non-zero, stable per game, varies over 20 games), name trim/cap, private-hidden / public-listed / default-public.
- `db-schema.test.ts` — the 42701 benign-race case.
- Three local hotseat e2e specs now select `mode-local` first (online is default). Validated `atlas`, `lobby-browser`, `multiplayer` e2e locally.

Full vitest suite: **752 passed**. lint + typecheck + drizzle check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
