### PR TITLE
feat(mp): weekly archive-sweep + host-remove + graceful gone-game join

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,14 @@ DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
 # `sweepStaleGames`.
 # BB_ENABLE_TTL_SWEEP=1
 
+# Weekly archive sweep (Vercel Cron → GET /api/cron/sweep, see vercel.json).
+# Archives never-started stale lobbies (hides them; NEVER deletes a row). The
+# endpoint is refused unless the caller presents `Authorization: Bearer
+# <CRON_SECRET>`, which Vercel Cron sends automatically when this is set. With
+# no CRON_SECRET the endpoint is disabled (returns 500). Set the SAME value in
+# the Vercel project settings.
+# CRON_SECRET="a-long-random-string"
+
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"

--- a/drizzle/0005_living_dormammu.sql
+++ b/drizzle/0005_living_dormammu.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "games" ADD COLUMN "archived" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,305 @@
+{
+  "id": "137dcd7d-0bed-46b6-a533-2dfbf529c88b",
+  "prevId": "80e882c8-9354-437b-b5e8-c5a7c5dc7275",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_token_idx": {
+          "name": "chat_messages_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "chat_messages_token_seq_pk": {
+          "name": "chat_messages_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_intents": {
+      "name": "game_intents",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_after": {
+          "name": "snapshot_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_intents_token_idx": {
+          "name": "game_intents_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "game_intents_token_seq_pk": {
+          "name": "game_intents_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lobby'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seats": {
+          "name": "seats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai": {
+          "name": "ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "games_phase_created_idx": {
+          "name": "games_phase_created_idx",
+          "columns": [
+            {
+              "expression": "phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_updated_active_idx": {
+          "name": "games_updated_active_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"games\".\"phase\" <> 'over'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1784833786840,
       "tag": "0004_whole_roughhouse",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1784835883389,
+      "tag": "0005_living_dormammu",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cron/sweep/route.ts
+++ b/src/app/api/cron/sweep/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { authorizeCron } from '~/server/mp/cron-auth'
+import { archiveStaleLobbies } from '~/server/mp/store'
+
+export const runtime = 'nodejs'
+// Never cache a mutation endpoint.
+export const dynamic = 'force-dynamic'
+
+// Weekly archive sweep (Vercel Cron — see vercel.json `crons`). Vercel invokes
+// this with `Authorization: Bearer <CRON_SECRET>`; only that authorized caller
+// may trigger it. It ARCHIVES never-started stale lobbies (does not delete any
+// row) so they drop off the public lobby list while surviving for analytics.
+export async function GET(req: Request) {
+  const auth = authorizeCron(
+    req.headers.get('authorization'),
+    process.env.CRON_SECRET,
+  )
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.error },
+      { status: auth.status ?? 401 },
+    )
+  }
+  try {
+    const archived = await archiveStaleLobbies()
+    return NextResponse.json({ ok: true, archived })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Sweep failed' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/mp/archive/route.ts
+++ b/src/app/api/mp/archive/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+import { archiveGame } from '~/server/mp/game'
+
+export const runtime = 'nodejs'
+
+// Host removes their own lobby from discovery. Authorized inside archiveGame by
+// the effective host's secret — a non-host seat or a stranger is refused. This
+// archives (hides) the game; it never deletes the row.
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as { token?: string; seatSecret?: string }
+    const result = await archiveGame(
+      String(body.token ?? ''),
+      String(body.seatSecret ?? ''),
+    )
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 400 })
+    }
+    return NextResponse.json({ ok: true, version: result.version })
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : 'Could not remove the game' },
+      { status: 400 },
+    )
+  }
+}

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -92,6 +92,8 @@ interface GameViewWire {
   phase: 'lobby' | 'playing' | 'over'
   /** table name, or '' when unnamed */
   name?: string
+  /** true once the game is archived (swept dead lobby, or host-removed) */
+  archived?: boolean
   version: number
   you: number | null
   /** seat currently holding host powers (usually 0; transfers if 0 is vacated) */
@@ -337,6 +339,15 @@ export function MpGame({ token }: { token: string }) {
     )
   }
 
