### PR TITLE
fix(db): cascade chat + intent rows when a game is deleted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1166,6 +1166,13 @@ When updating this file, preserve this bar for all agents and keep entries conci
   only a placeholder URL (no prod creds); prod unpooled URL lives only in
   Vercel/CI. All gates pure + pinned by `scripts/vercel-migrate.test.ts` +
   `scripts/guarded-push.test.ts` (now in the `pnpm test` glob).
+- CHILD ROWS CASCADE (migration 0006, 2026-07-23): `chat_messages.token` and
+  `game_intents.token` are real FKs onto `games.token` with `ON DELETE
+  CASCADE`, so deleting a game — sweep or a hand-run DELETE in the Neon console
+  — takes its chat + intent log with it, and an orphan can no longer be created.
+  The migration deletes any residual orphans FIRST (adding an FK validates
+  existing rows, so one orphan would fail the ALTER and kill the deploy) — do
+  the same for any future child table. Pinned by `store.cascade.test.ts`.
 - INTENT LOG (2026-07-17): every ACCEPTED state-mutating engine write appends
   one row to the append-only `game_intents` table (PK token+seq, chat pattern;
   swept with the game) — the machine-replayable record for bug reproduction,

--- a/drizzle/0006_demonic_vengeance.sql
+++ b/drizzle/0006_demonic_vengeance.sql
@@ -1,0 +1,12 @@
+-- Hand-written prelude (the two ALTERs below are drizzle-generated).
+--
+-- Adding a FOREIGN KEY VALIDATES every existing row, so a single orphaned
+-- child row — one whose game was deleted back when nothing tied them together
+-- — would fail the ALTER and kill the deploy. These tables have no life of
+-- their own (an orphan is unreachable by definition: no game, no way to read
+-- it), so clear any residual orphans first. Captain-authorized 2026-07-23.
+-- Both tables are small (hundreds of rows), so a plain DELETE is fine.
+DELETE FROM "game_intents" WHERE "token" NOT IN (SELECT "token" FROM "games");--> statement-breakpoint
+DELETE FROM "chat_messages" WHERE "token" NOT IN (SELECT "token" FROM "games");--> statement-breakpoint
+ALTER TABLE "chat_messages" ADD CONSTRAINT "chat_messages_token_games_token_fk" FOREIGN KEY ("token") REFERENCES "public"."games"("token") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "game_intents" ADD CONSTRAINT "game_intents_token_games_token_fk" FOREIGN KEY ("token") REFERENCES "public"."games"("token") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,333 @@
+{
+  "id": "aba94387-d146-40cc-9ca3-ca5b54704412",
+  "prevId": "137dcd7d-0bed-46b6-a533-2dfbf529c88b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.chat_messages": {
+      "name": "chat_messages",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_messages_token_idx": {
+          "name": "chat_messages_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_messages_token_games_token_fk": {
+          "name": "chat_messages_token_games_token_fk",
+          "tableFrom": "chat_messages",
+          "tableTo": "games",
+          "columnsFrom": [
+            "token"
+          ],
+          "columnsTo": [
+            "token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "chat_messages_token_seq_pk": {
+          "name": "chat_messages_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_intents": {
+      "name": "game_intents",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seat_id": {
+          "name": "seat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_after": {
+          "name": "snapshot_after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_intents_token_idx": {
+          "name": "game_intents_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_intents_token_games_token_fk": {
+          "name": "game_intents_token_games_token_fk",
+          "tableFrom": "game_intents",
+          "tableTo": "games",
+          "columnsFrom": [
+            "token"
+          ],
+          "columnsTo": [
+            "token"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "game_intents_token_seq_pk": {
+          "name": "game_intents_token_seq_pk",
+          "columns": [
+            "token",
+            "seq"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'lobby'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seats": {
+          "name": "seats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messages": {
+          "name": "messages",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai": {
+          "name": "ai",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "games_phase_created_idx": {
+          "name": "games_phase_created_idx",
+          "columns": [
+            {
+              "expression": "phase",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "games_updated_active_idx": {
+          "name": "games_updated_active_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"games\".\"phase\" <> 'over'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1784835883389,
       "tag": "0005_living_dormammu",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1784838872180,
+      "tag": "0006_demonic_vengeance",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -96,11 +96,18 @@ export const games = pgTable(
  * Chat is public to seated players; there is no seat-private channel, so no
  * per-seat filtering is needed on the chat rows themselves (the game view
  * still gates whether an unauthenticated viewer sees any chat at all).
+ *
+ * `token` is a real FOREIGN KEY with ON DELETE CASCADE: chat has no life of
+ * its own, so deleting a game — by the TTL sweep or by hand in the DB console
+ * — takes its chat with it. Before the FK existed (migration `0006`) such a
+ * delete silently orphaned these rows.
  */
 export const chatMessages = pgTable(
   'chat_messages',
   {
-    token: text('token').notNull(),
+    token: text('token')
+      .notNull()
+      .references(() => games.token, { onDelete: 'cascade' }),
     /** monotonically increasing per game; the message id on the wire */
     seq: integer('seq').notNull(),
     seatId: integer('seat_id').notNull(),
@@ -131,12 +138,15 @@ export const chatMessages = pgTable(
  * Server-side only: never shipped to clients, never read on the stream poll
  * (egress discipline) — only by the replay tooling (`../mp/replay.ts`) and the
  * TTL sweep. Same normalization pattern as `chat_messages`: PK (token, seq),
- * swept when the game is swept.
+ * `token` a FOREIGN KEY with ON DELETE CASCADE, so the log dies with its game
+ * however the game row is deleted (sweep or DB console) — see `chatMessages`.
  */
 export const gameIntents = pgTable(
   'game_intents',
   {
-    token: text('token').notNull(),
+    token: text('token')
+      .notNull()
+      .references(() => games.token, { onDelete: 'cascade' }),
     /** monotonically increasing per game; allocated inside the save statement */
     seq: integer('seq').notNull(),
     kind: text('kind', { enum: ['setup', 'intent'] }).notNull(),

--- a/src/server/mp/store.cascade.test.ts
+++ b/src/server/mp/store.cascade.test.ts
@@ -1,0 +1,105 @@
+// The `ON DELETE CASCADE` foreign keys added in migration `0006`.
+//
+// `chat_messages` and `game_intents` used to reference a game by a bare `token`
+// column, so deleting a game row (the TTL sweep, or a hand-run DELETE in the
+// Neon console) silently ORPHANED its chat and intent-log rows — invisible,
+// unreachable, and growing. Both columns are now real FKs onto `games.token`
+// with ON DELETE CASCADE.
+//
+// DB-backed on purpose: cascade is referential-integrity behaviour that only
+// the real database can demonstrate — a mock would prove nothing. Rows are
+// deleted BY TOKEN in teardown, never blanket-wiped: parallel vitest workers
+// share this database.
+import { randomUUID } from 'node:crypto'
+import { eq } from 'drizzle-orm'
+import { afterEach, beforeAll, expect, test, vi } from 'vitest'
+import { ensureTestSchema } from '../../test/db-schema'
+import { db } from '../db'
+import { chatMessages, gameIntents, games } from '../db/schema'
+import { appendChatMessage, saveGame } from './store'
+
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 })
+
+const seeded: string[] = []
+
+beforeAll(async () => {
+  await ensureTestSchema()
+})
+
+afterEach(async () => {
+  for (const token of seeded.splice(0)) {
+    await db.delete(games).where(eq(games.token, token))
+  }
+})
+
+/** A minimal real game row plus one intent-log row, written the way the live
+ *  path writes them (one atomic `saveGame`). */
+async function seedGameWithChildren(): Promise<string> {
+  const token = randomUUID().replace(/-/g, '')
+  seeded.push(token)
+  const stamp = new Date().toISOString()
+  await saveGame(
+    {
+      token,
+      phase: 'playing',
+      name: '',
+      visibility: 'public',
+      archived: false,
+      createdAt: stamp,
+      updatedAt: stamp,
+      version: 1,
+      seats: [],
+      snapshot: { context: {} },
+    },
+    { kind: 'setup', seatId: null, payload: { context: {} } },
+  )
+  await appendChatMessage(token, 0, 'Ada', 'hello', stamp)
+  return token
+}
+
+const countIntents = async (token: string) =>
+  (await db.select().from(gameIntents).where(eq(gameIntents.token, token)))
+    .length
+
+const countChat = async (token: string) =>
+  (await db.select().from(chatMessages).where(eq(chatMessages.token, token)))
+    .length
+
+test('deleting a game cascades away its intent log and chat', async () => {
+  const token = await seedGameWithChildren()
+  expect(await countIntents(token)).toBe(1)
+  expect(await countChat(token)).toBe(1)
+
+  // The bare DELETE a sweep — or a human in the DB console — issues.
+  await db.delete(games).where(eq(games.token, token))
+
+  expect(await countIntents(token)).toBe(0)
+  expect(await countChat(token)).toBe(0)
+})
+
+test('a child row for a nonexistent game is refused by the foreign key', async () => {
+  // The other half of the constraint: orphans can no longer be CREATED, which
+  // is what makes the one-off cleanup in migration 0006 a one-off.
+  const ghost = randomUUID().replace(/-/g, '')
+  await expect(
+    db.insert(gameIntents).values({
+      token: ghost,
+      seq: 1,
+      kind: 'intent',
+      seatId: 0,
+      payload: {},
+      version: 1,
+      createdAt: new Date().toISOString(),
+    }),
+  ).rejects.toThrow()
+  await expect(
+    db.insert(chatMessages).values({
+      token: ghost,
+      seq: 1,
+      seatId: 0,
+      name: 'Ada',
+      text: 'hello',
+      createdAt: new Date().toISOString(),
+    }),
+  ).rejects.toThrow()
+})

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -566,9 +566,10 @@ export async function sweepStaleGames(now = Date.now()): Promise<void> {
   // so a string `<` comparison is a correct TTL cutoff.
   const cutoff = new Date(now - GAME_TTL_MS).toISOString()
   await db.delete(games).where(lt(games.updatedAt, cutoff))
-  // Chat and intent-log rows are tied to game lifetime; drop any now-orphaned
-  // by the sweep above (anti-join is cheap at this scale and keeps deletion in
-  // one place).
+  // Chat and intent-log rows are tied to game lifetime. Since migration 0006
+  // both `token` columns are FKs with ON DELETE CASCADE, so the delete above
+  // already took them — these anti-joins are now a cheap belt-and-braces pass
+  // that also clears any orphan predating the constraint.
   await db
     .delete(chatMessages)
     .where(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,7 @@
     "moduleResolution": "Bundler",
     /* Next 16 mandates the React automatic runtime — it rewrites this to
        'react-jsx' on every build if set to 'preserve', so keep it here. */
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## The problem

`chat_messages` and `game_intents` referenced a game only by a bare `token` column plus an index — **no foreign key, no cascade**. So deleting a game row (the TTL sweep, or a hand-run `DELETE` in the Neon console) silently left its chat and intent-log rows behind: invisible, unreachable, and accumulating. Hit for real while deleting test games directly in Neon.

## The change

Both `token` columns are now real foreign keys onto `games.token` with `ON DELETE CASCADE`, declared in `schema.ts` and generated into migration `0006_demonic_vengeance`.

## ⚠️ Exactly what migration 0006 does to prod data

```sql
DELETE FROM "game_intents"  WHERE "token" NOT IN (SELECT "token" FROM "games");
DELETE FROM "chat_messages" WHERE "token" NOT IN (SELECT "token" FROM "games");
ALTER TABLE "chat_messages" ADD CONSTRAINT ... FOREIGN KEY ("token") REFERENCES "games"("token") ON DELETE cascade;
ALTER TABLE "game_intents"  ADD CONSTRAINT ... FOREIGN KEY ("token") REFERENCES "games"("token") ON DELETE cascade;
```

- **It deletes** any `game_intents` / `chat_messages` row whose game no longer exists — orphans, unreachable by definition. Rows belonging to a live game are untouched. The captain has already cleared the known orphans by hand and authorized clearing any residual ones.
- **Why the DELETE has to be there:** adding an FK validates every existing row, so one leftover orphan would fail the `ALTER` and kill the deploy.
- **Locking:** these tables hold hundreds of rows, so a plain `DELETE` + `ADD CONSTRAINT` is the whole story — deliberately no `NOT VALID` / `VALIDATE` ceremony at this size.

After this, deleting a game cascades its chat + intent log away, and an orphan can no longer be created at all.

## Verification

- Full migration chain applied **in order to a clean scratch database** (local Docker Postgres, prod's own `neon-http` migrator): both FKs present, `delete_rule = CASCADE`.
- Re-applied `0006` over **planted orphans** on a pre-0006 schema: prelude cleared them, both `ALTER`s succeeded, then a game delete left 0 intents and 0 chat rows.
- `drizzle-kit check` clean; re-running `pnpm db:generate` produces no new file; migration generated as `0006_*` chained off `0005_living_dormammu` (snapshot/journal untouched by hand).
- New DB-backed `src/server/mp/store.cascade.test.ts`: game + intent + chat → delete game → children gone; plus the negative half (inserting a child for a nonexistent game is refused).
- `pnpm typecheck && pnpm lint && pnpm test` (766 passed) `&& pnpm build` all green. **Production database never touched.**

Also: a note in `AGENTS.md`, and the sweep's now-redundant anti-join deletes are documented as belt-and-braces rather than removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Related chat messages and game intent records are now automatically removed when their game is deleted.
  * Prevented creation of chat messages or game intents for nonexistent games.
  * Cleaned up existing orphaned records during database migration.

* **Tests**
  * Added coverage to verify cascading deletion and referential integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->