### PR TITLE
fix(mp): rate-limit the JOIN and CHAT endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1257,10 +1257,18 @@ When updating this file, preserve this bar for all agents and keep entries conci
   (`.bb2-busy`, `aria-busy`), and gates board-click / hand-select handlers so
   a move can't be double-fired. Do NOT drive any game state off this signal.
 - ABUSE GUARDRAILS (2026-07-23): `src/server/mp/rate-limit.ts` holds the
-  per-IP in-memory limits on the two unauthenticated hot endpoints — game
-  create (`CREATE_LIMIT_MAX`/hour, 429 in `create/route.ts`) and concurrent
+  per-IP in-memory limits on the stranger-reachable hot endpoints — game
+  create (`CREATE_LIMIT_MAX`/hour, 429 in `create/route.ts`), concurrent
   SSE streams (`STREAM_CAP_PER_IP`, 429 in `stream/route.ts`; the release is
-  idempotent and wired into cleanup AND cancel). Deliberately in-process/per-
+  idempotent and wired into cleanup AND cancel), seat JOIN
+  (`JOIN_LIMIT_MAX`/10min — the lobby-SQUATTING brake, since public lobby
+  tokens are published by `/api/mp/lobbies` and a join needs only a token) and
+  CHAT (`CHAT_SEAT_LIMIT_MAX` per seat + `CHAT_IP_LIMIT_MAX` per IP per
+  minute; the seat key MUST include the IP, the check runs pre-auth). Every
+  429 is `{error}` + a `Retry-After` derived from its window constant.
+  `act`/`ready`/`start`/`release` are deliberately UNLIMITED: all require a
+  valid per-seat secret, only obtainable via the (now limited) join, so they
+  are not a stranger-reachable surface. Deliberately in-process/per-
   instance — the 2026-07-23 arch verdict forbids new vendors (no Upstash);
   do not "upgrade" it without that decision reopening. Streams keep
   `seat`/`secret` OPTIONAL — requiring auth to stream is a reserved

--- a/src/app/api/mp/chat/route.ts
+++ b/src/app/api/mp/chat/route.ts
@@ -1,6 +1,11 @@
 import { waitUntil } from '@vercel/functions'
 import { NextResponse } from 'next/server'
 import { kickAiTurns, sendChat } from '~/server/mp/game'
+import {
+  allowChat,
+  CHAT_LIMIT_WINDOW_MS,
+  clientIpFrom,
+} from '~/server/mp/rate-limit'
 
 export const runtime = 'nodejs'
 // Symmetric with the act route: a chat never advances the turn, but keeping
@@ -23,9 +28,26 @@ export async function POST(req: Request) {
       )
     }
     const token = String(body.token ?? '')
+    const seatId = Number(body.seatId ?? -1)
+    // Chat is the one seat-authenticated endpoint whose cost is per-MESSAGE
+    // spam rather than per-seat, so it carries its own window. The seat bucket
+    // is keyed by IP too — this runs before the secret is checked, and a bare
+    // token+seat key would let a stranger burn a real player's allowance.
+    const ip = clientIpFrom(req)
+    if (!allowChat(ip, `${ip}|${token}|${seatId}`)) {
+      return NextResponse.json(
+        { ok: false, error: 'Sending messages too quickly — slow down.' },
+        {
+          status: 429,
+          headers: {
+            'Retry-After': String(Math.ceil(CHAT_LIMIT_WINDOW_MS / 1000)),
+          },
+        },
+      )
+    }
     const result = await sendChat(
       token,
-      Number(body.seatId ?? -1),
+      seatId,
       String(body.seatSecret ?? ''),
       body.text,
     )

--- a/src/app/api/mp/join/route.ts
+++ b/src/app/api/mp/join/route.ts
@@ -1,9 +1,29 @@
 import { NextResponse } from 'next/server'
 import { joinGame } from '~/server/mp/game'
