### PR TITLE
feat(setup): drop the tagline, lead with Play online

### DIFF
--- a/src/components/setup-screen.tsx
+++ b/src/components/setup-screen.tsx
@@ -138,12 +138,6 @@ export function SetupScreen({
         >
           BRASS
         </h1>
-        <p
-          className="bb2-display text-lg italic"
-          style={{ color: 'rgba(231,215,177,.65)' }}
-        >
-          The Ironmaster&rsquo;s Atlas — pass one device between players
-        </p>
       </div>
 
       <div
@@ -160,23 +154,23 @@ export function SetupScreen({
           <button
             type="button"
             className="bb2-option justify-center py-2"
-            data-selected={mode === 'local'}
-            data-testid="mode-local"
-            onClick={() => setMode('local')}
-          >
-            <span className="text-[11.5px] font-bold uppercase tracking-[0.14em]">
-              One device
-            </span>
-          </button>
-          <button
-            type="button"
-            className="bb2-option justify-center py-2"
             data-selected={mode === 'online'}
             data-testid="mode-online"
             onClick={() => setMode('online')}
           >
             <span className="text-[11.5px] font-bold uppercase tracking-[0.14em]">
               Play online
+            </span>
+          </button>
+          <button
+            type="button"
+            className="bb2-option justify-center py-2"
+            data-selected={mode === 'local'}
+            data-testid="mode-local"
+            onClick={() => setMode('local')}
+          >
+            <span className="text-[11.5px] font-bold uppercase tracking-[0.14em]">
+              One device
             </span>
           </button>
           {aiEnabled && (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "moduleResolution": "Bundler",
     /* Next 16 mandates the React automatic runtime — it rewrites this to
        'react-jsx' on every build if set to 'preserve', so keep it here. */
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
Two captain-specified tweaks to the landing / setup screen (`src/components/setup-screen.tsx`).

**1. Tagline deleted.** The subtitle *"The Ironmaster's Atlas — pass one device between players"* is gone — the whole `<p>` is removed, not emptied. The header wrapper keeps its `gap-1` eyebrow + wordmark stack, so there is no orphaned element and no gap where the line was. "BIRMINGHAM · 1770" and "BRASS" are untouched (branding is a separate task).

**2. `PLAY ONLINE` now renders first**, `ONE DEVICE` second.

Play-online stays the default selected mode (#89): the selected styling is per-button (`data-selected={mode === 'online'}` / `=== 'local'`), never positional, so the highlight follows the mode rather than the slot. Verified in a real browser — on load `mode-online:true | mode-local:false`, and clicking `ONE DEVICE` flips it to `mode-online:false | mode-local:true`. Every e2e selector is a `data-testid`, so no spec asserted the old order and none needed updating; nothing asserted the tagline text either.

## Verification
- `pnpm typecheck` ✅ · `pnpm lint` ✅ (242 files) · `pnpm test` ✅ 752 passed / 4 skipped · `pnpm build` ✅
- `pnpm exec playwright test e2e/atlas.spec.ts` ✅ 4 passed (the specs that drive the charter through `mode-local`)
- Visual check at 1200×900 and 390×844 — header spacing clean at both, no gap under the wordmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)