### PR TITLE
fix(board): stop tile cubes colliding with the roman level numeral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -554,11 +554,19 @@ What this means in practice:
   the tint, the glyph keeps surface ink. Board tile faces use the SAME base
   hexes (`INDUSTRY_FILL`/`INDUSTRY_INK`, `board-map.tsx`). On-tile resource
   markers share one 1px parchment keyline `#f2e6c8` (cubes + merchant beer
-  barrel). Cube LAYOUT deliberately differs by surface: the board (`BuiltTile`)
-  keeps a single column and collapses >5 cubes (only Iron Works IV) to a count
-  numeral; the player MAT (`player-ledger.tsx` `MatTileArt`) draws EVERY cube in
-  a two-wide grid (captain's call, 2026-07-23) so six fit the face. Do not
-  re-unify them. DELIBERATE interim split: iron's on-tile CUBE fill stays orange
+  barrel). Cube LAYOUT: BOTH surfaces now draw EVERY cube in a two-wide grid —
+  the player MAT (`player-ledger.tsx` `MatTileArt`) and, since 2026-07-23, the
+  board (`BuiltTile`), whose geometry lives in the pure `board/tile-cubes.ts`
+  (`cubeCells`). The board's old single column TOUCHED the roman level numeral
+  (cube top y = numeral baseline 13) and physically could not hold the biggest
+  stacks — 5 cubes need 31px, the clear band between numeral and ribbon is
+  ~28.5px — which is why >5 used to collapse to a `×6` numeral. The grid is
+  LEFT-ALIGNED (odd cube in the left column, spare space right) with its right
+  edge on the numeral's, and `tile-cubes.test.ts` pins the clearances (numeral,
+  ribbon, glyph, tile face) for every count the tile data can produce. Change a
+  tile-face constant and re-run that test rather than eyeballing a nudge. The
+  two surfaces still differ in placement and in the mat's `depth` stacks —
+  don't collapse them into one component. DELIBERATE interim split: iron's on-tile CUBE fill stays orange
   `#d07135` while the tile FACE is steel `#8a939b` — the market-vs-tile iron
   hue reconcile is a separate follow-up, so do NOT "fix" the cube to match the
   face.

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -33,6 +33,7 @@ import {
   planPanToCity,
 } from './pan-into-view'
 import { farmBrewerySpurStyle } from './route-style'
+import { CUBE, cubeCells } from './tile-cubes'
 
 /* ---------------- palette (mirrors theme.css) ---------------- */
 