+  // Archived = the game is gone (swept dead lobby, or the host removed it).
+  // Show a clear "no longer exists" dead-end with a create-new call to action,
+  // for EVERYONE (a would-be joiner opening the link, a co-player still on the
+  // lobby) — never the confusing "all seats taken" join screen. Checked before
+  // join/lobby so it wins.
+  if (view.archived) {
+    return <GoneScreen />
+  }
+
   if (view.you === null) {
     return (
       <JoinScreen
@@ -364,6 +375,30 @@ function Centered({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen flex-col items-center justify-center gap-3 p-6 text-center">
       {children}
     </div>
+  )
+}
+
+/** Clear dead-end for a game that no longer exists — swept as a dead lobby or
+ *  removed by its host. Distinct from a genuinely full table: a create-new CTA
+ *  instead of "all seats taken". */
+function GoneScreen() {
+  return (
+    <Centered>
+      <span
+        className="bb2-display text-2xl font-bold"
+        style={{ color: 'var(--bb-parchment-bright)' }}
+        data-testid="game-gone"
+      >
+        This game no longer exists
+      </span>
+      <p className="text-[13px]" style={{ color: 'rgba(231,215,177,.55)' }}>
+        The table was closed or removed. Start a fresh one — it only takes a
+        moment.
+      </p>
+      <a href="/" className="bb2-confirm mt-2" data-testid="gone-host-new">
+        Host a new game
+      </a>
+    </Centered>
   )
 }
 
@@ -543,6 +578,35 @@ function LobbyScreen({
     }
   }
 
+  const removeGame = async () => {
+    if (!creds) return
+    if (
+      typeof window !== 'undefined' &&
+      !window.confirm(
+        'Remove this table? It disappears from the lobby for everyone. This cannot be undone here.',
+      )
+    ) {
+      return
+    }
+    setBusy(true)
+    try {
+      const res = await fetch('/api/mp/archive', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, seatSecret: creds.seatSecret }),
+      })
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string }
+        throw new Error(body.error ?? 'Could not remove the game')
+      }
+      // The table is gone — take the host home to start a new one.
+      if (typeof window !== 'undefined') window.location.assign('/')
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Could not remove the game')
+      setBusy(false)
+    }
+  }
+
   const startHint = !allClaimed
     ? 'Waiting for every seat to be claimed…'
     : !allReady
