### PR TITLE
feat(obs): add Sentry error tracking with secret scrubbing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,29 @@ DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"
+
+# ── Sentry error tracking ─────────────────────────────────────────────────
+# ALL FOUR ARE OPTIONAL. With no DSN the SDK initialises disabled: the app
+# builds and runs exactly as before, just without reporting — which is the
+# intended local/CI/preview default. Nothing in the app depends on Sentry.
+#
+# NEXT_PUBLIC_SENTRY_DSN — the ingest endpoint, used by the browser, the
+# server and the edge runtime. Public by design (it only permits ingest), so
+# NEXT_PUBLIC_ is correct. Needed at BUILD time (it is inlined into the client
+# bundle) AND at runtime. Set it in Vercel for Production + Preview.
+# NEXT_PUBLIC_SENTRY_DSN="https://<key>@<org>.ingest.sentry.io/<project-id>"
+#
+# NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE — 0..1, defaults to 0.01 (1%). Errors
+# are always sent in full; this only bounds performance transactions, which the
+# SSE stream would otherwise mint every ~1.2s per open tab.
+# NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE="0.01"
+#
+# SENTRY_AUTH_TOKEN / SENTRY_ORG / SENTRY_PROJECT — BUILD-TIME ONLY, used by
+# the bundler plugin in next.config.js to upload source maps so stack traces
+# are readable instead of minified noise. Never read at runtime, never sent to
+# the client. Without them the build skips the upload and is otherwise
+# identical. Mint the token at Sentry → Settings → Auth Tokens with the
+# `project:releases` scope.
+# SENTRY_AUTH_TOKEN="sntrys_..."
+# SENTRY_ORG="your-org-slug"
+# SENTRY_PROJECT="brass-birmingham"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -815,6 +815,53 @@ What this means in practice:
   action's built-in default `claude-sonnet-4-20250514` 404s (id no longer
   served). Bump this when the model id changes.
 
+## Error tracking — Sentry (added 2026-07-23)
+
+- `@sentry/nextjs` is PINNED EXACT at 10.67.0. Next 16 support landed in
+  **10.20.0** (that release widened `peerDependencies.next` to include
+  `^16.0.0-0`); verify with `npm view @sentry/nextjs@<v> peerDependencies.next`
+  before bumping, and never force-install past a peer error.
+- Wiring is the standard Next 15+/16 layout, all at the repo ROOT:
+  `instrumentation.ts` (`register()` + `onRequestError`), `sentry.server.config.ts`,
+  `sentry.edge.config.ts`, `instrumentation-client.ts` (+
+  `onRouterTransitionStart`). `next.config.js` is wrapped in `withSentryConfig`
+  (tunnel `/monitoring-tunnel`, source-map upload, `silent` unless a token).
+  The tunnel is a REWRITE, not a route — it never shows in the `next build`
+  route table; check `.next/routes-manifest.json` `rewrites.afterFiles`.
+- ALL init options live in ONE place, `src/lib/sentry-options.ts` — the three
+  runtimes only spread it, so scrubbing/sampling cannot drift between them.
+  Its callbacks are typed as identity generics (`<T>(e: T): T`) on purpose:
+  that is what makes one implementation satisfy the SDK's three different
+  callback signatures without this module importing a Sentry type.
+- SECURITY: `src/lib/sentry-scrub.ts` is the `beforeSend` body and the ONLY
+  gate. It drops request headers/cookies/bodies wholesale and deep-scrubs
+  URLs, query strings, messages, exceptions, tags, extra, contexts and
+  breadcrumbs. The GAME TOKEN is deliberately kept (it is the identifier, not a
+  credential); seat/host secrets, `CRON_SECRET` and auth tokens are redacted —
+  note the SSE stream takes `?seat=&secret=` so URLs leak if unscrubbed. NO
+  Session Replay, no profiling, `sendDefaultPii:false`, 1% traces. Pinned by
+  `sentry-scrub.test.ts` (unit) AND `sentry-wire.test.ts`, which boots a real
+  `NodeClient` against a localhost ingest server and asserts the RAW ENVELOPE
+  BYTES. Any new context field must be proven there in the same commit.
+- CAPTURE SITES all go through `captureMpError` (`src/server/observability.ts`),
+  which always writes a structured `[mp] <route> failed` console line (works
+  with no DSN — the local/CI/preview default) and reports with tags
+  `route`/`mp.token`/`mp.phase`/`mp.seat`/`mp.event`. Wired into the act, join,
+  create, start and stream routes, `broadcast`/`kickAiTurns`/`runAiTurns`,
+  `store.saveGame`, and the deploy migration (`scripts/vercel-migrate.mjs`).
+  A route captures only when `isExpectedMpError` (`src/server/mp/expected-errors.ts`)
+  says no — user-facing refusals ('No open seats', 'Game not found') are the
+  product working and must not burn the free tier. Add a NEW refusal string to
+  that list in the same commit that throws it.
+- The SDK is imported LAZILY inside `captureMpError` and only when a DSN is
+  set, so DSN-less runs (every test) never load it.
+- Env: `NEXT_PUBLIC_SENTRY_DSN` (build + runtime; missing ⇒ no-op, everything
+  still builds and runs) and the BUILD-ONLY `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/
+  `SENTRY_PROJECT` for source maps. All optional in `src/env.js`, documented in
+  `.env.example`.
+- GOTCHA: `pnpm test`'s glob now includes `src/lib/*.test.ts` — it did not
+  before, so a test placed there used to be silently skipped by CI.
+
 ## Analytics (added 2026-07-17)
 
 - TRAFFIC = Vercel Web Analytics: `<Analytics/>` from `@vercel/analytics/next`

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,0 +1,20 @@
+// Sentry init for the browser. Next 15+/16 loads this file automatically (it
+// replaced the old `sentry.client.config.ts`).
+//
+// NO Session Replay and NO profiling — deliberate: replay records the game
+// board and chat (PII) and burns the free tier. Errors only.
+import * as Sentry from '@sentry/nextjs'
+import { sharedSentryOptions } from '~/lib/sentry-options'
+
+Sentry.init({
+  ...sharedSentryOptions,
+  // Default browser integrations minus anything that ships payloads we do not
+  // want (replay/feedback are not added by default, but be explicit about it).
+  integrations: (defaults) =>
+    defaults.filter(
+      (i) => !['Replay', 'ReplayCanvas', 'Feedback'].includes(i.name),
+    ),
+})
+
+// Required for Next.js navigation instrumentation (App Router).
+export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,15 @@
+// Next.js instrumentation hook — the SDK's server/edge entry point.
+// `register()` runs once per runtime at boot; `onRequestError` is Next 15+/16's
+// hook for errors thrown in server components, route handlers and middleware.
+import * as Sentry from '@sentry/nextjs'
+
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./sentry.server.config')
+  }
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    await import('./sentry.edge.config')
+  }
+}
+
+export const onRequestError = Sentry.captureRequestError

--- a/next.config.js
+++ b/next.config.js
@@ -2,9 +2,30 @@
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially useful
  * for Docker builds.
  */
+import { withSentryConfig } from '@sentry/nextjs'
 import './src/env.js'
 
 /** @type {import("next").NextConfig} */
 const config = {}
 
-export default config
+// Source-map upload only happens when SENTRY_AUTH_TOKEN + org/project are set
+// (Vercel, build time). Without them the plugin warns and skips the upload
+// rather than failing, so local dev and preview need no Sentry setup — the
+// tunnel route below is still added either way.
+export default withSentryConfig(config, {
+  org: process.env.SENTRY_ORG,
+  project: process.env.SENTRY_PROJECT,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+
+  // Route events through our own origin so ad blockers can't silently eat a
+  // slice of client errors (they block requests to *.sentry.io by name).
+  tunnelRoute: '/monitoring-tunnel',
+
+  // Readable stack traces: upload maps, then delete them from the deployed
+  // bundle so they are not publicly served.
+  widenClientFileUpload: true,
+  sourcemaps: { deleteSourcemapsAfterUpload: true },
+
+  // Keep the build log quiet unless something actually goes wrong.
+  silent: !process.env.SENTRY_AUTH_TOKEN,
+})

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "typecheck": "tsc --noEmit",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
-    "test": "vitest run src/store/gameStore.*.test.ts src/data/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
-    "test:watch": "vitest src/store/gameStore.*.test.ts src/data/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
+    "test": "vitest run src/store/gameStore.*.test.ts src/data/*.test.ts src/lib/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
+    "test:watch": "vitest src/store/gameStore.*.test.ts src/data/*.test.ts src/lib/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
     "test:all": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
@@ -32,6 +32,7 @@
     "@anthropic-ai/sdk": "^0.113.0",
     "@libsql/client": "^0.9.0",
     "@neondatabase/serverless": "^1.1.0",
+    "@sentry/nextjs": "10.67.0",
     "@t3-oss/env-nextjs": "^0.13.11",
     "@vercel/analytics": "^2.0.1",
     "@vercel/functions": "^3.7.5",
@@ -72,6 +73,9 @@
   },
   "ct3aMetadata": {
     "initVersion": "7.38.1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["@sentry/cli"]
   },
   "packageManager": "pnpm@10.4.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,15 @@ importers:
       '@neondatabase/serverless':
         specifier: ^1.1.0
         version: 1.1.0