+import {
+  allowJoin,
+  clientIpFrom,
+  JOIN_LIMIT_WINDOW_MS,
+} from '~/server/mp/rate-limit'
 
 export const runtime = 'nodejs'
 
 export async function POST(req: Request) {
+  // Unauthenticated by design: a join needs only the game token, and public
+  // lobby tokens are published by /api/mp/lobbies — so without this window a
+  // stranger could harvest every token and squat every open seat, one HTTP
+  // request per seat. See rate-limit.ts for thresholds.
+  if (!allowJoin(clientIpFrom(req))) {
+    return NextResponse.json(
+      { error: 'Too many seat claims from this address — try again shortly.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil(JOIN_LIMIT_WINDOW_MS / 1000)),
+        },
+      },
+    )
+  }
   try {
     const body = (await req.json()) as { token?: string; name?: string }
     const result = await joinGame(

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -1596,10 +1596,16 @@ function MpTable({
                       const body = (await res.json()) as {
                         ok: boolean
                         view?: GameViewWire
+                        error?: string
                       }
                       // Apply the sender's fresh view (with the new message) at once,
                       // same version-guarded path as an SSE frame.
                       if (body.ok && body.view) applyView(body.view)
+                      // A refusal (rate limit, bad seat) must never look like a
+                      // silent drop — name it, the same way join does.
+                      else if (!body.ok) {
+                        toast.error(body.error ?? 'Could not send the message')
+                      }
                     } catch {
                       toast.error('Could not send the message')
                     }

--- a/src/server/mp/rate-limit.test.ts
+++ b/src/server/mp/rate-limit.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, test } from 'vitest'
 import {
   acquireSlot,
+  allowChat,
+  allowJoin,
+  CHAT_IP_LIMIT_MAX,
+  CHAT_LIMIT_WINDOW_MS,
+  CHAT_SEAT_LIMIT_MAX,
   clientIpFrom,
+  JOIN_LIMIT_MAX,
+  JOIN_LIMIT_WINDOW_MS,
   MAX_TRACKED_KEYS,
   takeFromWindow,
   type WindowEntry,
@@ -77,6 +84,112 @@ describe('acquireSlot — concurrent stream cap', () => {
     const a = acquireSlot(map, 'ip', 4)!
     a()
     expect(map.has('ip')).toBe(false)
+  })
+})
+
+// The allow* helpers share process-global maps (HMR-safe by design), so every
+// test below uses its OWN ip/seat keys and passes an explicit `now`.
+
+describe('allowJoin — per-IP seat-claim limiter (lobby squatting)', () => {
+  test('allows up to the limit inside the window, then 429s', () => {
+    const ip = 'join-basic'
+    for (let i = 0; i < JOIN_LIMIT_MAX; i++) {
+      expect(allowJoin(ip, 0)).toBe(true)
+    }
+    expect(allowJoin(ip, JOIN_LIMIT_WINDOW_MS - 1)).toBe(false)
+  })
+
+  test('the window resets', () => {
+    const ip = 'join-reset'
+    for (let i = 0; i < JOIN_LIMIT_MAX; i++) expect(allowJoin(ip, 0)).toBe(true)
+    expect(allowJoin(ip, JOIN_LIMIT_WINDOW_MS - 1)).toBe(false)
+    expect(allowJoin(ip, JOIN_LIMIT_WINDOW_MS)).toBe(true)
+  })
+
+  test('addresses are independent buckets', () => {
+    for (let i = 0; i < JOIN_LIMIT_MAX; i++) {
+      expect(allowJoin('join-a', 0)).toBe(true)
+    }
+    expect(allowJoin('join-a', 1)).toBe(false)
+    expect(allowJoin('join-b', 1)).toBe(true)
+  })
+
+  test('HAPPY PATH: a normal table filling up is never limited', () => {
+    // A whole 4-player household behind ONE NAT: the host plus three joiners,
+    // each of whom also refreshes/reconnects and re-claims a couple of times,
+    // and they do it twice over for a second game. Must stay well clear.
+    const ip = 'join-household'
+    let joins = 0
+    for (let game = 0; game < 2; game++) {
+      for (let seat = 1; seat <= 3; seat++) {
+        for (let attempt = 0; attempt < 3; attempt++) {
+          expect(allowJoin(ip, game * 1000)).toBe(true)
+          joins++
+        }
+      }
+    }
+    expect(joins).toBe(18)
+    expect(joins).toBeLessThan(JOIN_LIMIT_MAX)
+  })
+})
+
+describe('allowChat — per-seat + per-IP message limiter', () => {
+  test('a seat may send up to the seat limit, then is refused', () => {
+    const ip = 'chat-seat-ip'
+    const seat = `${ip}|tok|0`
+    for (let i = 0; i < CHAT_SEAT_LIMIT_MAX; i++) {
+      expect(allowChat(ip, seat, 0)).toBe(true)
+    }
+    expect(allowChat(ip, seat, CHAT_LIMIT_WINDOW_MS - 1)).toBe(false)
+  })
+
+  test('the window resets', () => {
+    const ip = 'chat-reset-ip'
+    const seat = `${ip}|tok|0`
+    for (let i = 0; i < CHAT_SEAT_LIMIT_MAX; i++) {
+      expect(allowChat(ip, seat, 0)).toBe(true)
+    }
+    expect(allowChat(ip, seat, CHAT_LIMIT_WINDOW_MS - 1)).toBe(false)
+    expect(allowChat(ip, seat, CHAT_LIMIT_WINDOW_MS)).toBe(true)
+  })
+
+  test('one noisy seat does not silence another seat on the same address', () => {
+    const ip = 'chat-shared-ip'
+    const loud = `${ip}|tok|0`
+    const quiet = `${ip}|tok|1`
+    for (let i = 0; i < CHAT_SEAT_LIMIT_MAX; i++) {
+      expect(allowChat(ip, loud, 0)).toBe(true)
+    }
+    expect(allowChat(ip, loud, 1)).toBe(false)
+    expect(allowChat(ip, quiet, 1)).toBe(true)
+  })
+
+  test('the per-IP ceiling still bounds many seats driven from one address', () => {
+    const ip = 'chat-many-seats'
+    let sent = 0
+    // Enough distinct seats that the IP bucket, not any seat bucket, is what
+    // eventually refuses.
+    for (let seat = 0; seat < 20 && sent <= CHAT_IP_LIMIT_MAX; seat++) {
+      for (let i = 0; i < CHAT_SEAT_LIMIT_MAX; i++) {
+        if (!allowChat(ip, `${ip}|tok|${seat}`, 0)) {
+          expect(sent).toBe(CHAT_IP_LIMIT_MAX)
+          return
+        }
+        sent++
+      }
+    }
+    throw new Error(`per-IP chat ceiling never applied (sent ${sent})`)
+  })
+
+  test('HAPPY PATH: normal conversation pace is never limited', () => {
+    // Four seats behind one NAT, each sending a message every ~5s for a
+    // minute — a chatty table, still far under both ceilings.
+    const ip = 'chat-conversation'
+    for (let tick = 0; tick < 12; tick++) {
+      for (let seat = 0; seat < 4; seat++) {
+        expect(allowChat(ip, `${ip}|tok|${seat}`, tick * 5000)).toBe(true)
+      }
+    }
   })
 })
 

--- a/src/server/mp/rate-limit.ts
+++ b/src/server/mp/rate-limit.ts
@@ -10,12 +10,20 @@
 // in practice these counters do bite.
 //
 // Two primitives, both pure and unit-tested:
-//   • fixed-window counter  — bounds game CREATION per IP
+//   • fixed-window counter  — bounds game CREATION, seat JOINs and CHAT per IP
 //   • concurrent-slot gauge — bounds simultaneously OPEN SSE streams per IP
 //
 // Neither identifies anyone beyond an IP bucket, and both defaults are picked
 // generously so no legitimate table (≤4 players, a handful of lobbies) ever
 // hits them.
+//
+// COVERAGE IS DELIBERATE. Only the endpoints an UNAUTHENTICATED stranger can
+// reach are limited: create, stream, join and chat. `act`/`ready`/`start`/
+// `release` all demand a valid per-seat secret (128-bit, handed out only by a
+// successful join), so they are not a stranger-reachable surface — and join,
+// which is the gate to getting such a secret, IS limited here. Chat needs a
+// seat too, but it is the one authenticated endpoint whose cost is per-MESSAGE
+// spam rather than per-seat, so it gets its own bucket.
 
 /* ---------------- tunable thresholds ---------------- */
 
@@ -34,6 +42,36 @@ export const CREATE_LIMIT_WINDOW_MS = 60 * 60 * 1000
  * + ~88 Neon queries/min each from one address. Tune here.
  */
 export const STREAM_CAP_PER_IP = 24
+
+/**
+ * Seat JOINs allowed per IP per window. This is the lobby-SQUATTING brake:
+ * public lobby tokens are handed out by `GET /api/mp/lobbies`, so a stranger
+ * can harvest every token and claim every open seat at one HTTP request each.
+ *
+ * Sized so a real household never notices. A whole 4-player table filling up
+ * from behind ONE NAT is 4 joins; add re-joins after a refresh, a dropped
+ * connection or a release-and-reclaim and a heavy games night is still well
+ * inside 40 per 10 minutes. An abuser gets 40 seats per 10 min per instance
+ * instead of unbounded. Tune here.
+ */
+export const JOIN_LIMIT_MAX = 40
+export const JOIN_LIMIT_WINDOW_MS = 10 * 60 * 1000
+
+/**
+ * Chat messages allowed per SEAT per window. A seat secret is required to
+ * chat, so this bounds spam from a legitimately seated player (or a leaked
+ * secret) rather than a stranger. 30 messages/minute is far past conversation
+ * pace — roughly one every two seconds, sustained. Tune here.
+ */
+export const CHAT_SEAT_LIMIT_MAX = 30
+export const CHAT_LIMIT_WINDOW_MS = 60 * 1000
+
+/**
+ * Chat messages allowed per IP per window, over the same window. Four players
+ * behind one NAT each chatting at the per-seat ceiling would be 120, so this
+ * only bites when a single address is driving many seats at once. Tune here.
+ */
+export const CHAT_IP_LIMIT_MAX = 120
 
 /** Hard bound on tracked keys so a scan of many IPs can't grow memory forever. */
 export const MAX_TRACKED_KEYS = 10_000
@@ -129,9 +167,14 @@ export function clientIpFrom(req: Request): string {
 const g = globalThis as unknown as {
   __bbCreateWindow?: Map<string, WindowEntry>
   __bbStreamSlots?: Map<string, number>
+  __bbJoinWindow?: Map<string, WindowEntry>
+  __bbChatWindow?: Map<string, WindowEntry>
 }
 const createWindow = (g.__bbCreateWindow ??= new Map())
 const streamSlots = (g.__bbStreamSlots ??= new Map())
+const joinWindow = (g.__bbJoinWindow ??= new Map())
+// One map for both chat buckets — the keys are prefixed and so cannot collide.
+const chatWindow = (g.__bbChatWindow ??= new Map())
 
 /** May this IP create another game right now? */
 export function allowCreate(ip: string, now: number = Date.now()): boolean {
@@ -140,6 +183,48 @@ export function allowCreate(ip: string, now: number = Date.now()): boolean {
     ip,
     CREATE_LIMIT_MAX,
     CREATE_LIMIT_WINDOW_MS,
+    now,
+  )
+}
+
+/** May this IP claim another seat right now? */
+export function allowJoin(ip: string, now: number = Date.now()): boolean {
+  return takeFromWindow(
+    joinWindow,
+    ip,
+    JOIN_LIMIT_MAX,
+    JOIN_LIMIT_WINDOW_MS,
+    now,
+  )
+}
+
+/**
+ * May this seat send another chat message right now? Both buckets are
+ * consumed, per-SEAT first so a single noisy seat is stopped before it can
+ * spend its housemates' shared per-IP allowance.
+ *
+ * `seatKey` MUST include the caller's IP (see the chat route): the check runs
+ * before the seat secret is verified, so a key of token+seat alone would let a
+ * stranger POST forged seat ids to exhaust a real player's chat allowance.
+ */
+export function allowChat(
+  ip: string,
+  seatKey: string,
+  now: number = Date.now(),
+): boolean {
+  const seatOk = takeFromWindow(
+    chatWindow,
+    `seat:${seatKey}`,
+    CHAT_SEAT_LIMIT_MAX,
+    CHAT_LIMIT_WINDOW_MS,
+    now,
+  )
+  if (!seatOk) return false
+  return takeFromWindow(
+    chatWindow,
+    `ip:${ip}`,
+    CHAT_IP_LIMIT_MAX,
+    CHAT_LIMIT_WINDOW_MS,
     now,
   )
 }


### PR DESCRIPTION
Closes the lobby-squatting vector left open after #87.

## Why JOIN was the exposed one

On `main`, only **create** and **stream** called `server/mp/rate-limit.ts`. A join needs **only the game token** — and public lobby tokens are handed out by the lobby list itself (`loadOpenLobbies` / `GET /api/mp/lobbies`). So anyone could read the public lobby list, harvest every token, and claim every open seat at one HTTP request per seat.

## What changed

Reuses the **existing** in-process fixed-window primitive (`takeFromWindow`) — no second mechanism, no vendor, no durable store (the 2026-07-23 arch verdict still forbids one), **no schema change and no migration**.

| Endpoint | Limit | Constant |
|---|---|---|
| join | 40 per 10 min per IP | `JOIN_LIMIT_MAX` / `JOIN_LIMIT_WINDOW_MS` |
| chat | 30/min per seat | `CHAT_SEAT_LIMIT_MAX` |
| chat | 120/min per IP | `CHAT_IP_LIMIT_MAX` |

All thresholds are tunable, commented constants alongside the existing ones.

**Generous by design.** A whole 4-player table filling up from behind **one NAT** is 4 joins; add refreshes, dropped connections and release-and-reclaim and a heavy games night is still far inside 40/10min. 30 chat messages/minute is roughly one every two seconds sustained — past any conversation pace.

**Chat's seat key includes the caller's IP.** The limit check runs *before* the seat secret is verified, so a bare `token|seat` key would let a stranger POST forged seat ids to exhaust a real player's chat allowance. Keying on `ip|token|seat` kills that cross-IP poison while still bounding a genuine seat (one seat, one IP).

## Response shape

Both refuse with **429 + `Retry-After`**, matching the create limiter's shape (`{ error }` JSON; chat adds `ok: false` since its client branches on `ok`). `Retry-After` is derived from each window constant rather than hardcoded.

The chat client previously **dropped a `!ok` response silently** — it now toasts the server's reason, the way join already did.

## Why `act` / `ready` / `start` / `release` are deliberately untouched

Stated explicitly so the choice is visible and reviewable: **all four require a valid per-seat secret** (128-bit, handed out only by a successful join), so an unauthenticated stranger cannot reach them at all. Their exposure profile is different from create/stream/join. And the gate to *getting* such a secret — join — **is** now limited, which is the actual chokepoint. Rate-limiting them would only throttle already-seated players mid-game.

## Testing

New unit tests in the existing `rate-limit.test.ts` style pin allowed-under-limit, refused-over-limit, window reset, and independent buckets for both new limits — plus two explicit **happy-path regression tests**:

- a 4-player household behind one NAT filling two tables, with retries, is never limited;
- four seats chatting every ~5s for a minute is never limited.

Also pinned: one noisy seat cannot silence another seat on the same address, and the per-IP ceiling still applies when many seats are driven from one address.

Legitimate multi-player join flow verified **end to end over real HTTP** through the limited route: `e2e/multiplayer.spec.ts` (create → join → live convergence → seat reclaim) and `e2e/lobby-browser.spec.ts` (discover → join → start) both pass.

`pnpm typecheck`, `pnpm lint`, `pnpm test` (773 passed), and `pnpm build` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