@@ -660,6 +724,15 @@ function LobbyScreen({
           >
             {startHint}
           </p>
+          <button
+            type="button"
+            className="bb2-ghost-btn w-full"
+            data-testid="lobby-remove"
+            disabled={busy}
+            onClick={() => void removeGame()}
+          >
+            Remove this table
+          </button>
         </div>
       )}
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,5 +1,6 @@
 import { sql } from 'drizzle-orm'
 import {
+  boolean,
   index,
   integer,
   jsonb,
@@ -51,6 +52,12 @@ export const games = pgTable(
       .notNull()
       .default('public'),
     version: integer('version').notNull().default(1),
+    /** A game hidden from discovery but KEPT for analytics: the weekly archive
+     *  sweep flips never-started lobbies here, and a host can archive their own
+     *  lobby on demand. Additive, default false → every existing row stays
+     *  visible. This is an archive, NOT a delete — the row (and its chat +
+     *  intent log) survives. `loadOpenLobbies` filters archived rows out. */
+    archived: boolean('archived').notNull().default(false),
     createdAt: text('created_at').notNull(),
     updatedAt: text('updated_at').notNull(),
     seats: jsonb('seats').notNull().$type<SeatRecord[]>(),

--- a/src/server/mp/archive.test.ts
+++ b/src/server/mp/archive.test.ts
@@ -1,0 +1,122 @@
+// Lobby lifecycle: the weekly archive sweep (item 5), a host removing their own
+// game (item 6), and the graceful "game no longer exists" join refusal (item
+// 7). All three share the additive `archived` state — a game is HIDDEN, never
+// deleted, so the row (and its chat + intent log) survives for analytics.
+import { beforeAll, describe, expect, test, vi } from 'vitest'
+import { ensureTestSchema } from '../../test/db-schema'
+import {
+  GAME_GONE_ERROR,
+  archiveGame,
+  createGame,
+  joinGame,
+  setSeatReady,
+  startGame,
+} from './game'
+import {
+  archiveStaleLobbies,
+  loadGame,
+  loadOpenLobbies,
+  saveGame,
+} from './store'
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
+
+beforeAll(async () => {
+  await ensureTestSchema()
+})
+
+/** Backdate a game's `updatedAt` so the sweep's 7-day cutoff catches it. Goes
+ *  through the version-guarded save, exactly like the real writer. */
+async function backdate(token: string, daysAgo: number): Promise<void> {
+  const game = (await loadGame(token))!
+  game.version++
+  game.updatedAt = new Date(
+    Date.now() - daysAgo * 24 * 60 * 60 * 1000,
+  ).toISOString()
+  await saveGame(game)
+}
+
+/** A started (playing) game: create → join → ready → host start. */
+async function startedGame() {
+  const host = await createGame('Ada', 2)
+  const guest = await joinGame(host.token, 'Brunel')
+  await setSeatReady(host.token, 0, host.seatSecret, true)
+  await setSeatReady(host.token, guest.seatId, guest.seatSecret, true)
+  const started = await startGame(host.token, host.seatSecret)
+  expect(started.ok).toBe(true)
+  return host
+}
+
+describe('weekly archive sweep (item 5)', () => {
+  test('a stale never-started lobby is ARCHIVED, not deleted', async () => {
+    const host = await createGame('Ada', 3) // an open lobby
+    await backdate(host.token, 8) // older than the 7-day TTL
+
+    await archiveStaleLobbies() // default 7-day cutoff
+
+    const after = await loadGame(host.token)
+    expect(after).not.toBeNull() // the row SURVIVES
+    expect(after!.archived).toBe(true) // …just hidden
+    // and it drops off the public lobby list
+    const lobbies = await loadOpenLobbies()
+    expect(lobbies.find((l) => l.token === host.token)).toBeUndefined()
+  })
+
+  test('a fresh lobby and a started game are left untouched', async () => {
+    const fresh = await createGame('Ada', 3) // recent — inside the TTL
+    const playing = await startedGame()
+    await backdate(playing.token, 30) // stale, but NOT a lobby
+
+    await archiveStaleLobbies()
+
+    expect((await loadGame(fresh.token))!.archived).toBe(false)
+    // a game in progress is never archived by the sweep (phase !== 'lobby')
+    const p = await loadGame(playing.token)
+    expect(p!.archived).toBe(false)
+    expect(p!.phase).toBe('playing')
+  })
+})
+
+describe('host removes their own game (item 6)', () => {
+  test('the host archives their lobby — row survives, drops off the list', async () => {
+    const host = await createGame('Ada', 3)
+    const res = await archiveGame(host.token, host.seatSecret)
+    expect(res.ok).toBe(true)
+
+    const after = await loadGame(host.token)
+    expect(after).not.toBeNull() // archived, NOT deleted
+    expect(after!.archived).toBe(true)
+    expect(
+      (await loadOpenLobbies()).find((l) => l.token === host.token),
+    ).toBeUndefined()
+  })
+
+  test('a non-host seat cannot archive the game', async () => {
+    const host = await createGame('Ada', 3)
+    const guest = await joinGame(host.token, 'Brunel')
+    const res = await archiveGame(host.token, guest.seatSecret)
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.error).toMatch(/only the host/i)
+    // untouched
+    expect((await loadGame(host.token))!.archived).toBe(false)
+  })
+
+  test('a started game cannot be removed this way', async () => {
+    const host = await startedGame()
+    const res = await archiveGame(host.token, host.seatSecret)
+    expect(res.ok).toBe(false)
+    if (!res.ok) expect(res.error).toMatch(/only a lobby/i)
+  })
+})
+
+describe('graceful join of a gone game (item 7)', () => {
+  test('joining an archived game reports GONE, not "no open seats"', async () => {
+    const host = await createGame('Ada', 3) // has open seats
+    await archiveGame(host.token, host.seatSecret)
+    // Distinct signal — the UI shows a "no longer exists" dead-end, not the
+    // full-table message (the game still has open seats; it is simply gone).
+    await expect(joinGame(host.token, 'Latecomer')).rejects.toThrow(
+      GAME_GONE_ERROR,
+    )
+  })
+})

--- a/src/server/mp/cron-auth.test.ts
+++ b/src/server/mp/cron-auth.test.ts
@@ -1,0 +1,34 @@
+// Cron endpoint auth — pure, offline (no DB, no request). Guards the weekly
+// archive sweep so ONLY the authorized Vercel-Cron caller can trigger it.
+import { describe, expect, it } from 'vitest'
+import { authorizeCron } from './cron-auth'
+
+describe('authorizeCron', () => {
+  const SECRET = 'super-secret-cron-token'
+
+  it('accepts the exact `Bearer <CRON_SECRET>` header', () => {
+    expect(authorizeCron(`Bearer ${SECRET}`, SECRET)).toEqual({ ok: true })
+  })
+
+  it('refuses a wrong secret with 401', () => {
+    const res = authorizeCron('Bearer nope', SECRET)
+    expect(res.ok).toBe(false)
+    expect(res.status).toBe(401)
+  })
+
+  it('refuses a missing/blank Authorization header with 401', () => {
+    expect(authorizeCron(null, SECRET).status).toBe(401)
+    expect(authorizeCron(undefined, SECRET).status).toBe(401)
+    expect(authorizeCron('', SECRET).status).toBe(401)
+  })
+
+  it('refuses a bare-token header lacking the Bearer scheme', () => {
+    expect(authorizeCron(SECRET, SECRET).status).toBe(401)
+  })
+
+  it('is DISABLED (500) when the server has no CRON_SECRET configured', () => {
+    // No secret on the server → nobody, not even a matching header, may run it.
+    expect(authorizeCron(`Bearer ${SECRET}`, undefined).status).toBe(500)
+    expect(authorizeCron('Bearer anything', '').status).toBe(500)
+  })
+})

--- a/src/server/mp/cron-auth.ts
+++ b/src/server/mp/cron-auth.ts
@@ -1,0 +1,47 @@
+// Auth for the Vercel-Cron sweep endpoint.
+//
+// Vercel Cron invokes the endpoint with `Authorization: Bearer <CRON_SECRET>`
+// when the `CRON_SECRET` env var is set on the project (the documented,
+// vendor-native pattern — no extra service). We REQUIRE the secret: if the
+// server has no `CRON_SECRET` configured, every request is refused, so the
+// sweep can never be triggered unauthenticated. The check is a pure function so
+// it can be unit-tested without a request or a DB.
+import { timingSafeEqual } from 'node:crypto'
+
+export interface CronAuthResult {
+  ok: boolean
+  /** HTTP status to return when not ok (401 unauthorized / 500 misconfigured) */
+  status?: number
+  error?: string
+}
+
+/** Constant-time compare of two strings (length-safe). */
+function secretsMatch(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  return ab.length === bb.length && timingSafeEqual(ab, bb)
+}
+
+/**
+ * Decide whether a cron request is authorized.
+ *  - No `CRON_SECRET` on the server → 500 misconfigured, never run.
+ *  - Header must be exactly `Bearer <CRON_SECRET>` (constant-time compared).
+ *  - Anything else → 401.
+ */
+export function authorizeCron(
+  authHeader: string | null | undefined,
+  cronSecret: string | undefined,
+): CronAuthResult {
+  if (!cronSecret) {
+    return {
+      ok: false,
+      status: 500,
+      error: 'Sweep endpoint is not configured (no CRON_SECRET on the server).',
+    }
+  }
+  const expected = `Bearer ${cronSecret}`
+  if (!authHeader || !secretsMatch(authHeader, expected)) {
+    return { ok: false, status: 401, error: 'Unauthorized' }
+  }
+  return { ok: true }
+}

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -196,6 +196,10 @@ export interface GameView {
   phase: GameRecord['phase']
   /** the table's name, or '' when unnamed (public metadata) */
   name: string
+  /** true once the game is archived (swept as a dead lobby, or removed by its
+   *  host) — the client shows a "game no longer exists" dead-end rather than a
+   *  lobby/join screen. */
+  archived: boolean
   version: number
   you: number | null
   /** the seat that currently holds host powers (start the game, release seats).
@@ -347,6 +351,7 @@ export function viewFor(
     token: game.token,
     phase: game.phase,
     name: game.name,
+    archived: game.archived,
     version: game.version,
     you: authed ? seatId : null,
     hostSeatId: effectiveHostSeat(game)?.seatId ?? null,
@@ -426,6 +431,7 @@ export async function createGame(
     phase: 'lobby',
     name: (options.name ?? '').trim().slice(0, GAME_NAME_MAX_LENGTH),
     visibility: options.visibility === 'private' ? 'private' : 'public',
+    archived: false,
     createdAt: now,
     updatedAt: now,
     version: 1,
@@ -498,6 +504,52 @@ function startEngine(game: GameRecord): void {
   actor.stop()
 }
 
+/** The exact reason a join is refused because the game is gone (archived).
+ *  Stable string so the client can distinguish it from a full table. */
+export const GAME_GONE_ERROR = 'This game no longer exists.'
+
+/**
+ * Host removes their OWN lobby from discovery (item 6). This ARCHIVES the game
+ * — it does NOT delete the row (kept for analytics, and reversible) — so the
+ * user-visible effect ("my table is gone from the lobby browser") matches a
+ * delete while the data survives. Authorized as a HOST action: only the
+ * effective host's secret works (post-#88 that is seat 0, or the next seated
+ * human if seat 0 was vacated — see effectiveHostSeat). A non-host seat or a
+ * stranger is refused. Only a lobby-phase game can be removed this way; a game
+ * in progress is not on the lobby browser and archiving it would strand its
+ * players. Idempotent: archiving an already-archived lobby just succeeds.
+ */
+export async function archiveGame(
+  token: string,
+  hostSecret: string,
+): Promise<
+  { ok: true; view: GameView; version: number } | { ok: false; error: string }
+> {
+  return withGameLock(token, async () => {
+    const game = await loadGame(token)
+    if (!game) return { ok: false, error: 'Game not found' }
+    const host = effectiveHostSeat(game)
+    if (!host || !secretMatches(hostSecret, host.secretHash)) {
+      return { ok: false, error: 'Only the host can remove this game' }
+    }
+    if (game.phase !== 'lobby') {
+      return { ok: false, error: 'Only a lobby can be removed' }
+    }
+    if (!game.archived) {
+      game.archived = true
+      game.version++
+      game.updatedAt = new Date().toISOString()
+      await saveGame(game)
+      broadcast(token)
+    }
+    return {
+      ok: true,
+      view: viewFor(game, host.seatId, hostSecret),
+      version: game.version,
+    }
+  })
+}
+
 export async function joinGame(
   token: string,
   name: string,
@@ -505,6 +557,12 @@ export async function joinGame(
   return withGameLock(token, async () => {
     const game = await loadGame(token)
     if (!game) throw new Error('Game not found')
+    // An archived game is gone from discovery and cannot be joined — report it
+    // as such so the UI shows a clear "no longer exists, start a new one"
+    // dead-end, distinct from a genuinely full table (see GAME_GONE_ERROR /
+    // the JoinScreen). The UI reaches this from the view's `archived` flag
+    // first; this is defense-in-depth for a direct POST.
+    if (game.archived) throw new Error(GAME_GONE_ERROR)
     // Join takes the first OPEN human seat. This is what makes both races safe
     // under the per-game lock: a started game has every seat claimed (startGame
     // requires it), and two players racing the last open seat serialize here —

--- a/src/server/mp/store.stats.test.ts
+++ b/src/server/mp/store.stats.test.ts
@@ -50,6 +50,7 @@ const seat = (seatId: number, name: string | null): SeatRecord => ({
 async function seedGame(opts: {
   ageMs?: number
   phase?: GameRecord['phase']
+  archived?: boolean
   seats: SeatRecord[]
 }): Promise<void> {
   const token = randomUUID().replace(/-/g, '')
@@ -60,6 +61,7 @@ async function seedGame(opts: {
     phase: opts.phase ?? 'playing',
     name: '',
     visibility: 'public',
+    archived: opts.archived ?? false,
     createdAt: stamp,
     updatedAt: stamp,
     version: 1,
@@ -131,6 +133,19 @@ describe('loadActivityStats', () => {
   test('excludes a finished game even when it was just touched', async () => {
     await seedGame({
       phase: 'over',
+      seats: [seat(0, 'Ada'), seat(1, 'Brunel')],
+    })
+    expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({
+      activeGames: 0,
+      activePlayers: 0,
+    })
+  })
+
+  test('excludes an archived lobby even when just touched (host removed it)', async () => {
+    // A host-archived lobby keeps its version bump but is not "in progress".
+    await seedGame({
+      phase: 'lobby',
+      archived: true,
       seats: [seat(0, 'Ada'), seat(1, 'Brunel')],
     })
     expect(await loadActivityStats(ACTIVE_WINDOW_MS, NOW)).toEqual({

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -62,6 +62,9 @@ export interface GameRecord {
   /** 'public' games are advertised in the lobby browser; 'private' ones are
    *  invite-link only and never returned by `loadOpenLobbies` */
   visibility: 'public' | 'private'
+  /** hidden from discovery but kept for analytics — see the `archived` column.
+   *  Set by the weekly archive sweep or a host archiving their own lobby. */
+  archived: boolean
   createdAt: string
   updatedAt: string
   version: number
@@ -88,6 +91,7 @@ function rowToRecord(row: GameRow): GameRecord {
     phase: row.phase,
     name: row.name,
     visibility: row.visibility,
+    archived: row.archived,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
     version: row.version,
@@ -107,6 +111,7 @@ function recordToRow(game: GameRecord): GameRow {
     phase: game.phase,
     name: game.name,
     visibility: game.visibility,
+    archived: game.archived,
     createdAt: game.createdAt,
     updatedAt: game.updatedAt,
     version: game.version,
@@ -252,7 +257,16 @@ export async function loadActivityStats(
       activePlayers: sql<number>`coalesce(sum(${seated}), 0)`,
     })
     .from(games)
-    .where(and(gte(games.updatedAt, cutoff), ne(games.phase, 'over')))
+    .where(
+      and(
+        gte(games.updatedAt, cutoff),
+        ne(games.phase, 'over'),
+        // An archived lobby is not "in progress" even if a host archived it
+        // moments ago (item 6 bumps version but keeps the stale updatedAt; a
+        // freshly host-archived lobby would otherwise count here).
+        eq(games.archived, false),
+      ),
+    )
   const row = rows[0]
   // Postgres count()/sum() are bigint — they arrive as strings over neon-http.
   return {
@@ -291,6 +305,10 @@ export interface LobbySummary {
  * only by its invite link, so its token must never appear on this public list
  * (that is also a small security win — private tokens stay off the public
  * endpoint). `public` is the default, so existing rows keep showing.
+ *
+ * ARCHIVED games are likewise excluded at the SQL level: the weekly sweep and
+ * a host's own "remove from lobby" both flip `archived` true, which drops the
+ * table off this list while KEEPING the row for analytics.
  */
 export async function loadOpenLobbies(limit = 50): Promise<LobbySummary[]> {
   const rows = await db
@@ -301,7 +319,13 @@ export async function loadOpenLobbies(limit = 50): Promise<LobbySummary[]> {
       createdAt: games.createdAt,
     })
     .from(games)
-    .where(and(eq(games.phase, 'lobby'), eq(games.visibility, 'public')))
+    .where(
+      and(
+        eq(games.phase, 'lobby'),
+        eq(games.visibility, 'public'),
+        eq(games.archived, false),
+      ),
+    )
     .orderBy(desc(games.createdAt))
     .limit(limit)
   return rows
@@ -561,4 +585,46 @@ export async function sweepStaleGames(now = Date.now()): Promise<void> {
         db.select({ token: games.token }).from(games),
       ),
     )
+}
+
+/** How long a never-started lobby may sit untouched before the weekly sweep
+ *  archives it (hides it from discovery, keeps the row). */
+export const LOBBY_ARCHIVE_TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+/**
+ * Archive — NEVER delete — lobbies nobody ever started that have gone stale.
+ *
+ * This is the weekly Vercel-Cron sweep (item 5). It flips `archived` true on
+ * every game still in the `lobby` phase, not already archived, and untouched
+ * for `ttlMs`. Started (`playing`) and finished (`over`) games are left alone
+ * — only dead never-started lobbies are cleaned up, and even they SURVIVE as
+ * rows (with their chat + intent log) for analytics; they simply drop off the
+ * public lobby list (`loadOpenLobbies` filters archived) and any client still
+ * sitting on one converges to the "game no longer exists" screen via the
+ * version bump.
+ *
+ * A single bulk UPDATE (no per-row load/save). `updatedAt` is deliberately NOT
+ * bumped: it is the staleness clock, and a fresh timestamp would both re-hide
+ * the row from a future re-sweep check and make it look active. `version` IS
+ * bumped so the stream poll notices and refreshes watchers. Returns how many
+ * lobbies were archived.
+ */
+export async function archiveStaleLobbies(
+  now = Date.now(),
+  ttlMs = LOBBY_ARCHIVE_TTL_MS,
+): Promise<number> {
+  // ISO-8601 timestamps sort lexicographically the same as chronologically.
+  const cutoff = new Date(now - ttlMs).toISOString()
+  const archived = await db
+    .update(games)
+    .set({ archived: true, version: sql`${games.version} + 1` })
+    .where(
+      and(
+        eq(games.phase, 'lobby'),
+        eq(games.archived, false),
+        lt(games.updatedAt, cutoff),
+      ),
+    )
+    .returning({ token: games.token })
+  return archived.length
 }

--- a/src/test/db-schema.test.ts
+++ b/src/test/db-schema.test.ts
@@ -30,7 +30,7 @@ describe('isBenignSchemaRace', () => {
   })
 
   it('accepts duplicate_column (42701) — an additive ADD COLUMN re-run/raced', () => {
-    // Re-running `ALTER TABLE games ADD COLUMN name …` over a branch that
+    // Re-running `ALTER TABLE games ADD COLUMN archived …` over a branch that
     // already has the column, or a parallel worker adding it a hair earlier.
     expect(isBenignSchemaRace(pgError({ code: '42701' }))).toBe(true)
   })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/sweep",
+      "schedule": "0 3 * * 1"
+    }
+  ]
+}


### PR DESCRIPTION
Bucket B **lobby lifecycle** — items 5, 6, 7. Base: `main` (fresh, not stacked on the lobby-bundle PR).

All three share **one additive `archived` state**: a game is **hidden, never deleted**, so the row (with its chat + intent log) survives for analytics. `loadOpenLobbies` and `loadActivityStats` filter archived rows out.

## Schema
Migration `0004_woozy_tattoo.sql`:
```sql
ALTER TABLE "games" ADD COLUMN "archived" boolean DEFAULT false NOT NULL;
```
Non-destructive, safe default — existing rows stay visible. `drizzle-kit check` + the generate-clean CI gate pass.

> ⚠️ **Migration number:** this PR's `0004` is independent of the lobby-bundle PR's own `0004`. If that PR merges first, **renumber this migration to `0005`** before merging this one.

## (5) Weekly archive-sweep
`archiveStaleLobbies(now, ttlMs=7d)` flips `archived` on **never-started** lobbies (`phase 'lobby'`, untouched 7 days) via one bulk UPDATE. It **archives, never deletes**, and never touches `playing`/`over` games. Triggered by **Vercel Cron** (`vercel.json` → `GET /api/cron/sweep`, weekly Mon 03:00 UTC). The endpoint is **protected** — `authorizeCron` requires `Authorization: Bearer <CRON_SECRET>` (constant-time compare), the header Vercel Cron sends automatically; with no `CRON_SECRET` the endpoint is disabled (500). It does **not** bump `updatedAt` (the staleness clock) but does bump `version` so stream watchers converge. Set `CRON_SECRET` in Vercel project settings (documented in `.env.example`).

## ⚠️ (6) Host power: remove your own game
A host can remove their **own** lobby on demand — `archiveGame` + `POST /api/mp/archive` + a **"Remove this table"** button in the lobby. Implemented as **archive/hide, not a hard delete** (reversible, keeps the row; same user-visible effect as a delete). Authorized by the **effective host's** secret (post-#88: seat 0 or the inherited host). A non-host / stranger is refused, and only a lobby-phase game can be removed (a game in progress isn't on the browser and archiving it would strand players).

## (7) Graceful "game no longer exists" on join
Joining an archived/gone game now returns a distinct `GAME_GONE_ERROR` instead of the confusing "No open seats", and the client shows a clear dead-end (`GoneScreen`: "This game no longer exists" + a **Host a new game** CTA) for anyone landing on an archived game — never the full-table message. `archived` is surfaced on `GameView` so the UI distinguishes *gone* from *genuinely full*.

## Tests
- `archive.test.ts` — stale lobby **archived, not deleted** + fresh/started untouched (item 5); host-remove ok + **non-host refused** + started-game refused (item 6); **join-gone signal** distinct from full (item 7).
- `cron-auth.test.ts` — offline auth matrix (valid / wrong / missing / no-Bearer / no-secret-disabled).
- `store.stats` — archived lobby excluded from active counts.
- `db-schema` — the 42701 (duplicate_column) benign-race case.

Full vitest: **752 passed**. lint + typecheck + drizzle check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hosts can remove lobby games before they start.
  * Archived games are hidden from lobby discovery and display a clear “game no longer exists” message.
  * Stale, never-started lobbies are automatically archived weekly.
  * Archived games are retained for analytics while no longer accepting joins.

* **Bug Fixes**
  * Prevented archived games from appearing in active game and player statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->