@@ -1520,58 +1521,26 @@ function BuiltTile({ occ }: { occ: BuiltIndustry }) {
       >
         {ROMAN[occ.level] ?? occ.level}
       </text>
-      {/* resource cubes riding on the tile — up to five in a column that
-          clears the owner ribbon; six or more (only Iron Works IV reaches
-          six) collapses to a count numeral so no cube goes silently missing. */}
+      {/* resource cubes riding on the tile — a left-aligned two-column block
+          in the right gutter, sized by `tile-cubes.ts` so it always clears the
+          level numeral above and the owner ribbon below (a single column
+          could not hold the biggest stacks without touching either). */}
       {cubes && cubes.n > 0 && (
         <g>
-          {cubes.n <= 5 ? (
-            Array.from({ length: cubes.n }, (_, i) => (
-              <rect
-                key={i}
-                x={SLOT - 11}
-                y={13 + i * 6.6}
-                width="6.2"
-                height="6.2"
-                rx="1"
-                fill={cubes.c}
-                stroke="#f2e6c8"
-                strokeWidth="1"
-              >
-                <title>resource cube on tile</title>
-              </rect>
-            ))
-          ) : (
-            <g>
-              <rect
-                x={SLOT - 11}
-                y="13"
-                width="6.2"
-                height="6.2"
-                rx="1"
-                fill={cubes.c}
-                stroke="#f2e6c8"
-                strokeWidth="1"
-              />
-              <text
-                x={SLOT - 7.9}
-                y="27"
-                textAnchor="middle"
-                fill="#f2e6c8"
-                stroke="#16130f"
-                strokeWidth="0.5"
-                paintOrder="stroke"
-                style={{
-                  fontFamily: 'var(--bb-display)',
-                  fontWeight: 700,
-                  fontSize: 11,
-                }}
-              >
-                {`×${cubes.n}`}
-                <title>{`${cubes.n} resource cubes on tile`}</title>
-              </text>
-            </g>
-          )}
+          <title>{`${cubes.n} resource cube${cubes.n === 1 ? '' : 's'} on tile`}</title>
+          {cubeCells(cubes.n).map((cell) => (
+            <rect
+              key={`${cell.x}:${cell.y}`}
+              x={cell.x}
+              y={cell.y}
+              width={CUBE}
+              height={CUBE}
+              rx="1"
+              fill={cubes.c}
+              stroke="#f2e6c8"
+              strokeWidth="1"
+            />
+          ))}
         </g>
       )}
       {/* printed stats: VP roundel · link icons · income advance.

--- a/src/components/board/tile-cubes.test.ts
+++ b/src/components/board/tile-cubes.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { SLOT } from './marker-anchor'
+import {
+  CUBE,
+  CUBE_COLS,
+  CUBE_ORIGIN_X,
+  MAX_TILE_CUBES,
+  NUMERAL_BASELINE,
+  RIBBON_TOP,
+  cubeCells,
+} from './tile-cubes'
+
+/** The keyline is 1px centred on the cube edge, so it bleeds 0.5 each way. */
+const KEYLINE = 0.5
+/** The counts the tile data can actually produce (see industryTiles.ts). */
+const COUNTS = [1, 2, 3, 4, 5, 6]
+
+describe('cubeCells', () => {
+  it('draws every cube — nothing collapses into a count numeral', () => {
+    for (const n of COUNTS) expect(cubeCells(n)).toHaveLength(n)
+    expect(cubeCells(0)).toEqual([])
+  })
+
+  it('never touches the roman level numeral', () => {
+    for (const n of COUNTS) {
+      const top = Math.min(...cubeCells(n).map((c) => c.y)) - KEYLINE
+      expect(top).toBeGreaterThan(NUMERAL_BASELINE)
+    }
+  })
+
+  it('never touches the owner ribbon and stays inside the tile face', () => {
+    for (const n of COUNTS) {
+      const cells = cubeCells(n)
+      expect(Math.max(...cells.map((c) => c.y)) + CUBE + KEYLINE).toBeLessThan(
+        RIBBON_TOP,
+      )
+      expect(Math.min(...cells.map((c) => c.x)) - KEYLINE).toBeGreaterThan(0)
+      expect(Math.max(...cells.map((c) => c.x)) + CUBE + KEYLINE).toBeLessThan(
+        SLOT,
+      )
+    }
+  })
+
+  it('clears the industry glyph, which occupies x 5..29', () => {
+    for (const n of COUNTS) {
+      expect(
+        Math.min(...cubeCells(n).map((c) => c.x)) - KEYLINE,
+      ).toBeGreaterThan(29)
+    }
+  })
+
+  it('left-aligns every count — an odd cube sits in the left column', () => {
+    for (const n of COUNTS) {
+      const cells = cubeCells(n)
+      // first cube of every row is flush with the block's left edge
+      for (let i = 0; i < n; i += CUBE_COLS) {
+        expect(cells[i]!.x).toBe(CUBE_ORIGIN_X)
+      }
+      // a lone trailing cube is never nudged towards the centre
+      if (n % CUBE_COLS === 1) expect(cells[n - 1]!.x).toBe(CUBE_ORIGIN_X)
+    }
+  })
+
+  it('never overlaps another cube', () => {
+    for (const n of COUNTS) {
+      const cells = cubeCells(n)
+      for (let i = 0; i < cells.length; i++) {
+        for (let j = i + 1; j < cells.length; j++) {
+          const a = cells[i]!
+          const b = cells[j]!
+          const apart =
+            Math.abs(a.x - b.x) >= CUBE + 1 || Math.abs(a.y - b.y) >= CUBE + 1
+          expect(apart).toBe(true)
+        }
+      }
+    }
+  })
+
+  it('wraps in reading order across CUBE_COLS columns', () => {
+    const cells = cubeCells(MAX_TILE_CUBES)
+    expect(new Set(cells.map((c) => c.x)).size).toBe(CUBE_COLS)
+    expect(new Set(cells.map((c) => c.y)).size).toBe(MAX_TILE_CUBES / CUBE_COLS)
+  })
+})

--- a/src/components/board/tile-cubes.ts
+++ b/src/components/board/tile-cubes.ts
@@ -1,0 +1,55 @@
+import { SLOT } from './marker-anchor'
+
+/**
+ * Geometry for the resource cubes printed on a built industry tile
+ * (`BuiltTile` in `board-map.tsx`).
+ *
+ * Pure on purpose: the cubes share the tile's narrow right gutter with the
+ * roman level numeral above them and the owner ribbon below, and the old
+ * single column both TOUCHED the numeral (cube top y = numeral baseline) and
+ * could not physically hold the biggest stacks — a column needs
+ * `6.2 * 5 = 31px` for Coal Mine III's five cubes while the clear band between
+ * numeral and ribbon is only ~28.5px, which is why six (Iron Works IV) used to
+ * collapse into a `×6` numeral. Two left-aligned columns fit all six with real
+ * clearance at both ends, so every cube is drawn.
+ */
+
+/** Side of one cube (the 1px parchment keyline sits centred on this edge). */
+export const CUBE = 6.2
+/** Gap between cubes, both axes. */
+export const CUBE_GAP = 1.8
+/** Cubes fill left-to-right across this many columns, then wrap down. */
+export const CUBE_COLS = 2
+
+/** Baseline of the roman level numeral — the cubes must clear it. */
+export const NUMERAL_BASELINE = 13
+/** Top edge of the owner ribbon — the cubes must clear it too. */
+export const RIBBON_TOP = SLOT - 6
+
+const BLOCK_W = CUBE_COLS * CUBE + (CUBE_COLS - 1) * CUBE_GAP
+
+/**
+ * The block's right edge lines up with the level numeral's right edge
+ * (`x = SLOT - 5`), and cubes fill FROM THE LEFT inside it — so an odd cube
+ * always sits in the left column with the spare space on the right, never
+ * centred.
+ */
+export const CUBE_ORIGIN_X = SLOT - 5 - BLOCK_W
+/** Clear air between the numeral's baseline and the first cube row. */
+export const CUBE_ORIGIN_Y = NUMERAL_BASELINE + 3.5
+
+/** The largest stack the tile data can produce (Iron Works IV). */
+export const MAX_TILE_CUBES = 6
+
+export interface CubeCell {
+  x: number
+  y: number
+}
+
+/** Top-left corner of each cube, in tile-local units, filling left-to-right. */
+export function cubeCells(n: number): CubeCell[] {
+  return Array.from({ length: Math.max(0, n) }, (_, i) => ({
+    x: CUBE_ORIGIN_X + (i % CUBE_COLS) * (CUBE + CUBE_GAP),
+    y: CUBE_ORIGIN_Y + Math.floor(i / CUBE_COLS) * (CUBE + CUBE_GAP),
+  }))
+}


### PR DESCRIPTION
## The bug

On a built industry tile the resource cubes started at `y = 13` — **exactly the roman level numeral's baseline** — so every stack touched the numeral. Worse, the single column could not physically hold the biggest stacks: five cubes need 31px, while the clear band between numeral and owner ribbon is only ~28.5px. That is why six cubes (Iron Works IV) collapsed into a `×6` numeral, and why Coal Mine III's column ran into the ribbon.

## The fix

A **left-aligned two-column grid** in the tile's right gutter, extracted into the pure `src/components/board/tile-cubes.ts` (`cubeCells`):

- the block's right edge lines up with the numeral's, and cubes fill **from the left** — an odd cube always sits in the left column with the spare space on the right, never centred;
- 3.5px of clear air below the numeral baseline, ~7px above the owner ribbon at the maximum count, and it clears the industry glyph — so nothing touches at any level or industry type;
- all six cubes are drawn, so the `×6` collapse is gone.

Colours, cube size, glyphs, ribbon and numeral are untouched — this is spacing/layout only.

## Before

Every level touches the numeral; Coal IV runs into the ribbon; Iron IV collapses to `×6`.

![Before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr92-before.png)

## After

![After](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr92-after.png)

## On the real board (rail fixture, zoomed in)

Coal Mine II — 3 cubes, 2 + 1 left-aligned, clear of both numeral and ribbon.

![Board](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr92-board.png)

## Verification

- `tile-cubes.test.ts` pins, for **every count the tile data can produce (1..6)**: clearance from the numeral, from the ribbon, from the glyph and from the tile edges; left alignment at every count; no cube-on-cube overlap.
- Browser-verified across **every industry × level combination** (via a throwaway sweep page, removed before commit), at several **board zoom levels**, and at **mobile width (390px)**.
- `pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green locally (752 tests).

## Note on AGENTS.md

`AGENTS.md` previously recorded "the board keeps a single column … do not re-unify them" as a captain's call. That single column is the thing that cannot fit the biggest stacks without touching something, so this PR supersedes that line and rewrites the note to describe the new board layout (the two surfaces still differ in placement and in the mat's `depth` stacks).