+      '@sentry/nextjs':
+        specifier: 10.67.0
+        version: 10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(webpack@5.109.0(postcss@8.5.22))
       '@t3-oss/env-nextjs':
         specifier: ^0.13.11
         version: 0.13.11(@typescript/typescript6@6.0.2)(zod@3.24.2)
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.11(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.1(next@16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/functions':
         specifier: ^3.7.5
         version: 3.7.5(ws@8.21.1)
@@ -31,10 +34,10 @@ importers:
         version: 6.1.0(@types/react@19.2.17)(react@19.2.8)(xstate@5.32.5)
       drizzle-orm:
         specifier: ^0.45.2
-        version: 0.45.2(@libsql/client@0.9.0)(@neondatabase/serverless@1.1.0)(@types/pg@8.15.5)
+        version: 0.45.2(@libsql/client@0.9.0)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.15.5)
       next:
         specifier: ^16.2.11
-        version: 16.2.11(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -122,7 +125,7 @@ importers:
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: ^3.2.7
-        version: 3.2.7(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0)
+        version: 3.2.7(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0)
 
 packages:
 
@@ -142,6 +145,17 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.2':
+    resolution: {integrity: sha512-GvpKWDmzBFzbtVElU+tEDMDYyMY8SnMH4NNwwlUQioNHZvE6sSuHEqNkfU3iYhWL+/XO5Ej+MzhVJoqM10NYCQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    resolution: {integrity: sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==}
+    hasBin: true
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    resolution: {integrity: sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -1065,8 +1079,14 @@ packages:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/source-map@0.3.11':
+    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
+
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -1202,6 +1222,48 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@opentelemetry/api-logs@0.220.0':
+    resolution: {integrity: sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.10.0':
+    resolution: {integrity: sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.220.0':
+    resolution: {integrity: sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.10.0':
+    resolution: {integrity: sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.10.0':
+    resolution: {integrity: sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace@2.10.0':
+    resolution: {integrity: sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1211,8 +1273,31 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@rollup/plugin-commonjs@28.0.1':
+    resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/rollup-android-arm-eabi@4.34.8':
     resolution: {integrity: sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
     os: [android]
 
@@ -1221,8 +1306,18 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
   '@rollup/rollup-darwin-arm64@4.34.8':
     resolution: {integrity: sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1231,8 +1326,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rollup/rollup-freebsd-arm64@4.34.8':
     resolution: {integrity: sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
     os: [freebsd]
 
@@ -1241,8 +1346,18 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rollup/rollup-linux-arm-gnueabihf@4.34.8':
     resolution: {integrity: sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
 
@@ -1251,14 +1366,39 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-gnu@4.34.8':
     resolution: {integrity: sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
 
   '@rollup/rollup-linux-arm64-musl@4.34.8':
     resolution: {integrity: sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==}
     cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
     os: [linux]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.8':
@@ -1271,8 +1411,28 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
   '@rollup/rollup-linux-riscv64-gnu@4.34.8':
     resolution: {integrity: sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
 
@@ -1281,8 +1441,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-gnu@4.34.8':
     resolution: {integrity: sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
 
@@ -1291,8 +1461,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rollup/rollup-win32-arm64-msvc@4.34.8':
     resolution: {integrity: sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
     os: [win32]
 
@@ -1301,13 +1491,187 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.34.8':
     resolution: {integrity: sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==}
     cpu: [x64]
     os: [win32]
 
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@sentry/babel-plugin-component-annotate@5.3.0':
+    resolution: {integrity: sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==}
+    engines: {node: '>= 18'}
+
+  '@sentry/browser-utils@10.67.0':
+    resolution: {integrity: sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.67.0':
+    resolution: {integrity: sha512-/ZhsAvte4rYhg0A0RtSFFgAgXhyMOfQIeOAfMfptN+X6IVSYOfkA9jtrP+Ej4+6vlaUFWRir1HweF56y63dEEA==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    resolution: {integrity: sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==}
+    engines: {node: '>= 18'}
+
+  '@sentry/bundler-plugins@10.67.0':
+    resolution: {integrity: sha512-HKLhbMZJsabZlXTog8CTa1ReeDW/mf1cwN7O8K+DKhe/kGHB3whHRseqsyjxyJwPdzC/0lM+8rgfqgxpc7jR9A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.67.0':
+    resolution: {integrity: sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.67.0':
+    resolution: {integrity: sha512-I4ML2/SF3enwikb6ZSoRiqolQrx0zSzTSnUgwCmugICF/jpHW0th1pCray9R+t1Zzibw/Dpj4t/DNXaSDRa2MA==}
+    engines: {node: '>=18'}
+
+  '@sentry/nextjs@10.67.0':
+    resolution: {integrity: sha512-errNYlnhQBTDGzgAH0kkneD3/sK+VqW1qBixV8S/Gg4ygj6+QjigOU9idJA980H7mjyxrM1iT74qtcFt24nFow==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      next: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
+
+  '@sentry/node-core@10.67.0':
+    resolution: {integrity: sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+
+  '@sentry/node@10.67.0':
+    resolution: {integrity: sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.67.0':
+    resolution: {integrity: sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+
+  '@sentry/react@10.67.0':
+    resolution: {integrity: sha512-fS0DplcP9eMxBIRurPC/uxa4NrFK+l9ZsnvQo7wZvNutc7DpTAH0hgFt6laVNCe57s1pFo+OZuKsYBA6JDvH4Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
+
+  '@sentry/replay-canvas@10.67.0':
+    resolution: {integrity: sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.67.0':
+    resolution: {integrity: sha512-nkEUgPCR82EcyJkCf3XCE9H0R5KisCqyCAaSGxe7NpAoQbvASHx4MUNgXVAn+D0M494gvPZh6lFH7JgzqTcSqQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/server-utils@10.67.0':
+    resolution: {integrity: sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==}
+    engines: {node: '>=18'}
+
+  '@sentry/vercel-edge@10.67.0':
+    resolution: {integrity: sha512-tez7Kwz24PE4BCjzc2kcRc0gF4DWxYlSn61we9nRKSBh/wwUsQEznJfQ7tYxWbc67kxayQiyS5Vl9zzv5urTGw==}
+    engines: {node: '>=18'}
+
+  '@sentry/webpack-plugin@5.4.0':
+    resolution: {integrity: sha512-J3a0BvUZ75Qxy+v/Ap3Hx4ZEcSjlPHZ/jDtxdRhXQCyNeEb8xq0uUBTI9VLtGk2eNeNucOxOEJ5ngqdNjnEH/A==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      webpack: '>=5.0.0'
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -1365,6 +1729,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1703,6 +2070,51 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
+  '@webassemblyjs/ast@1.14.1':
+    resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2':
+    resolution: {integrity: sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==}
+
+  '@webassemblyjs/helper-api-error@1.13.2':
+    resolution: {integrity: sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==}
+
+  '@webassemblyjs/helper-buffer@1.14.1':
+    resolution: {integrity: sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    resolution: {integrity: sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==}
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2':
+    resolution: {integrity: sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    resolution: {integrity: sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==}
+
+  '@webassemblyjs/ieee754@1.13.2':
+    resolution: {integrity: sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==}
+
+  '@webassemblyjs/leb128@1.13.2':
+    resolution: {integrity: sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==}
+
+  '@webassemblyjs/utf8@1.13.2':
+    resolution: {integrity: sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    resolution: {integrity: sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==}
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    resolution: {integrity: sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==}
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    resolution: {integrity: sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==}
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    resolution: {integrity: sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==}
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
+
   '@xstate/react@6.1.0':
     resolution: {integrity: sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==}
     peerDependencies:
@@ -1711,6 +2123,12 @@ packages:
     peerDependenciesMeta:
       xstate:
         optional: true
+
+  '@xtuc/ieee754@1.2.0':
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  '@xtuc/long@4.2.2':
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1722,12 +2140,33 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  ajv-formats@2.1.1:
+    resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-keywords@5.1.0:
+    resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
+    peerDependencies:
+      ajv: ^8.8.2
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1805,6 +2244,10 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -1862,6 +2305,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.28.7:
+    resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -1903,6 +2351,9 @@ packages:
   caniuse-lite@1.0.30001735:
     resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
 
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
@@ -1923,6 +2374,13 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
+  chrome-trace-event@1.0.4:
+    resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
+    engines: {node: '>=6.0'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -1937,9 +2395,15 @@ packages:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -2049,6 +2513,14 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   drizzle-kit@0.31.10:
     resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
     hasBin: true
@@ -2155,6 +2627,9 @@ packages:
   electron-to-chromium@1.5.103:
     resolution: {integrity: sha512-P6+XzIkfndgsrjROJWfSvVEgNHtPgbhVyTkwLjUM2HU/h7pZRORgaTlHqfAikqxKmdJMLW8fftrdGWbd/Ds0FA==}
 
+  electron-to-chromium@1.5.395:
+    resolution: {integrity: sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -2163,6 +2638,10 @@ packages:
 
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
+    engines: {node: '>=10.13.0'}
+
+  enhanced-resolve@5.24.3:
+    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
 
   es-abstract@1.23.9:
@@ -2187,6 +2666,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -2311,6 +2793,10 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
   eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -2341,13 +2827,24 @@ packages:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
     engines: {node: '>=0.10'}
 
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2359,6 +2856,10 @@ packages:
   event-target-shim@6.0.2:
     resolution: {integrity: sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==}
     engines: {node: '>=10.13.0'}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -2390,6 +2891,9 @@ packages:
 
   fast-sha256@1.3.0:
     resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.19.0:
     resolution: {integrity: sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==}
@@ -2521,6 +3025,10 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     hasBin: true
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -2607,6 +3115,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@3.3.2:
+    resolution: {integrity: sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==}
+    engines: {node: '>=18'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2702,6 +3214,9 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -2764,6 +3279,10 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -2798,6 +3317,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -2860,11 +3382,18 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2877,12 +3406,20 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
   mime-types@2.1.35:
@@ -2907,9 +3444,59 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minimizer-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-DoeAZz8Q1C1znwsUzej1fdoi4jCf7/+Em27ouLqfK/+3m8G+D7yDhUwrc3CNhjSzGUN1kn7Iv4sWmjflQHenpw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@minify-html/node': '*'
+      '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
+      esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
+      '@swc/core':
+        optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
+      esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
+        optional: true
+      uglify-js:
+        optional: true
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2929,6 +3516,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
@@ -2961,12 +3551,25 @@ packages:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3067,6 +3670,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3248,11 +3855,18 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
@@ -3292,6 +3906,14 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -3322,6 +3944,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3343,6 +3970,13 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  schema-utils@4.3.3:
+    resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
+    engines: {node: '>= 10.13.0'}
+
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3440,6 +4074,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
@@ -3530,6 +4168,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -3547,6 +4189,15 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  terser@5.49.0:
+    resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -3588,6 +4239,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -3624,6 +4278,10 @@ packages:
   type-fest@0.20.2:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -3667,6 +4325,12 @@ packages:
 
   update-browserslist-db@1.1.2:
     resolution: {integrity: sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -3764,9 +4428,33 @@ packages:
       jsdom:
         optional: true
 
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
+    engines: {node: '>=10.13.0'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
+    engines: {node: '>=10.13.0'}
+
+  webpack@5.109.0:
+    resolution: {integrity: sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3894,6 +4582,30 @@ snapshots:
       standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 3.24.2
+
+  '@apm-js-collab/code-transformer-bundler-plugins@0.7.2':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      es-module-lexer: 2.3.1
+      magic-string: 0.30.21
+      module-details-from-path: 1.0.4
+
+  '@apm-js-collab/code-transformer@0.18.1':
+    dependencies:
+      '@types/estree': 1.0.9
+      astring: 1.9.0
+      esquery: 1.7.0
+      meriyah: 6.1.4
+      semifies: 1.0.0
+      source-map: 0.6.1
+
+  '@apm-js-collab/tracing-hooks@0.13.0':
+    dependencies:
+      '@apm-js-collab/code-transformer': 0.18.1
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -4502,7 +5214,14 @@ snapshots:
 
   '@jridgewell/set-array@1.2.1': {}
 
+  '@jridgewell/source-map@0.3.11':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -4620,6 +5339,49 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opentelemetry/api-logs@0.220.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.220.0
+      import-in-the-middle: 3.3.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/sdk-trace@2.10.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -4627,34 +5389,90 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
+  '@rollup/plugin-commonjs@28.0.1(rollup@4.62.2)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.5)
+      is-reference: 1.2.1
+      magic-string: 0.30.17
+      picomatch: 4.0.5
+    optionalDependencies:
+      rollup: 4.62.2
+
+  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
+    dependencies:
+      '@types/estree': 1.0.6
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+    optionalDependencies:
+      rollup: 4.62.2
+
   '@rollup/rollup-android-arm-eabi@4.34.8':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
   '@rollup/rollup-android-arm64@4.34.8':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.34.8':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.34.8':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.34.8':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.34.8':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.8':
@@ -4663,28 +5481,268 @@ snapshots:
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-riscv64-gnu@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-s390x-gnu@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
   '@rollup/rollup-linux-x64-gnu@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-x64-musl@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
   '@rollup/rollup-win32-arm64-msvc@4.34.8':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
   '@rollup/rollup-win32-ia32-msvc@4.34.8':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.34.8':
     optional: true
 
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
+
+  '@sentry/babel-plugin-component-annotate@5.3.0': {}
+
+  '@sentry/browser-utils@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/browser@10.67.0':
+    dependencies:
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/feedback': 10.67.0
+      '@sentry/replay': 10.67.0
+      '@sentry/replay-canvas': 10.67.0
+
+  '@sentry/bundler-plugin-core@5.3.0':
+    dependencies:
+      '@babel/core': 7.26.9
+      '@sentry/babel-plugin-component-annotate': 5.3.0
+      '@sentry/cli': 2.58.6
+      dotenv: 16.6.1
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.17
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/bundler-plugins@10.67.0(rollup@4.62.2)(webpack@5.109.0(postcss@8.5.22))':
+    dependencies:
+      '@babel/core': 7.26.9
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.67.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.17
+    optionalDependencies:
+      rollup: 4.62.2
+      webpack: 5.109.0(postcss@8.5.22)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.67.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/feedback@10.67.0':
+    dependencies:
+      '@sentry/core': 10.67.0
+
+  '@sentry/nextjs@10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(next@16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)(webpack@5.109.0(postcss@8.5.22))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/bundler-plugin-core': 5.3.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/node': 10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/react': 10.67.0(react@19.2.8)
+      '@sentry/server-utils': 10.67.0
+      '@sentry/vercel-edge': 10.67.0
+      '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.109.0(postcss@8.5.22))
+      next: 16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      rollup: 4.62.2
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - '@opentelemetry/sdk-trace-base'
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
+  '@sentry/node-core@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      import-in-the-middle: 3.3.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+
+  '@sentry/node@10.67.0(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      '@sentry/node-core': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.220.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/opentelemetry': 10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))
+      '@sentry/server-utils': 10.67.0
+      import-in-the-middle: 3.3.2
+    transitivePeerDependencies:
+      - '@opentelemetry/core'
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.67.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.10.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.10.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.10.0(@opentelemetry/api@1.9.1)
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/react@10.67.0(react@19.2.8)':
+    dependencies:
+      '@sentry/browser': 10.67.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+      react: 19.2.8
+
+  '@sentry/replay-canvas@10.67.0':
+    dependencies:
+      '@sentry/core': 10.67.0
+      '@sentry/replay': 10.67.0
+
+  '@sentry/replay@10.67.0':
+    dependencies:
+      '@sentry/browser-utils': 10.67.0
+      '@sentry/core': 10.67.0
+
+  '@sentry/server-utils@10.67.0':
+    dependencies:
+      '@apm-js-collab/code-transformer-bundler-plugins': 0.7.2
+      '@apm-js-collab/tracing-hooks': 0.13.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.67.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@sentry/vercel-edge@10.67.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@sentry/core': 10.67.0
+
+  '@sentry/webpack-plugin@5.4.0(rollup@4.62.2)(webpack@5.109.0(postcss@8.5.22))':
+    dependencies:
+      '@sentry/bundler-plugins': 10.67.0(rollup@4.62.2)(webpack@5.109.0(postcss@8.5.22))
+      webpack: 5.109.0(postcss@8.5.22)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
 
   '@stablelib/base64@1.0.1': {}
 
@@ -4730,6 +5788,8 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -4992,9 +6052,9 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vercel/analytics@2.0.1(next@16.2.11(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/analytics@2.0.1(next@16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
-      next: 16.2.11(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   '@vercel/cli-config@0.2.0':
@@ -5026,13 +6086,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@6.1.1(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0))':
+  '@vitest/mocker@3.2.7(vite@6.1.1(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.1.1(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0)
+      vite: 6.1.1(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -5060,6 +6120,82 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@webassemblyjs/ast@1.14.1':
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+
+  '@webassemblyjs/floating-point-hex-parser@1.13.2': {}
+
+  '@webassemblyjs/helper-api-error@1.13.2': {}
+
+  '@webassemblyjs/helper-buffer@1.14.1': {}
+
+  '@webassemblyjs/helper-numbers@1.13.2':
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.13.2
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/helper-wasm-bytecode@1.13.2': {}
+
+  '@webassemblyjs/helper-wasm-section@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/wasm-gen': 1.14.1
+
+  '@webassemblyjs/ieee754@1.13.2':
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  '@webassemblyjs/leb128@1.13.2':
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  '@webassemblyjs/utf8@1.13.2': {}
+
+  '@webassemblyjs/wasm-edit@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/helper-wasm-section': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-opt': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      '@webassemblyjs/wast-printer': 1.14.1
+
+  '@webassemblyjs/wasm-gen@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wasm-opt@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-buffer': 1.14.1
+      '@webassemblyjs/wasm-gen': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+
+  '@webassemblyjs/wasm-parser@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/helper-api-error': 1.13.2
+      '@webassemblyjs/helper-wasm-bytecode': 1.13.2
+      '@webassemblyjs/ieee754': 1.13.2
+      '@webassemblyjs/leb128': 1.13.2
+      '@webassemblyjs/utf8': 1.13.2
+
+  '@webassemblyjs/wast-printer@1.14.1':
+    dependencies:
+      '@webassemblyjs/ast': 1.14.1
+      '@xtuc/long': 4.2.2
+
   '@xstate/react@6.1.0(@types/react@19.2.17)(react@19.2.8)(xstate@5.32.5)':
     dependencies:
       react: 19.2.8
@@ -5070,11 +6206,17 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@xtuc/ieee754@1.2.0': {}
+
+  '@xtuc/long@4.2.2': {}
+
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
 
   acorn@8.14.0: {}
+
+  acorn@8.17.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -5082,12 +6224,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  ajv-formats@2.1.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-keywords@5.1.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+      fast-deep-equal: 3.1.3
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -5192,6 +6350,8 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  astring@1.9.0: {}
+
   async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
@@ -5246,6 +6406,14 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.2(browserslist@4.24.4)
 
+  browserslist@4.28.7:
+    dependencies:
+      baseline-browser-mapping: 2.11.1
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.395
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
+
   buffer-from@1.1.2: {}
 
   cac@6.7.14: {}
@@ -5287,6 +6455,8 @@ snapshots:
 
   caniuse-lite@1.0.30001735: {}
 
+  caniuse-lite@1.0.30001806: {}
+
   chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
@@ -5316,6 +6486,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  chrome-trace-event@1.0.4: {}
+
+  cjs-module-lexer@2.2.0: {}
+
   client-only@0.0.1: {}
 
   color-convert@2.0.1:
@@ -5328,7 +6502,11 @@ snapshots:
     dependencies:
       delayed-stream: 1.0.0
 
+  commander@2.20.3: {}
+
   commander@4.1.1: {}
+
+  commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
 
@@ -5417,6 +6595,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dotenv@16.6.1: {}
+
+  dotenv@17.4.2: {}
+
   drizzle-kit@0.31.10:
     dependencies:
       '@drizzle-team/brocli': 0.10.2
@@ -5424,10 +6606,11 @@ snapshots:
       esbuild: 0.25.9
       tsx: 4.23.1
 
-  drizzle-orm@0.45.2(@libsql/client@0.9.0)(@neondatabase/serverless@1.1.0)(@types/pg@8.15.5):
+  drizzle-orm@0.45.2(@libsql/client@0.9.0)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.1)(@types/pg@8.15.5):
     optionalDependencies:
       '@libsql/client': 0.9.0
       '@neondatabase/serverless': 1.1.0
+      '@opentelemetry/api': 1.9.1
       '@types/pg': 8.15.5
 
   dunder-proto@1.0.1:
@@ -5440,6 +6623,8 @@ snapshots:
 
   electron-to-chromium@1.5.103: {}
 
+  electron-to-chromium@1.5.395: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -5448,6 +6633,11 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  enhanced-resolve@5.24.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
 
   es-abstract@1.23.9:
     dependencies:
@@ -5584,6 +6774,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -5860,6 +7052,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
   eslint-scope@7.2.2:
     dependencies:
       esrecurse: 4.3.0
@@ -5924,11 +7121,19 @@ snapshots:
     dependencies:
       estraverse: 5.3.0
 
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
 
+  estraverse@4.3.0: {}
+
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -5937,6 +7142,8 @@ snapshots:
   esutils@2.0.3: {}
 
   event-target-shim@6.0.2: {}
+
+  events@3.3.0: {}
 
   execa@5.1.1:
     dependencies:
@@ -5977,6 +7184,8 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-sha256@1.3.0: {}
+
+  fast-uri@3.1.4: {}
 
   fastq@1.19.0:
     dependencies:
@@ -6122,6 +7331,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -6199,6 +7414,12 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-in-the-middle@3.3.2:
+    dependencies:
+      cjs-module-lexer: 2.2.0
+      es-module-lexer: 2.3.1
+      module-details-from-path: 1.0.4
 
   imurmurhash@0.1.4: {}
 
@@ -6295,6 +7516,10 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.6
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.3
@@ -6361,6 +7586,12 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jest-worker@27.5.1:
+    dependencies:
+      '@types/node': 20.17.19
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   jiti@1.21.7: {}
 
   jose@5.10.0: {}
@@ -6385,6 +7616,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -6449,6 +7682,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -6457,11 +7692,17 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   math-intrinsics@1.1.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  meriyah@6.1.4: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -6469,6 +7710,8 @@ snapshots:
       picomatch: 2.3.1
 
   mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
 
   mime-types@2.1.35:
     dependencies:
@@ -6490,7 +7733,21 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minimizer-webpack-plugin@5.6.1(postcss@8.5.22)(webpack@5.109.0(postcss@8.5.22)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.49.0
+      webpack: 5.109.0(postcss@8.5.22)
+    optionalDependencies:
+      postcss: 8.5.22
+
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -6506,12 +7763,14 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  neo-async@2.6.2: {}
+
   next-themes@0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next@16.2.11(@babel/core@7.26.9)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.2.11(@babel/core@7.26.9)(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
@@ -6530,6 +7789,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
+      '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -6538,6 +7798,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -6545,6 +7809,8 @@ snapshots:
       formdata-polyfill: 4.0.10
 
   node-releases@2.0.19: {}
+
+  node-releases@2.0.51: {}
 
   normalize-path@3.0.0: {}
 
@@ -6650,6 +7916,11 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -6757,6 +8028,8 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  progress@2.0.3: {}
+
   promise-limit@2.7.0: {}
 
   prop-types@15.8.1:
@@ -6764,6 +8037,8 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
 
@@ -6807,6 +8082,15 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-from@4.0.0: {}
 
@@ -6855,6 +8139,37 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.34.8
       fsevents: 2.3.3
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -6881,6 +8196,15 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   scheduler@0.27.0: {}
+
+  schema-utils@4.3.3:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  semifies@1.0.0: {}
 
   semver@6.3.1: {}
 
@@ -7006,6 +8330,10 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
@@ -7123,6 +8451,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
@@ -7158,6 +8490,15 @@ snapshots:
 
   tapable@2.2.1: {}
 
+  tapable@2.3.3: {}
+
+  terser@5.49.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.17.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -7192,6 +8533,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tr46@0.0.3: {}
+
   ts-algebra@2.0.0: {}
 
   ts-api-utils@2.0.1(@typescript/typescript6@6.0.2):
@@ -7224,6 +8567,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-fest@0.20.2: {}
+
+  type-fest@0.7.1: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -7309,6 +8654,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
+    dependencies:
+      browserslist: 4.28.7
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -7325,13 +8676,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@3.2.4(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0):
+  vite-node@3.2.4(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.1.1(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0)
+      vite: 6.1.1(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7346,7 +8697,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.1.1(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0):
+  vite@6.1.1(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.22
@@ -7355,14 +8706,15 @@ snapshots:
       '@types/node': 20.17.19
       fsevents: 2.3.3
       jiti: 1.21.7
+      terser: 5.49.0
       tsx: 4.23.1
       yaml: 2.7.0
 
-  vitest@3.2.7(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0):
+  vitest@3.2.7(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@6.1.1(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.7(vite@6.1.1(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7
@@ -7380,8 +8732,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.1.1(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0)
-      vite-node: 3.2.4(@types/node@20.17.19)(jiti@1.21.7)(tsx@4.23.1)(yaml@2.7.0)
+      vite: 6.1.1(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0)
+      vite-node: 3.2.4(@types/node@20.17.19)(jiti@1.21.7)(terser@5.49.0)(tsx@4.23.1)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.17.19
@@ -7399,7 +8751,56 @@ snapshots:
       - tsx
       - yaml
 
+  watchpack@2.5.2:
+    dependencies:
+      graceful-fs: 4.2.11
+
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
+
+  webpack-sources@3.5.1: {}
+
+  webpack@5.109.0(postcss@8.5.22):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      browserslist: 4.28.7
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.3
+      es-module-lexer: 2.3.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(postcss@8.5.22)(webpack@5.109.0(postcss@8.5.22))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/scripts/vercel-migrate.mjs
+++ b/scripts/vercel-migrate.mjs
@@ -125,11 +125,48 @@ async function main() {
   console.log('[vercel-migrate] migrations up to date.')
 }
 
+/**
+ * Best-effort Sentry report for a failed deploy migration. A broken migration
+ * fails the build loudly in the Vercel log, but nobody watches those — and the
+ * migration is the one step that can leave prod on a schema the code does not
+ * expect. Fully guarded: no DSN (local, CI, a fork) ⇒ nothing happens, and a
+ * reporting failure can never mask the migration failure itself.
+ *
+ * @param {unknown} err
+ * @returns {Promise<void>}
+ */
+async function reportMigrationFailure(err) {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN
+  if (!dsn) return
+  try {
+    const Sentry = await import('@sentry/nextjs')
+    Sentry.init({
+      dsn,
+      enabled: true,
+      tracesSampleRate: 0,
+      sendDefaultPii: false,
+    })
+    Sentry.captureException(err, {
+      tags: { route: 'scripts/vercel-migrate', 'mp.phase': 'migration' },
+      contexts: {
+        migration: {
+          vercelEnv: process.env.VERCEL_ENV ?? null,
+          commit: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+        },
+      },
+    })
+    await Sentry.flush(2000)
+  } catch {
+    // reporting must never mask the real failure below
+  }
+}
+
 // Only run the side-effecting migrate when invoked as the build entrypoint,
 // so the test can import `decideMigration` without hitting the network.
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch((err) => {
+  main().catch(async (err) => {
     console.error('[vercel-migrate] migration failed:', err)
+    await reportMigrationFailure(err)
     process.exit(1)
   })
 }

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,0 +1,9 @@
+// Sentry init for the Vercel Edge runtime (middleware / edge routes). brass
+// has no edge routes today, but the Next.js SDK still needs this file wired so
+// anything that later runs on the edge reports through the same scrubber.
+import * as Sentry from '@sentry/nextjs'
+import { sharedSentryOptions } from '~/lib/sentry-options'
+
+Sentry.init({
+  ...sharedSentryOptions,
+})

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,0 +1,12 @@
+// Sentry init for the Node.js server runtime (API routes, server components,
+// the AI turn runner). Loaded by `instrumentation.ts`'s `register()`.
+//
+// With no NEXT_PUBLIC_SENTRY_DSN this initialises disabled — the app runs
+// exactly as before, just without reporting. Errors only: no profiling
+// (`profilesSampleRate` unset) and no replay. See src/lib/sentry-options.ts.
+import * as Sentry from '@sentry/nextjs'
+import { sharedSentryOptions } from '~/lib/sentry-options'
+
+Sentry.init({
+  ...sharedSentryOptions,
+})

--- a/src/app/api/mp/act/route.ts
+++ b/src/app/api/mp/act/route.ts
@@ -1,6 +1,8 @@
 import { waitUntil } from '@vercel/functions'
 import { NextResponse } from 'next/server'
+import { captureMpError } from '~/server/observability'
 import { actInGame, kickAiTurns } from '~/server/mp/game'
+import { isExpectedMpError } from '~/server/mp/expected-errors'
 
 export const runtime = 'nodejs'
 // A move may kick a multi-step AI turn (model calls); keep the instance alive
@@ -9,6 +11,11 @@ export const runtime = 'nodejs'
 export const maxDuration = 300
 
 export async function POST(req: Request) {
+  // Populated as soon as the body parses, so a throw further down still
+  // reports WHICH game / seat / event blew up (see observability.ts).
+  let token: string | undefined
+  let seatId: number | undefined
+  let eventType: string | undefined
   try {
     const body = (await req.json()) as {
       token?: string
@@ -22,10 +29,12 @@ export async function POST(req: Request) {
         { status: 400 },
       )
     }
-    const token = String(body.token ?? '')
+    token = String(body.token ?? '')
+    seatId = Number(body.seatId ?? -1)
+    eventType = body.event.type
     const result = await actInGame(
       token,
-      Number(body.seatId ?? -1),
+      seatId,
       String(body.seatSecret ?? ''),
       body.event,
     )
@@ -37,6 +46,17 @@ export async function POST(req: Request) {
     // client applies its authoritative result immediately (see actInGame).
     return NextResponse.json(result, { status: result.ok ? 200 : 400 })
   } catch (e) {
+    // A move that throws is a genuine server fault (rule refusals come back as
+    // an `{ok:false}` result, never an exception) — report it with the game,
+    // seat and machine event so it is diagnosable, never just "400 somewhere".
+    if (!isExpectedMpError(e)) {
+      captureMpError(e, {
+        route: 'api/mp/act',
+        token,
+        seatId,
+        eventType,
+      })
+    }
     return NextResponse.json(
       { ok: false, error: e instanceof Error ? e.message : 'Action failed' },
       { status: 400 },

--- a/src/app/api/mp/create/route.ts
+++ b/src/app/api/mp/create/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server'
 import { aiOpponentsEnabled } from '~/lib/features'
 import { isAiTierId } from '~/server/ai/types'
+import { captureMpError } from '~/server/observability'
 import { createGame } from '~/server/mp/game'
+import { isExpectedMpError } from '~/server/mp/expected-errors'
 import { allowCreate, clientIpFrom } from '~/server/mp/rate-limit'
 
 export const runtime = 'nodejs'
@@ -47,6 +49,11 @@ export async function POST(req: Request) {
     )
     return NextResponse.json(result)
   } catch (e) {
+    // Create touches the DB (and the TTL sweep) before any game exists, so
+    // there is no token yet — the route tag is the whole diagnosis here.
+    if (!isExpectedMpError(e)) {
+      captureMpError(e, { route: 'api/mp/create', phase: 'lobby' })
+    }
     return NextResponse.json(
       { error: e instanceof Error ? e.message : 'Could not create the game' },
       { status: 400 },

--- a/src/app/api/mp/join/route.ts
+++ b/src/app/api/mp/join/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
+import { captureMpError } from '~/server/observability'
 import { joinGame } from '~/server/mp/game'
+import { isExpectedMpError } from '~/server/mp/expected-errors'
 import {
   allowJoin,
   clientIpFrom,
@@ -24,14 +26,18 @@ export async function POST(req: Request) {
       },
     )
   }
+  let token: string | undefined
   try {
     const body = (await req.json()) as { token?: string; name?: string }
-    const result = await joinGame(
-      String(body.token ?? ''),
-      String(body.name ?? ''),
-    )
+    token = String(body.token ?? '')
+    const result = await joinGame(token, String(body.name ?? ''))
     return NextResponse.json(result)
   } catch (e) {
+    // 'No open seats' / 'Game not found' are the product working; anything
+    // else is a fault worth an event.
+    if (!isExpectedMpError(e)) {
+      captureMpError(e, { route: 'api/mp/join', token })
+    }
     return NextResponse.json(
       { error: e instanceof Error ? e.message : 'Could not join the game' },
       { status: 400 },

--- a/src/app/api/mp/start/route.ts
+++ b/src/app/api/mp/start/route.ts
@@ -1,20 +1,26 @@
 import { NextResponse } from 'next/server'
+import { captureMpError } from '~/server/observability'
 import { startGame } from '~/server/mp/game'
+import { isExpectedMpError } from '~/server/mp/expected-errors'
 
 export const runtime = 'nodejs'
 
 export async function POST(req: Request) {
+  let token: string | undefined
   try {
     const body = (await req.json()) as { token?: string; seatSecret?: string }
-    const result = await startGame(
-      String(body.token ?? ''),
-      String(body.seatSecret ?? ''),
-    )
+    token = String(body.token ?? '')
+    const result = await startGame(token, String(body.seatSecret ?? ''))
     if (!result.ok) {
       return NextResponse.json({ error: result.error }, { status: 400 })
     }
     return NextResponse.json(result)
   } catch (e) {
+    // Engine setup runs here (deal, shuffle, first snapshot) — a throw is a
+    // real bug, not a lobby refusal, so it must reach Sentry with the token.
+    if (!isExpectedMpError(e)) {
+      captureMpError(e, { route: 'api/mp/start', token, phase: 'lobby' })
+    }
     return NextResponse.json(
       { error: e instanceof Error ? e.message : 'Could not start the game' },
       { status: 400 },

--- a/src/app/api/mp/stream/route.ts
+++ b/src/app/api/mp/stream/route.ts
@@ -31,6 +31,7 @@ import {
 } from '~/server/mp/game'
 import { acquireStreamSlot, clientIpFrom } from '~/server/mp/rate-limit'
 import { loadGame, loadVersionAndSeq } from '~/server/mp/store'
+import { captureMpError } from '~/server/observability'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -55,7 +56,13 @@ export async function GET(req: NextRequest) {
   const seatId = seatParam === null ? null : Number(seatParam)
   const secret = params.get('secret')
 
-  const game = await loadGame(token).catch(() => null)
+  const game = await loadGame(token).catch((err: unknown) => {
+    // Distinguishable from "no such token": a DB fault here 404s every viewer
+    // of a live game, which is precisely the silent prod break we had no way
+    // of seeing. The client still gets the same 404.
+    captureMpError(err, { route: 'api/mp/stream', token })
+    return null
+  })
   if (!game) return new Response('Game not found', { status: 404 })
 
   // Abuse bound: each stream holds a serverless slot for up to 290s and polls
@@ -97,6 +104,21 @@ export async function GET(req: NextRequest) {
       let lastVersion = -1
       let lastSeq = 0
       let pollTimer: ReturnType<typeof setTimeout> | undefined
+      // The loop ticks every ~1.2s for up to 290s: a sustained DB outage would
+      // otherwise mint ~240 identical events per stream per IP. Report the
+      // FIRST failure of each stream and stay quiet after that.
+      let reportedFailure = false
+      const reportOnce = (err: unknown, where: string) => {
+        if (reportedFailure) return
+        reportedFailure = true
+        captureMpError(err, {
+          route: `api/mp/stream:${where}`,
+          token,
+          seatId,
+          phase: game.phase,
+          extra: { lastVersion, lastSeq },
+        })
+      }
 
       const write = (chunk: string) => {
         if (!open) return
@@ -160,8 +182,11 @@ export async function GET(req: NextRequest) {
               }
             }
           })
-          .catch(() => {
-            // a transient load/filter error must not break the pipe
+          .catch((err: unknown) => {
+            // a transient load/filter error must not break the pipe, but a
+            // persistent one means this viewer has silently stopped receiving
+            // state — report the first occurrence per stream.
+            reportOnce(err, 'sync')
           })
         return syncing
       }
@@ -180,8 +205,9 @@ export async function GET(req: NextRequest) {
         try {
           void kickAiTurns(token)
           await syncNow()
-        } catch {
+        } catch (err) {
           // a transient DB blip must not kill the stream; next tick retries
+          reportOnce(err, 'poll')
         }
         if (open) pollTimer = setTimeout(() => void poll(), POLL_INTERVAL_MS)
       }

--- a/src/env.js
+++ b/src/env.js
@@ -16,6 +16,11 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(['development', 'test', 'production'])
       .default('development'),
+    // Sentry source-map upload — BUILD TIME ONLY (next.config.js). Optional
+    // everywhere: without them the build simply skips the upload.
+    SENTRY_AUTH_TOKEN: z.string().optional(),
+    SENTRY_ORG: z.string().optional(),
+    SENTRY_PROJECT: z.string().optional(),
   },
 
   /**
@@ -24,6 +29,10 @@ export const env = createEnv({
    * `NEXT_PUBLIC_`.
    */
   client: {
+    // Sentry ingest endpoint. Optional by design: no DSN ⇒ the SDK is a no-op
+    // and the app behaves exactly as it did before (see src/lib/sentry-*.ts).
+    NEXT_PUBLIC_SENTRY_DSN: z.string().url().optional(),
+    NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE: z.string().optional(),
     // NEXT_PUBLIC_CLIENTVAR: z.string(),
   },
 
@@ -35,6 +44,12 @@ export const env = createEnv({
     DATABASE_URL: process.env.DATABASE_URL,
     DATABASE_URL_UNPOOLED: process.env.DATABASE_URL_UNPOOLED,
     NODE_ENV: process.env.NODE_ENV,
+    SENTRY_AUTH_TOKEN: process.env.SENTRY_AUTH_TOKEN,
+    SENTRY_ORG: process.env.SENTRY_ORG,
+    SENTRY_PROJECT: process.env.SENTRY_PROJECT,
+    NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
+    NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE:
+      process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
   /**

--- a/src/lib/sentry-options.test.ts
+++ b/src/lib/sentry-options.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { FILTERED } from './sentry-scrub'
+import { sharedSentryOptions, tracesSampleRate } from './sentry-options'
+
+describe('tracesSampleRate', () => {
+  it('defaults to 1% and rejects junk / out-of-range values', () => {
+    expect(tracesSampleRate(undefined)).toBe(0.01)
+    expect(tracesSampleRate('')).toBe(0.01)
+    expect(tracesSampleRate('not-a-number')).toBe(0.01)
+    expect(tracesSampleRate('-1')).toBe(0.01)
+    expect(tracesSampleRate('2')).toBe(0.01)
+  })
+
+  it('honours a valid override', () => {
+    expect(tracesSampleRate('0')).toBe(0)
+    expect(tracesSampleRate('0.25')).toBe(0.25)
+    expect(tracesSampleRate('1')).toBe(1)
+  })
+})
+
+describe('sharedSentryOptions', () => {
+  it('degrades gracefully with no DSN configured', () => {
+    // the test env sets no NEXT_PUBLIC_SENTRY_DSN — this is the local/CI/
+    // preview default, and it must be a no-op rather than a crash.
+    expect(sharedSentryOptions.dsn).toBeUndefined()
+    expect(sharedSentryOptions.enabled).toBe(false)
+  })
+
+  it('is free-tier friendly: low traces, no PII, no replay/profiling', () => {
+    expect(sharedSentryOptions.tracesSampleRate).toBeLessThanOrEqual(0.05)
+    expect(sharedSentryOptions.sendDefaultPii).toBe(false)
+    expect(sharedSentryOptions).not.toHaveProperty('replaysSessionSampleRate')
+    expect(sharedSentryOptions).not.toHaveProperty('replaysOnErrorSampleRate')
+    expect(sharedSentryOptions).not.toHaveProperty('profilesSampleRate')
+  })
+
+  it('runs every event through the scrubber before send', () => {
+    const secret = 'aabbccddeeff00112233445566778899'
+    const out = sharedSentryOptions.beforeSend({
+      request: { url: `/api/mp/stream?token=abc&secret=${secret}` },
+      extra: { seatSecret: secret },
+    })
+    expect(JSON.stringify(out)).not.toContain(secret)
+    expect(out.request?.url).toContain(`secret=${FILTERED}`)
+    expect(out.request?.url).toContain('token=abc')
+  })
+
+  it('scrubs breadcrumbs too (a fetch crumb carries the stream URL)', () => {
+    const secret = 'ffeeddccbbaa99887766554433221100'
+    const crumb = sharedSentryOptions.beforeBreadcrumb({
+      message: `GET /api/mp/stream?secret=${secret}`,
+      data: { url: `/api/mp/stream?secret=${secret}` },
+    })
+    expect(JSON.stringify(crumb)).not.toContain(secret)
+  })
+})

--- a/src/lib/sentry-options.ts
+++ b/src/lib/sentry-options.ts
@@ -1,0 +1,52 @@
+// One place for the Sentry init options shared by the client, server and edge
+// runtimes. Keeping it here (rather than copy-pasting three near-identical
+// `Sentry.init` blocks) means the scrubbing and the sampling can never drift
+// between runtimes — a leak on ONE surface is a leak.
+//
+// FREE-TIER POSTURE, deliberate:
+//   • errors only — no Session Replay (PII + quota), no profiling.
+//   • `tracesSampleRate` is tiny and env-overridable; the SSE stream alone
+//     would otherwise mint a transaction every ~1.2s per open tab.
+//   • no DSN ⇒ the SDK initialises into a no-op. Local dev, CI and previews
+//     build and run identically, just without reporting. Nothing in the app
+//     may depend on Sentry being live.
+import { scrubEvent } from './sentry-scrub'
+
+/** The DSN is public by design (it only permits ingest), hence NEXT_PUBLIC_. */
+export const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN
+
+/** True when a DSN is configured; false ⇒ every capture is a silent no-op. */
+export const sentryEnabled = !!SENTRY_DSN
+
+/** Fraction of transactions sampled. Default 1%; override per-environment. */
+export function tracesSampleRate(
+  raw: string | undefined = process.env.NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE,
+): number {
+  if (raw === undefined || raw.trim() === '') return 0.01
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > 1) return 0.01
+  return parsed
+}
+
+/**
+ * Options every runtime passes to `Sentry.init`. `beforeSend`/
+ * `beforeSendTransaction` are the last gate before an event leaves the
+ * process — see sentry-scrub.ts for what they strip and why.
+ */
+export const sharedSentryOptions = {
+  dsn: SENTRY_DSN,
+  enabled: sentryEnabled,
+  tracesSampleRate: tracesSampleRate(),
+  // Errors only: no replay, no profiling, no PII.
+  sendDefaultPii: false,
+  // Keep local/CI consoles quiet; Vercel logs already carry our own lines.
+  debug: false,
+  // Typed as identity-preserving generics so ONE implementation satisfies the
+  // SDK's three different callback signatures (ErrorEvent / TransactionEvent /
+  // Breadcrumb) without this module importing any Sentry type.
+  beforeSend: <T>(event: T): T => scrubEvent(event),
+  beforeSendTransaction: <T>(event: T): T => scrubEvent(event),
+  // A fetch/xhr breadcrumb carries the full URL — the SSE stream URL holds
+  // `?secret=…`, so a crumb must go through the same scrubber as an event.
+  beforeBreadcrumb: <T>(crumb: T): T => scrubEvent(crumb),
+}

--- a/src/lib/sentry-scrub.test.ts
+++ b/src/lib/sentry-scrub.test.ts
@@ -1,0 +1,183 @@
+// THE SECURITY PIN for Sentry. There is no Sentry project to send a probe
+// event to (the DSN is set by the owner in Vercel), so the proof that seat
+// secrets / host secrets / CRON_SECRET / auth tokens never leave this app is
+// asserted at the `beforeSend` layer — the last gate every event passes
+// through, shared by the client, server and edge runtimes.
+//
+// If a check here fails, a credential is on its way to a third party.
+import { describe, expect, it } from 'vitest'
+import {
+  FILTERED,
+  isSecretKey,
+  scrubEvent,
+  scrubQueryString,
+  scrubText,
+  scrubUrl,
+  scrubValue,
+} from './sentry-scrub'
+
+/** Realistic values, so a substring leak is detectable in the payload. */
+const SEAT_SECRET = 'b3f1c9a27de54810aa9f0c6b1e2d3f47'
+const HOST_SECRET = '9911aabbccdd00112233445566778899'
+const CRON = 'cron-super-secret-value-1234567890'
+const GAME_TOKEN = '0f8a1c2b3d4e5f60718293a4b5c6d7e8'
+
+/** Assert a credential appears NOWHERE in the serialized event. */
+function expectNoSecrets(payload: unknown) {
+  const json = JSON.stringify(payload)
+  expect(json).not.toContain(SEAT_SECRET)
+  expect(json).not.toContain(HOST_SECRET)
+  expect(json).not.toContain(CRON)
+}
+
+describe('isSecretKey', () => {
+  it('flags every credential-bearing key name we ship', () => {
+    for (const k of [
+      'secret',
+      'seatSecret',
+      'hostSecret',
+      'secretHash',
+      'CRON_SECRET',
+      'Authorization',
+      'authToken',
+      'SENTRY_AUTH_TOKEN',
+      'apiKey',
+      'api_key',
+      'password',
+      'cookie',
+    ]) {
+      expect(isSecretKey(k), k).toBe(true)
+    }
+  })
+
+  it('does NOT flag the game token — it is the identifier, not a credential', () => {
+    for (const k of ['token', 'gameToken', 'seatId', 'phase', 'route']) {
+      expect(isSecretKey(k), k).toBe(false)
+    }
+  })
+})
+
+describe('scrubUrl / scrubQueryString', () => {
+  // The SSE stream is `GET /api/mp/stream?token=…&seat=1&secret=…`, so a URL
+  // is a credential carrier here, not just metadata.
+  it('strips the stream URL secret but keeps token, seat and path', () => {
+    const url = `https://brass.example/api/mp/stream?token=${GAME_TOKEN}&seat=2&secret=${SEAT_SECRET}`
+    const out = scrubUrl(url)
+    expect(out).not.toContain(SEAT_SECRET)
+    expect(out).toContain(`secret=${FILTERED}`)
+    expect(out).toContain(`token=${GAME_TOKEN}`)
+    expect(out).toContain('seat=2')
+    expect(out).toContain('/api/mp/stream')
+  })
+
+  it('scrubs seatSecret and apiKey params, case-insensitively', () => {
+    const out = scrubQueryString(
+      `seatSecret=${SEAT_SECRET}&APIKEY=${CRON}&page=3`,
+    )
+    expectNoSecrets(out)
+    expect(out).toContain('page=3')
+  })
+
+  it('leaves a URL with no query string alone', () => {
+    expect(scrubUrl('https://brass.example/g/abc')).toBe(
+      'https://brass.example/g/abc',
+    )
+  })
+})
+
+describe('scrubText', () => {
+  it('redacts inline key=value credentials in free text', () => {
+    const out = scrubText(
+      `refused: seatSecret=${SEAT_SECRET} for token=${GAME_TOKEN}`,
+    )
+    expectNoSecrets(out)
+    expect(out).toContain(GAME_TOKEN)
+  })
+
+  it('redacts a Bearer credential', () => {
+    const out = scrubText(`Authorization header was Bearer ${CRON}`)
+    expectNoSecrets(out)
+  })
+
+  it('is idempotent — scrubbing twice does not corrupt the placeholder', () => {
+    const once = scrubText(`secret=${SEAT_SECRET}`)
+    expect(scrubText(once)).toBe(once)
+  })
+})
+
+describe('scrubValue', () => {
+  it('redacts by key at any depth and survives cycles', () => {
+    const node: Record<string, unknown> = {
+      game: {
+        token: GAME_TOKEN,
+        seats: [{ seatId: 0, secretHash: HOST_SECRET }],
+      },
+      env: { CRON_SECRET: CRON },
+    }
+    node.self = node // a Sentry `extra` really can be cyclic
+    const out = scrubValue(node) as Record<string, unknown>
+    // The cycle survives as a cycle (so it cannot be JSON.stringify'd) — walk
+    // it by hand and prove the scrubbed clone, not the raw original, is what
+    // the self-reference points at.
+    const env = out.env as Record<string, unknown>
+    expect(env.CRON_SECRET).toBe(FILTERED)
+    const game = out.game as Record<string, unknown>
+    expect(game.token).toBe(GAME_TOKEN)
+    const seats = game.seats as Record<string, unknown>[]
+    expect(seats[0]?.secretHash).toBe(FILTERED)
+    expect(out.self).toBe(out)
+  })
+})
+
+describe('scrubEvent (the beforeSend body)', () => {
+  it('drops headers, cookies and bodies wholesale', () => {
+    const event = scrubEvent({
+      request: {
+        url: 'https://brass.example/api/mp/act',
+        headers: {
+          authorization: `Bearer ${CRON}`,
+          cookie: `s=${SEAT_SECRET}`,
+        },
+        cookies: { s: SEAT_SECRET },
+        data: { token: GAME_TOKEN, seatSecret: SEAT_SECRET },
+      },
+    })
+    expect(event.request?.headers).toBeUndefined()
+    expect(event.request?.cookies).toBeUndefined()
+    expect(event.request?.data).toBeUndefined()
+    expectNoSecrets(event)
+  })
+
+  it('scrubs the URL, query string, message, exception, tags, extra, contexts and breadcrumbs', () => {
+    const event = scrubEvent({
+      message: `stream failed for secret=${SEAT_SECRET}`,
+      request: {
+        url: `https://brass.example/api/mp/stream?token=${GAME_TOKEN}&secret=${SEAT_SECRET}`,
+        query_string: `token=${GAME_TOKEN}&secret=${SEAT_SECRET}`,
+      },
+      exception: {
+        values: [{ value: `save failed (hostSecret=${HOST_SECRET})` }],
+      },
+      tags: { 'mp.token': GAME_TOKEN, seatSecret: SEAT_SECRET },
+      extra: { seats: [{ seatId: 1, secret: SEAT_SECRET }] },
+      contexts: { multiplayer: { token: GAME_TOKEN, secretHash: HOST_SECRET } },
+      user: { id: 'seat-1', secret: SEAT_SECRET },
+      breadcrumbs: [
+        {
+          message: `GET /api/mp/stream?secret=${SEAT_SECRET}`,
+          data: { url: `/api/mp/stream?secret=${SEAT_SECRET}` },
+        },
+      ],
+    })
+    expectNoSecrets(event)
+    // …while keeping everything that makes the event diagnosable.
+    const json = JSON.stringify(event)
+    expect(json).toContain(GAME_TOKEN)
+    expect(json).toContain('/api/mp/stream')
+    expect((event.tags as Record<string, unknown>)['mp.token']).toBe(GAME_TOKEN)
+  })
+
+  it('handles an event with nothing to scrub', () => {
+    expect(scrubEvent({})).toEqual({})
+  })
+})

--- a/src/lib/sentry-scrub.ts
+++ b/src/lib/sentry-scrub.ts
@@ -1,0 +1,224 @@
+// Secret scrubbing for every Sentry event leaving this app.
+//
+// WHY THIS EXISTS. brass has no accounts: a player IS their credential. The
+// per-seat `seatSecret` (and the host's, which is just seat 0's) is a bearer
+// token that lets anyone holding it play that seat, and `CRON_SECRET` lets
+// anyone holding it drive the sweep endpoint. Those must NEVER reach a
+// third-party service, not in a body, a URL, a header, a tag, an `extra`, or
+// an exception message.
+//
+// The GAME TOKEN is deliberately NOT scrubbed — it identifies which game broke
+// and is the whole point of the context we attach. It is not a credential on
+// its own (acting still needs a seat secret).
+//
+// Everything here is pure so it can be unit-tested without a DSN or a network
+// (see sentry-scrub.test.ts) — that test IS the proof that the secrets do not
+// escape, since there is no Sentry project to send a probe event to yet.
+
+/** Placeholder written over any redacted value. */
+export const FILTERED = '[Filtered]'
+
+/**
+ * Key names whose VALUE is a credential. Matched case-insensitively as a
+ * SUBSTRING of the key, so `seatSecret`, `secretHash`, `hostSecret`,
+ * `SENTRY_AUTH_TOKEN` and `authorization` are all covered by a short list.
+ *
+ * NOTE the deliberate omission of a bare `token` — `token` is the game token
+ * (public, and the identifier we want). `authToken`/`auth_token` are caught by
+ * the `auth` entry.
+ */
+const SECRET_KEY_PARTS = [
+  'secret',
+  'authorization',
+  'auth',
+  'password',
+  'passwd',
+  'apikey',
+  'api_key',
+  'cookie',
+  'credential',
+  'session',
+]
+
+/** Query parameters whose value is a credential (the SSE stream takes
+ *  `?token=…&seat=…&secret=…`, so URLs leak too if left alone). */
+const SECRET_QUERY_PARAMS = [
+  'secret',
+  'seatsecret',
+  'hostsecret',
+  'authorization',
+  'auth',
+  'apikey',
+  'api_key',
+  'key',
+]
+
+/** `secret=abc`, `seatSecret: "abc"`, `Bearer abc` embedded in free text
+ *  (exception messages, log breadcrumbs, stringified request lines). Each
+ *  entry replaces its LAST capture group with the placeholder, keeping the
+ *  key name visible so the event still reads sensibly. */
+const SECRET_TEXT_PATTERNS: [RegExp, string][] = [
+  [
+    /((?:seat|host)?secret|authorization|api[-_]?key|password)(["']?\s*[=:]\s*["']?)([^\s"'&,}]+)/gi,
+    `$1$2${FILTERED}`,
+  ],
+  [/(bearer\s+)([A-Za-z0-9._~+/=-]{8,})/gi, `$1${FILTERED}`],
+]
+
+export function isSecretKey(key: string): boolean {
+  const k = key.toLowerCase()
+  return SECRET_KEY_PARTS.some((part) => k.includes(part))
+}
+
+/** Redact `secret=…`-style fragments inside an arbitrary string. */
+export function scrubText(value: string): string {
+  let out = value
+  for (const [re, replacement] of SECRET_TEXT_PATTERNS) {
+    out = out.replace(re, replacement)
+  }
+  return out
+}
+
+/**
+ * Strip credential-bearing query params from a URL, preserving everything
+ * else (path + the game token) so the event still says WHICH endpoint broke.
+ * Works on relative URLs and on strings that don't parse as URLs at all.
+ */
+export function scrubUrl(url: string): string {
+  const qIndex = url.indexOf('?')
+  if (qIndex === -1) return scrubText(url)
+  const base = url.slice(0, qIndex)
+  const query = scrubQueryString(url.slice(qIndex + 1))
+  return query ? `${base}?${query}` : base
+}
+
+/** Scrub a bare query string (`a=1&secret=x`), no leading `?`. */
+export function scrubQueryString(query: string): string {
+  return query
+    .split('&')
+    .map((pair) => {
+      const eq = pair.indexOf('=')
+      if (eq === -1) return pair
+      const name = pair.slice(0, eq)
+      return SECRET_QUERY_PARAMS.includes(name.toLowerCase())
+        ? `${name}=${FILTERED}`
+        : pair
+    })
+    .join('&')
+}
+
+/** Depth beyond which we stop walking and redact rather than risk recursing
+ *  through a pathological payload inside `beforeSend`. */
+const MAX_DEPTH = 8
+
+/**
+ * Deep-walk any JSON-ish value, redacting values under secret-looking keys and
+ * scrubbing secret fragments out of every remaining string.
+ *
+ * Returns a CLONE — the original is never mutated. Cycles are handled by
+ * registering each clone before descending, so a self-referencing `extra`
+ * (Sentry really does ship those) comes back cyclic and fully scrubbed rather
+ * than falling back to the raw, unscrubbed original.
+ */
+export function scrubValue(
+  value: unknown,
+  depth = 0,
+  seen = new Map<object, unknown>(),
+): unknown {
+  if (typeof value === 'string') return scrubText(value)
+  if (value === null || typeof value !== 'object') return value
+  const cached = seen.get(value)
+  if (cached !== undefined) return cached
+  // Past the depth bound we redact rather than return the raw value: a deep
+  // object could still be carrying a credential.
+  if (depth > MAX_DEPTH) return FILTERED
+  if (Array.isArray(value)) {
+    const out: unknown[] = []
+    seen.set(value, out)
+    for (const v of value) out.push(scrubValue(v, depth + 1, seen))
+    return out
+  }
+  const out: Record<string, unknown> = {}
+  seen.set(value, out)
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    out[k] = isSecretKey(k) ? FILTERED : scrubValue(v, depth + 1, seen)
+  }
+  return out
+}
+
+/** The subset of a Sentry event this scrubber touches. Typed structurally so
+ *  the pure module needs no `@sentry/*` import (and stays unit-testable). The
+ *  public `scrubEvent` is generic and casts to this internally, so it accepts
+ *  the SDK's own `ErrorEvent`/`TransactionEvent` without fighting their
+ *  (index-signature-free) types. */
+interface ScrubbableEvent {
+  message?: unknown
+  request?: {
+    url?: string
+    query_string?: unknown
+    headers?: unknown
+    cookies?: unknown
+    data?: unknown
+    [k: string]: unknown
+  }
+  exception?: { values?: { value?: string; [k: string]: unknown }[] }
+  tags?: Record<string, unknown>
+  extra?: Record<string, unknown>
+  contexts?: Record<string, unknown>
+  breadcrumbs?: {
+    message?: string
+    data?: unknown
+    [k: string]: unknown
+  }[]
+  user?: Record<string, unknown>
+  /** a Breadcrumb's payload — `beforeBreadcrumb` hands one straight to
+   *  `scrubEvent`, and a fetch crumb's `data.url` is the SSE stream URL. */
+  data?: unknown
+  [k: string]: unknown
+}
+
+/**
+ * `beforeSend` body, shared by the client, server and edge SDK configs.
+ *
+ * Two rules, both non-negotiable:
+ *  1. Request headers, cookies and bodies are DROPPED WHOLESALE — we never
+ *     want to reason about whether a particular one carried a secret.
+ *  2. Everything that survives (URL, message, exception values, tags, extra,
+ *     contexts, breadcrumbs) is deep-scrubbed by key name and by text pattern.
+ */
+export function scrubEvent<T>(input: T): T {
+  const event = input as ScrubbableEvent
+  if (event.request) {
+    const req = event.request
+    if (typeof req.url === 'string') req.url = scrubUrl(req.url)
+    if (typeof req.query_string === 'string') {
+      req.query_string = scrubQueryString(req.query_string)
+    } else if (req.query_string) {
+      req.query_string = scrubValue(req.query_string)
+    }
+    // Never ship raw headers/cookies/bodies — see rule 1 above.
+    req.headers = undefined
+    req.cookies = undefined
+    req.data = undefined
+  }
+  if (typeof event.message === 'string')
+    event.message = scrubText(event.message)
+  for (const value of event.exception?.values ?? []) {
+    if (typeof value.value === 'string') value.value = scrubText(value.value)
+  }
+  if (event.tags) event.tags = scrubValue(event.tags) as Record<string, unknown>
+  if (event.extra) {
+    event.extra = scrubValue(event.extra) as Record<string, unknown>
+  }
+  if (event.contexts) {
+    event.contexts = scrubValue(event.contexts) as Record<string, unknown>
+  }
+  if (event.user) event.user = scrubValue(event.user) as Record<string, unknown>
+  if (event.data) event.data = scrubValue(event.data)
+  for (const crumb of event.breadcrumbs ?? []) {
+    if (typeof crumb.message === 'string')
+      crumb.message = scrubText(crumb.message)
+    if (crumb.data) crumb.data = scrubValue(crumb.data)
+  }
+  return input
+}

--- a/src/lib/sentry-wire.test.ts
+++ b/src/lib/sentry-wire.test.ts
@@ -1,0 +1,91 @@
+// END-TO-END proof that the scrubbing is actually WIRED, not just written.
+//
+// The unit tests in sentry-scrub.test.ts prove the `beforeSend` body redacts
+// credentials. This one proves the SDK really runs it: a live Sentry client is
+// pointed at a throwaway localhost "ingest" server with the exact options the
+// app ships (`sharedSentryOptions`), a deliberate error is thrown and captured
+// with the same context `captureMpError` attaches, and the RAW BYTES that left
+// the process are asserted.
+//
+// There is no real Sentry project yet (the owner sets the DSN in Vercel), so
+// this localhost envelope IS the deliberate-test-error verification.
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { sharedSentryOptions } from './sentry-options'
+
+const SEAT_SECRET = 'deadbeefdeadbeefdeadbeefdeadbeef'
+const CRON = 'cron-secret-value-that-must-not-escape'
+const GAME_TOKEN = '11223344556677889900aabbccddeeff'
+
+let server: Server
+let received: string[] = []
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    let body = ''
+    req.on('data', (c) => {
+      body += String(c)
+    })
+    req.on('end', () => {
+      received.push(`${req.url ?? ''}\n${body}`)
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end('{"id":"test"}')
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+})
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+})
+
+describe('a captured error on the wire', () => {
+  it('carries the game context and NONE of the credentials', async () => {
+    received = []
+    const port = (server.address() as AddressInfo).port
+    const Sentry = await import('@sentry/nextjs')
+    const client = new Sentry.NodeClient({
+      ...sharedSentryOptions,
+      dsn: `http://publickey@127.0.0.1:${port}/1`,
+      enabled: true,
+      // a scope-less client we drive directly, so nothing here touches the
+      // app's own (disabled) global client
+      integrations: [],
+      stackParser: Sentry.defaultStackParser,
+      transport: Sentry.makeNodeTransport,
+    })
+
+    let thrown: unknown
+    try {
+      // the deliberate test error — shaped like a real store failure, with a
+      // credential baked into the message the way a careless throw would.
+      throw new Error(
+        `saveGame failed for token=${GAME_TOKEN} seatSecret=${SEAT_SECRET}`,
+      )
+    } catch (err) {
+      thrown = err
+    }
+
+    client.captureException(thrown, {
+      captureContext: {
+        tags: { route: 'mp/store.saveGame', 'mp.token': GAME_TOKEN },
+        extra: { seatSecret: SEAT_SECRET, CRON_SECRET: CRON },
+        contexts: {
+          multiplayer: { token: GAME_TOKEN, phase: 'playing', seatId: 2 },
+        },
+      },
+    })
+    await client.flush(4000)
+
+    const wire = received.join('\n')
+    expect(wire, 'the envelope reached the test ingest server').not.toBe('')
+    // (a) it captured, with the context that makes it diagnosable
+    expect(wire).toContain(GAME_TOKEN)
+    expect(wire).toContain('mp/store.saveGame')
+    expect(wire).toContain('playing')
+    // (b) it scrubbed — no credential is anywhere in the bytes we sent
+    expect(wire).not.toContain(SEAT_SECRET)
+    expect(wire).not.toContain(CRON)
+  })
+})

--- a/src/server/mp/expected-errors.test.ts
+++ b/src/server/mp/expected-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { EXPECTED_MP_ERRORS, isExpectedMpError } from './expected-errors'
+
+// NB: deliberately NOT importing `./game` for GAME_GONE_ERROR — game.ts pulls
+// in the DB client (which needs DATABASE_URL at import), and this suite is an
+// offline one. The literal is duplicated here on purpose.
+const GAME_GONE_ERROR = 'This game no longer exists.'
+
+describe('isExpectedMpError', () => {
+  it('treats every listed refusal as ordinary (never a Sentry event)', () => {
+    for (const message of EXPECTED_MP_ERRORS) {
+      expect(isExpectedMpError(new Error(message)), message).toBe(true)
+    }
+  })
+
+  it('covers the archived-game refusal the service actually throws', () => {
+    // pinned against the real constant so the list can't drift from game.ts
+    expect(isExpectedMpError(new Error(GAME_GONE_ERROR))).toBe(true)
+  })
+
+  it('treats a genuine fault as unexpected, so it IS reported', () => {
+    expect(isExpectedMpError(new Error('connect ECONNREFUSED'))).toBe(false)
+    expect(isExpectedMpError(new TypeError('x is not a function'))).toBe(false)
+    expect(isExpectedMpError('some non-Error throw')).toBe(false)
+    expect(isExpectedMpError(undefined)).toBe(false)
+  })
+})

--- a/src/server/mp/expected-errors.ts
+++ b/src/server/mp/expected-errors.ts
@@ -1,0 +1,48 @@
+// Which thrown MP errors are ORDINARY, and which are worth waking someone for.
+//
+// The multiplayer service reports user-facing refusals by throwing — 'No open
+// seats', 'Game not found', '2–4 players'. Those are the product working as
+// designed; sending each one to Sentry would bury a real crash under lobby
+// noise (and burn the free tier). Anything NOT listed here is treated as
+// unexpected and captured: over-reporting a new refusal string once is the
+// safe side of that trade, silently swallowing a crash is not.
+//
+// Pure + unit-tested (expected-errors.test.ts) — no DB, no Sentry.
+
+/** Exact messages the service throws as a normal, user-visible refusal. */
+export const EXPECTED_MP_ERRORS: readonly string[] = [
+  'Game not found',
+  'No such seat',
+  'No open seats',
+  'Not your seat',
+  'The game has not started',
+  'The game has already started',
+  'That seat is already open',
+  'AI seats cannot be released',
+  'You are not seated at this table',
+  'Only the host can start the game',
+  'Every seat must be filled to start',
+  'Every player must be ready to start',
+  '2–4 players',
+  'Missing event',
+  'Malformed game token',
+  'Concurrent write: the game changed under this save',
+]
+
+/** Prefixes for the same, where the message carries a variable tail. */
+const EXPECTED_PREFIXES: readonly string[] = [
+  // this table is gone / archived (GAME_GONE_ERROR and friends)
+  'This game no longer exists',
+  // AI seating misconfiguration is a setup problem, not a crash
+  'AI opponents are not available',
+  'That AI rival is served by a model gateway',
+  // a malformed client body reaching JSON.parse
+  'Unexpected token',
+  'Unexpected end of JSON input',
+]
+
+export function isExpectedMpError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err ?? '')
+  if (EXPECTED_MP_ERRORS.includes(message)) return true
+  return EXPECTED_PREFIXES.some((p) => message.startsWith(p))
+}

--- a/src/server/mp/game.ts
+++ b/src/server/mp/game.ts
@@ -10,6 +10,7 @@
 import { createHash, randomBytes, timingSafeEqual } from 'node:crypto'
 import { createActor } from 'xstate'
 import { gameStore } from '../../store/gameStore'
+import { captureMpError } from '../observability'
 import { STEP_SAFETY_BUDGET, aiDecideAndApply } from '../ai/driver'
 import {
   gatewayBaseUrl,
@@ -138,8 +139,10 @@ function broadcast(token: string) {
   for (const fn of bus.get(token) ?? []) {
     try {
       fn()
-    } catch {
-      // a dead SSE writer must not break the others
+    } catch (err) {
+      // a dead SSE writer must not break the others — but a listener that
+      // throws is a bug in the stream, so it gets reported rather than eaten.
+      captureMpError(err, { route: 'mp/game.broadcast', token })
     }
   }
 }
@@ -896,8 +899,11 @@ export function kickAiTurns(token: string): Promise<void> {
   if (aiRunning.has(token)) return Promise.resolve()
   aiRunning.add(token)
   const p = maybeRunAiTurns(token)
-    .catch(() => {
-      // the runner never propagates — a failed decision is logged in-game
+    .catch((err) => {
+      // the runner never propagates (a failed decision is logged in-game), but
+      // it must not be invisible either: this is the gate + full-row read, so a
+      // throw here is a DB/serialization fault, not a bad model answer.
+      captureMpError(err, { route: 'mp/game.kickAiTurns', token })
     })
     .finally(() => {
       aiRunning.delete(token)
@@ -982,9 +988,20 @@ async function runAiTurns(token: string): Promise<void> {
       )
       if (turnNotes.length > 16) turnNotes = turnNotes.slice(-16)
     } catch (err) {
-      // Surface driver failures in the server log — the game itself stays
-      // consistent (nothing was applied) and a reconnect re-kicks the turn.
-      console.error('[ai] turn runner stopped:', err)
+      // Surface driver failures — the game itself stays consistent (nothing
+      // was applied) and a reconnect re-kicks the turn, but an AI that quietly
+      // stops deciding is exactly the kind of prod break nobody used to see.
+      captureMpError(err, {
+        route: 'mp/game.runAiTurns',
+        token,
+        phase: peek.phase,
+        seatId: seat.seatId,
+        extra: {
+          aiTier: seat.aiTier,
+          stepsThisTurn,
+          modelCallsThisTurn,
+        },
+      })
       aiThinking.delete(token)
       broadcast(token)
       return

--- a/src/server/mp/store.ts
+++ b/src/server/mp/store.ts
@@ -25,6 +25,8 @@ import {
 import { type AiLogEntry, type AiTierId, type AiUsageTotals } from '../ai/types'
 import { db } from '../db'
 import { chatMessages, gameIntents, games } from '../db/schema'
+import { captureMpError } from '../observability'
+import { isExpectedMpError } from './expected-errors'
 
 export interface SeatRecord {
   seatId: number
@@ -486,6 +488,28 @@ export async function loadIntentLog(token: string): Promise<IntentLogRow[]> {
 export async function saveGame(
   game: GameRecord,
   /** append this to the intent log ATOMICALLY with the snapshot write */
+  intentLog?: IntentLogEntry,
+): Promise<void> {
+  try {
+    await writeGame(game, intentLog)
+  } catch (err) {
+    // The store is the one place a fault means LOST PLAY, so it reports even
+    // though the caller rethrows to the route. 'Concurrent write' is the
+    // optimistic-concurrency guard doing its job and is not an incident.
+    if (!isExpectedMpError(err)) {
+      captureMpError(err, {
+        route: 'mp/store.saveGame',
+        token: game.token,
+        phase: game.phase,
+        extra: { version: game.version, intentKind: intentLog?.kind ?? null },
+      })
+    }
+    throw err
+  }
+}
+
+async function writeGame(
+  game: GameRecord,
   intentLog?: IntentLogEntry,
 ): Promise<void> {
   if (!TOKEN_RE.test(game.token)) throw new Error('Malformed game token')

--- a/src/server/observability.ts
+++ b/src/server/observability.ts
@@ -1,0 +1,110 @@
+// Server-side error reporting for the multiplayer surface.
+//
+// Before this module the whole MP server had exactly ONE `console.error` (the
+// AI turn runner) and every other failure was swallowed into an `{ok:false}`
+// the client rendered as a toast — so a prod break was invisible. Every
+// capture site therefore does TWO things:
+//   1. writes a structured server log line (works with no Sentry at all, which
+//      is the local/CI/preview default), and
+//   2. reports to Sentry with enough context to answer "which game, which
+//      player, which action" — never just "500 somewhere".
+//
+// Context is STRUCTURED (tags + a named context block), never string
+// concatenation, so events group by route and filter by token in the UI.
+//
+// The Sentry SDK is imported LAZILY and only when a DSN is configured: with no
+// DSN this file is a console-only logger and the SDK is never even loaded (it
+// keeps the offline unit suites and DSN-less builds completely unaffected).
+import { sentryEnabled } from '~/lib/sentry-options'
+import { scrubValue } from '~/lib/sentry-scrub'
+
+export interface MpErrorContext {
+  /** Where it broke — an API route path or a `module.function` name.
+   *  Becomes the `route` tag, so events group per surface. */
+  route: string
+  /** The game's public token. NOT a credential (acting needs a seat secret)
+   *  and the only way to find the game, so it is reported verbatim. */
+  token?: string | null
+  /** Lifecycle phase of the game record: 'lobby' | 'playing' | 'over' | … */
+  phase?: string | null
+  /** Seat index the request acted as / on. Never the seat SECRET. */
+  seatId?: number | null
+  /** Machine event type for an `act` intent (`BUILD`, `CONFIRM`, …). */
+  eventType?: string | null
+  /** Anything else worth seeing on the event. Deep-scrubbed before send. */
+  extra?: Record<string, unknown>
+}
+
+/** Tag values must be strings; drop the tag entirely when there is nothing. */
+function tagsFrom(ctx: MpErrorContext): Record<string, string> {
+  const tags: Record<string, string> = { route: ctx.route }
+  if (ctx.token) tags['mp.token'] = ctx.token
+  if (ctx.phase) tags['mp.phase'] = ctx.phase
+  if (typeof ctx.seatId === 'number' && ctx.seatId >= 0) {
+    tags['mp.seat'] = String(ctx.seatId)
+  }
+  if (ctx.eventType) tags['mp.event'] = ctx.eventType
+  return tags
+}
+
+/** The console half — always runs, DSN or not. */
+function logLine(err: unknown, ctx: MpErrorContext): void {
+  const detail = err instanceof Error ? (err.stack ?? err.message) : String(err)
+  console.error(
+    `[mp] ${ctx.route} failed`,
+    scrubValue({
+      token: ctx.token ?? undefined,
+      phase: ctx.phase ?? undefined,
+      seat: ctx.seatId ?? undefined,
+      event: ctx.eventType ?? undefined,
+      ...ctx.extra,
+    }),
+    detail,
+  )
+}
+
+/**
+ * Report a server-side failure. Never throws and never awaits the transport —
+ * a capture must not be able to break, slow or fail the request it describes.
+ */
+export function captureMpError(err: unknown, ctx: MpErrorContext): void {
+  logLine(err, ctx)
+  if (!sentryEnabled) return
+  void import('@sentry/nextjs')
+    .then((Sentry) => {
+      Sentry.captureException(err, {
+        tags: tagsFrom(ctx),
+        contexts: {
+          multiplayer: scrubValue({
+            route: ctx.route,
+            token: ctx.token ?? null,
+            phase: ctx.phase ?? null,
+            seatId: ctx.seatId ?? null,
+            eventType: ctx.eventType ?? null,
+            ...ctx.extra,
+          }) as Record<string, unknown>,
+        },
+      })
+    })
+    .catch(() => {
+      // reporting must never cascade into a second failure
+    })
+}
+
+/**
+ * Wrap an API route handler so an unhandled throw is captured with route
+ * context and then rethrown for the handler's own error response. Used by the
+ * MP routes, whose `catch` blocks previously turned every crash into a silent
+ * 400.
+ */
+export async function withMpCapture<T>(
+  ctx: MpErrorContext,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run()
+  } catch (err) {
+    captureMpError(err, ctx)
+    throw err
+  }
+}


### PR DESCRIPTION
Closes readiness blocker #2 — the app had **zero observability**: no error tracker, and exactly one `console.error` in the entire multiplayer server. Every MP failure was caught and returned as `{ok:false}`, so a prod break was invisible.

## Next 16 support — verified, not assumed

`@sentry/nextjs` widened `peerDependencies.next` to include `^16.0.0-0` in **10.20.0**:

```
10.19.0: ^13.2.0 || ^14.0 || ^15.0.0-rc.0
10.20.0: ^13.2.0 || ^14.0 || ^15.0.0-rc.0 || ^16.0.0-0
```

Pinned **exact at `10.67.0`** (current latest). Installs cleanly against Next 16.2.11 — no peer override, no Next downgrade. `pnpm-lock.yaml` regenerated and committed.

## What landed

**Wiring** — the current Next 15+/16 layout, all at repo root: `instrumentation.ts` (`register()` + `onRequestError`), `sentry.server.config.ts`, `sentry.edge.config.ts`, `instrumentation-client.ts` (+ `onRouterTransitionStart`). All three runtimes spread one shared options object (`src/lib/sentry-options.ts`) so scrubbing and sampling cannot drift between them.

**Tunnel route** — `tunnelRoute: '/monitoring-tunnel'`, so ad blockers can't silently swallow a slice of client errors. It's implemented as a *rewrite*, so it does not appear in the `next build` route table; verified present in `.next/routes-manifest.json` → `rewrites.afterFiles`.

**Source maps** — `withSentryConfig` uploads them when `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/`SENTRY_PROJECT` are present at build time, then deletes them from the deployed bundle. Without a token the plugin no-ops and the build is the ordinary one.

**Real capture on the real paths.** `captureMpError` (`src/server/observability.ts`) always writes a structured `[mp] <route> failed` server log line (works with no Sentry at all) *and* reports with structured tags — `route`, `mp.token`, `mp.phase`, `mp.seat`, `mp.event` — plus a `multiplayer` context block. Enough to open an event and know **which game, which player, which action**. Wired into:

- SSE stream (`api/mp/stream`) — the initial `loadGame`, plus the sync/poll loops, reported **once per stream** so a DB outage can't mint ~240 identical events per viewer
- `act`, `join`, `create`, `start` routes
- the AI turn runner (`runAiTurns`, `kickAiTurns`) — replaces the lone `console.error`, now with tier/steps/model-calls
- `broadcast`
- store: `saveGame`
- the deploy migration (`scripts/vercel-migrate.mjs`), fully guarded

Ordinary refusals (`No open seats`, `Game not found`, `Concurrent write…`) are classified by `isExpectedMpError` and **never sent** — lobby noise must not bury a crash or burn the quota.

## Security — secrets provably never reach Sentry

`src/lib/sentry-scrub.ts` is the `beforeSend`/`beforeSendTransaction`/`beforeBreadcrumb` body and the only gate:

- request **headers, cookies and bodies are dropped wholesale** — never attached at all
- URLs and query strings are scrubbed (the SSE stream takes `?seat=&secret=`, so URLs leak if left alone)
- messages, exception values, tags, `extra`, `contexts`, `user` and breadcrumbs are deep-scrubbed by key name *and* by text pattern (`secret=…`, `Bearer …`), cycle-safe and depth-bounded
- the **game token is deliberately kept** — it identifies the game and is not a credential (acting still needs a seat secret)
- **no Session Replay**, no profiling, `sendDefaultPii: false`

Proven two ways, since there is no Sentry project to send a probe to yet:

1. `src/lib/sentry-scrub.test.ts` — unit assertions at the `beforeSend` level.
2. `src/lib/sentry-wire.test.ts` — an **end-to-end wire test**: boots a real `NodeClient` with the exact options the app ships, points it at a throwaway localhost ingest server, throws a deliberate error carrying a seat secret and a `CRON_SECRET`, and asserts the **raw envelope bytes** contain the game token and route but neither credential. This is the "deliberate test error" verification, run locally and in CI.

## Free-tier friendly

Errors only. `tracesSampleRate` 1% (env-overridable, validated). No replay, no profiling, no Vercel cron monitors.

## Missing DSN degrades gracefully

No DSN ⇒ the SDK initialises disabled *and* is never even imported on the server (`captureMpError` lazy-imports only when a DSN is set). Local dev, CI and previews build and run exactly as before, just without reporting. Verified: `pnpm build` green both with and without `NEXT_PUBLIC_SENTRY_DSN`.

## ⚠️ What Julius must set in Vercel for this to work in prod

No DSN exists anywhere yet — this PR builds against env placeholders. After creating the Sentry project:

| Var | Scope | When | Required? |
|---|---|---|---|
| `NEXT_PUBLIC_SENTRY_DSN` | Production + Preview | **Build time AND runtime** (it is inlined into the client bundle, so a redeploy is needed after setting it) | **Yes** — nothing reports without it |
| `SENTRY_AUTH_TOKEN` | Production (+ Preview if you want preview maps) | **Build time only** | Only for readable stack traces |
| `SENTRY_ORG` | same as above | Build time only | with the token |
| `SENTRY_PROJECT` | same as above | Build time only | with the token |

`SENTRY_AUTH_TOKEN` is a **secret** — mint it at Sentry → Settings → Auth Tokens with the `project:releases` scope. It is never read at runtime and never reaches the client. Optional: `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` (defaults to `0.01`).

All four are documented with these notes in `.env.example` and declared optional in `src/env.js`.

## Notes

- No schema change, no migration (sibling PR owns `0006`).
- `pnpm test`'s glob now includes `src/lib/*.test.ts` — it did not before, so tests placed there were silently skipped.
- `pnpm typecheck && pnpm lint && pnpm test && pnpm build` all green locally (798 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
