### PR TITLE
fix(ui): make the board's pinch-zoom and pan usable on a phone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -613,6 +613,25 @@ What this means in practice:
   manual path:
   `axi eval 'document.querySelector("[data-conn=\"belper|leek\"]").focus()'`
   then `axi press Enter`.
+- PAN/ZOOM MATHS LIVES IN `board/viewport.ts` (2026-07-23) — never inline a
+  `(clientX - rect.left) / rect.width` again. The board svg is letterboxed
+  inside its element (`preserveAspectRatio="xMidYMid meet"`): at 390px that is
+  ~68px of empty bar above and below, so element-rect fractions made vertical
+  panning ~1.5x too slow and slid the pinch focal point off the fingers.
+  Everything (wheel, +/−, one-finger pan, pinch) goes through that module's
+  `contentBox`/`pointFraction`/`zoomAtFraction`/`panByPixels`/`pinchView`, all
+  `clampView`-bounded so the board can never be panned off screen — it owns
+  `clampAxis`, which `pan-into-view.ts` imports rather than duplicating.
+  Two fingers pan as well as zoom; lifting one hands the gesture to the other.
+  Phone-specific chrome: the legend is `sm:`-gated (it sat ON the home control
+  at 390px) and `.bb2-board-ctrl` is 42px under `@media (pointer: coarse)`.
+  Pinned by `viewport.test.ts` + `e2e/board-touch-zoom.spec.ts`, which drives
+  REAL multi-touch via CDP `Input.dispatchTouchEvent` — Playwright's
+  touchscreen API is single-point, and synthetic pointer events prove nothing
+  about the browser gesture path (same blind spot as the setPointerCapture
+  bug above). GOTCHA for that spec: a phone-viewport `click` scrolls the board
+  out of the viewport, and touch coordinates are viewport-relative — measure
+  boxes only after `scrollIntoViewIfNeeded()`.
 - SVG Z-ORDER IS DOCUMENT ORDER (2026-07-23). Routes run city-centre to
   city-centre, so 10 of the 39 route midpoints sit inside a plate or its name
   ribbon — a built link's boat/locomotive marker painted there vanishes under

--- a/e2e/board-touch-zoom.spec.ts
+++ b/e2e/board-touch-zoom.spec.ts
@@ -1,0 +1,210 @@
+import { type CDPSession, type Page, expect, test } from '@playwright/test'
+
+/**
+ * The board on a PHONE: pinch-to-zoom, one-finger pan, and the +/−/home
+ * controls that have to stay coherent with them. At the fit-the-board default
+ * a city slot renders at ~11px on a 390px screen — technically painted,
+ * practically unreadable and untappable — so zooming in is the whole game on a
+ * phone, and it has to land the finger on the right tile afterwards.
+ *
+ * Touch is driven through raw CDP `Input.dispatchTouchEvent`: Playwright's own
+ * touchscreen API is single-point, and synthetic `dispatchEvent` pointers would
+ * not prove the real browser gesture path works (the same blind spot that once
+ * hid the setPointerCapture click-eating bug — see board-map.tsx).
+ */
+
+const PHONE = { width: 390, height: 844 }
+
+interface Touch {
+  x: number
+  y: number
+  id: number
+}
+
+/** One raw multi-touch frame. `type` is CDP's touch event type. */
+async function touch(
+  cdp: CDPSession,
+  type: 'touchStart' | 'touchMove' | 'touchEnd',
+  points: Touch[],
+) {
+  await cdp.send('Input.dispatchTouchEvent', {
+    type,
+    touchPoints: points.map((p) => ({ x: p.x, y: p.y, id: p.id })),
+  })
+}
+
+/** Viewport box of the board svg. */
+async function boardBox(page: Page) {
+  const box = await page.getByLabel('Game board map').boundingBox()
+  if (!box) throw new Error('board svg has no box')
+  return box
+}
+
+/**
+ * Drive a two-finger pinch about `anchor`, from `fromGap` to `toGap` px
+ * between the fingers. The fingers travel horizontally and are kept inside
+ * `bounds` — a touch point outside the svg lands on another element and the
+ * gesture silently never starts.
+ */
+async function pinch(
+  cdp: CDPSession,
+  anchor: { x: number; y: number },
+  fromGap: number,
+  toGap: number,
+  bounds: { x: number; width: number },
+) {
+  const lo = bounds.x + 2
+  const hi = bounds.x + bounds.width - 2
+  const at = (gap: number) => [
+    { x: Math.max(lo, anchor.x - gap), y: anchor.y, id: 1 },
+    { x: Math.min(hi, anchor.x + gap), y: anchor.y, id: 2 },
+  ]
+  const step = fromGap < toGap ? 10 : -10
+  await touch(cdp, 'touchStart', at(fromGap))
+  for (
+    let gap = fromGap + step;
+    step > 0 ? gap <= toGap : gap >= toGap;
+    gap += step
+  ) {
+    await touch(cdp, 'touchMove', at(gap))
+  }
+  await touch(cdp, 'touchEnd', [])
+}
+
+function viewBoxWidth(vb: string | null): number {
+  return Number((vb ?? '').split(/\s+/)[2])
+}
+
+test.use({ viewport: PHONE, hasTouch: true, isMobile: true })
+
+test('phone: pinch zooms the board in and out about the fingers', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  await expect(page.getByTestId('era-plate')).toHaveText('canal era')
+
+  const svg = page.getByLabel('Game board map')
+  const plate = page.locator('g[data-city="birmingham"]')
+  const before = await svg.getAttribute('viewBox')
+  const smallPlate = (await plate.boundingBox())!
+  // The premise of this whole spec: unreadably small at the default view.
+  expect(smallPlate.width).toBeLessThan(40)
+
+  const cdp = await page.context().newCDPSession(page)
+  const box = await boardBox(page)
+  const anchor = {
+    x: smallPlate.x + smallPlate.width / 2,
+    y: smallPlate.y + smallPlate.height / 2,
+  }
+
+  // Spread two fingers apart, centred on Birmingham.
+  await pinch(cdp, anchor, 20, 130, box)
+
+  await expect.poll(async () => svg.getAttribute('viewBox')).not.toBe(before)
+  const zoomedVb = await svg.getAttribute('viewBox')
+  expect(viewBoxWidth(zoomedVb)).toBeLessThan(viewBoxWidth(before))
+
+  // Readable AND tappable: the plate is now several times its former size,
+  // and it stayed under the fingers that grabbed it.
+  const bigPlate = (await plate.boundingBox())!
+  expect(bigPlate.width).toBeGreaterThan(smallPlate.width * 2.5)
+  const drift = Math.hypot(
+    bigPlate.x + bigPlate.width / 2 - anchor.x,
+    bigPlate.y + bigPlate.height / 2 - anchor.y,
+  )
+  expect(drift).toBeLessThan(12)
+
+  // Pinching closed zooms back out, from the middle of the board where both
+  // fingers are certain to have room.
+  const centre = { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+  await pinch(cdp, centre, 130, 20, box)
+  await expect
+    .poll(async () => viewBoxWidth(await svg.getAttribute('viewBox')))
+    .toBeGreaterThan(viewBoxWidth(zoomedVb))
+})
+
+test('phone: one finger pans while zoomed, and home restores the fit view', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  const svg = page.getByLabel('Game board map')
+  const fitView = await svg.getAttribute('viewBox')
+
+  // Zoom in with the control, so this test does not depend on the gesture.
+  const zoomIn = page.getByRole('button', { name: 'Zoom in' })
+  for (let i = 0; i < 4; i++) await zoomIn.click()
+  await expect.poll(async () => svg.getAttribute('viewBox')).not.toBe(fitView)
+  const zoomed = await svg.getAttribute('viewBox')
+
+  const box = await boardBox(page)
+  const cdp = await page.context().newCDPSession(page)
+  const from = { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+  await touch(cdp, 'touchStart', [{ ...from, id: 1 }])
+  for (let i = 1; i <= 8; i++) {
+    await touch(cdp, 'touchMove', [
+      { x: from.x - i * 9, y: from.y - i * 7, id: 1 },
+    ])
+  }
+  await touch(cdp, 'touchEnd', [])
+
+  await expect.poll(async () => svg.getAttribute('viewBox')).not.toBe(zoomed)
+  // A pan never changes the zoom level.
+  expect(viewBoxWidth(await svg.getAttribute('viewBox'))).toBeCloseTo(
+    viewBoxWidth(zoomed),
+    5,
+  )
+
+  // The home control is reachable on a phone (the legend used to cover it)
+  // and puts the whole board back.
+  await page.getByRole('button', { name: 'Reset view' }).click()
+  await expect.poll(async () => svg.getAttribute('viewBox')).toBe(fitView)
+})
+
+test('phone: a tap after zooming selects the tile under the finger', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+
+  // Enter a build so city plates become legal tap targets.
+  await page.getByTestId('action-build').click()
+  await page.getByTestId('card-brewery_2').click()
+  await expect(page.getByText(/Choose a site for your brewery/)).toBeVisible()
+
+  const derby = page.locator('g[data-city="derby"]')
+  await expect(derby).toHaveAttribute('data-legal', 'true')
+
+  // Pinch in on Derby itself, then tap it where it now sits.
+  const svg = page.getByLabel('Game board map')
+  // Picking the card scrolled the phone page down to the hand tray — touch
+  // coordinates are viewport-relative, so bring the board back first.
+  await svg.scrollIntoViewIfNeeded()
+  const cdp = await page.context().newCDPSession(page)
+  const board = await boardBox(page)
+  const small = (await derby.boundingBox())!
+  await pinch(
+    cdp,
+    { x: small.x + small.width / 2, y: small.y + small.height / 2 },
+    20,
+    130,
+    board,
+  )
+  await expect
+    .poll(async () => viewBoxWidth(await svg.getAttribute('viewBox')))
+    .toBeLessThan(1600)
+
+  const box = (await derby.boundingBox())!
+  expect(box.width).toBeGreaterThan(small.width * 2)
+  const point = { x: box.x + box.width / 2, y: box.y + box.height / 2, id: 1 }
+  await touch(cdp, 'touchStart', [point])
+  await touch(cdp, 'touchEnd', [])
+
+  // The engine took DERBY, not a neighbour — no coordinate drift between the
+  // visual transform and the hit test. The journal names the site, so this
+  // pins WHICH plate the finger landed on.
+  const confirm = page.getByTestId('confirm-action')
+  await expect(confirm).toBeEnabled()
+  await confirm.click()
+  await expect(
+    page.getByText(/Eliza built Brewery \(I\) at Derby/),
+  ).toBeVisible()
+})

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -34,6 +34,15 @@ import {
 } from './pan-into-view'
 import { farmBrewerySpurStyle } from './route-style'
 import { CUBE, cubeCells } from './tile-cubes'
+import {
+  FULL_VIEW,
+  type PinchStart,
+  type ViewBox,
+  panByPixels,
+  pinchView,
+  pointFraction,
+  zoomAtFraction,
+} from './viewport'
 
 /* ---------------- palette (mirrors theme.css) ---------------- */
 
@@ -238,36 +247,35 @@ export function BoardMap({
   vpColor = null,
 }: BoardMapProps) {
   const svgRef = useRef<SVGSVGElement | null>(null)
-  const [vb, setVb] = useState({ x: 0, y: 0, w: VIEW_W, h: VIEW_H })
+  const [vb, setVb] = useState<ViewBox>(FULL_VIEW)
+  // Latest vb for the gesture handlers and the focus effect, without
+  // retriggering either on every user pan.
+  const vbRef = useRef(vb)
+  vbRef.current = vb
   const drag = useRef<{
     px: number
     py: number
-    vb: { x: number; y: number; w: number; h: number }
+    vb: ViewBox
     moved: boolean
   } | null>(null)
 
   /* ---- pan / zoom ---- */
 
+  // All client→board maths goes through `viewport.ts`, which measures against
+  // the LETTERBOXED content box rather than the element rect — see the note
+  // there. Never inline the old `(clientX - rect.left) / rect.width` form.
   useEffect(() => {
     const svg = svgRef.current
     if (!svg) return
     const onWheel = (e: WheelEvent) => {
       e.preventDefault()
       stopAutoPan()
-      setVb((v) => {
-        const rect = svg.getBoundingClientRect()
-        const fx = (e.clientX - rect.left) / rect.width
-        const fy = (e.clientY - rect.top) / rect.height
-        const scale = e.deltaY > 0 ? 1.14 : 1 / 1.14
-        const w = Math.min(Math.max(v.w * scale, VIEW_W / 6), VIEW_W * 1.3)
-        const h = (w / VIEW_W) * VIEW_H
-        return {
-          x: v.x + (v.w - w) * fx,
-          y: v.y + (v.h - h) * fy,
-          w,
-          h,
-        }
-      })
+      const { fx, fy } = pointFraction(
+        svg.getBoundingClientRect(),
+        e.clientX,
+        e.clientY,
+      )
+      setVb((v) => zoomAtFraction(v, e.deltaY > 0 ? 1.14 : 1 / 1.14, fx, fy))
     }
     svg.addEventListener('wheel', onWheel, { passive: false })
     return () => svg.removeEventListener('wheel', onWheel)
@@ -275,16 +283,18 @@ export function BoardMap({
 
   // Live pointer positions — one pointer pans, two pointers pinch-zoom.
   const pointers = useRef(new Map<number, { x: number; y: number }>())
-  const pinch = useRef<{
-    dist: number
-    vb: { x: number; y: number; w: number; h: number }
-  } | null>(null)
+  const pinch = useRef<PinchStart | null>(null)
 
-  const pinchDistance = () => {
+  /** Distance + midpoint of the two live pointers (0 when fewer than two). */
+  const pinchSpan = () => {
     const pts = [...pointers.current.values()]
-    if (pts.length < 2) return 0
+    if (pts.length < 2) return null
     const [a, b] = pts as [{ x: number; y: number }, { x: number; y: number }]
-    return Math.hypot(a.x - b.x, a.y - b.y)
+    return {
+      dist: Math.hypot(a.x - b.x, a.y - b.y),
+      midX: (a.x + b.x) / 2,
+      midY: (a.y + b.y) / 2,
+    }
   }
 
   // IMPORTANT: never setPointerCapture on pointerdown. Capturing retargets
@@ -300,6 +310,11 @@ export function BoardMap({
     }
   }
 
+  /** Begin (or restart) a one-finger pan from `e`'s position. */
+  const seatDrag = (clientX: number, clientY: number, moved: boolean): void => {
+    drag.current = { px: clientX, py: clientY, vb: vbRef.current, moved }
+  }
+
   const onPointerDown = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.pointerType === 'mouse' && e.button !== 0) return
     stopAutoPan()
@@ -307,47 +322,43 @@ export function BoardMap({
     if (pointers.current.size === 2) {
       // second finger down — switch from pan to pinch (no click expected
       // from a two-finger gesture, so capturing immediately is safe)
-      pinch.current = { dist: pinchDistance(), vb }
+      const span = pinchSpan()
+      const svg = svgRef.current
+      if (span && svg) {
+        const { fx, fy } = pointFraction(
+          svg.getBoundingClientRect(),
+          span.midX,
+          span.midY,
+        )
+        pinch.current = { view: vbRef.current, fx, fy, dist: span.dist }
+      }
       if (drag.current) drag.current.moved = true
       for (const id of pointers.current.keys()) capturePointer(id)
       return
     }
-    drag.current = { px: e.clientX, py: e.clientY, vb, moved: false }
+    seatDrag(e.clientX, e.clientY, false)
   }
   const onPointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
     const svg = svgRef.current
     if (!svg || !pointers.current.has(e.pointerId)) return
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY })
 
-    if (pinch.current && pointers.current.size >= 2) {
-      const p = pinch.current
-      const dist = pinchDistance()
-      if (dist <= 0 || p.dist <= 0) return
-      const rect = svg.getBoundingClientRect()
-      const pts = [...pointers.current.values()]
-      const midX = (pts[0]!.x + pts[1]!.x) / 2
-      const midY = (pts[0]!.y + pts[1]!.y) / 2
-      const fx = (midX - rect.left) / rect.width
-      const fy = (midY - rect.top) / rect.height
-      const w = Math.min(
-        Math.max(p.vb.w * (p.dist / dist), VIEW_W / 6),
-        VIEW_W * 1.3,
+    const p = pinch.current
+    if (p && pointers.current.size >= 2) {
+      const span = pinchSpan()
+      if (!span) return
+      const { fx, fy } = pointFraction(
+        svg.getBoundingClientRect(),
+        span.midX,
+        span.midY,
       )
-      const h = (w / VIEW_W) * VIEW_H
-      setVb({
-        x: p.vb.x + (p.vb.w - w) * fx,
-        y: p.vb.y + (p.vb.h - h) * fy,
-        w,
-        h,
-      })
+      // One gesture, both effects: spreading zooms, sliding pans.
+      setVb(pinchView(p, span.dist, fx, fy))
       return
     }
 
     const d = drag.current
     if (!d) return
-    const rect = svg.getBoundingClientRect()
-    const dx = ((e.clientX - d.px) / rect.width) * d.vb.w
-    const dy = ((e.clientY - d.py) / rect.height) * d.vb.h
     if (
       !d.moved &&
       Math.abs(e.clientX - d.px) + Math.abs(e.clientY - d.py) > 4
@@ -357,11 +368,27 @@ export function BoardMap({
       capturePointer(e.pointerId)
     }
     if (!d.moved) return
-    setVb({ x: d.vb.x - dx, y: d.vb.y - dy, w: d.vb.w, h: d.vb.h })
+    setVb(
+      panByPixels(
+        d.vb,
+        svg.getBoundingClientRect(),
+        e.clientX - d.px,
+        e.clientY - d.py,
+      ),
+    )
   }
   const onPointerUp = (e: React.PointerEvent<SVGSVGElement>) => {
     pointers.current.delete(e.pointerId)
     if (pointers.current.size < 2) pinch.current = null
+    const [remaining] = [...pointers.current.values()]
+    if (remaining) {
+      // Lifting one finger of a pinch hands the gesture back to the other:
+      // re-seat the pan from where that finger IS, against the zoom the pinch
+      // just left behind (its stale start view would otherwise jump the map).
+      // Seeded as already-moved so no stray click fires from a two-finger tap.
+      seatDrag(remaining.x, remaining.y, true)
+      return
+    }
     // Delay so child click handlers can consult wasDrag()
     setTimeout(() => {
       drag.current = null
@@ -371,22 +398,15 @@ export function BoardMap({
 
   const zoomBy = (scale: number) => {
     stopAutoPan()
-    return setVb((v) => {
-      const w = Math.min(Math.max(v.w * scale, VIEW_W / 6), VIEW_W * 1.3)
-      const h = (w / VIEW_W) * VIEW_H
-      return { x: v.x + (v.w - w) / 2, y: v.y + (v.h - h) / 2, w, h }
-    })
+    return setVb((v) => zoomAtFraction(v, scale, 0.5, 0.5))
   }
   const resetView = () => {
     stopAutoPan()
-    setVb({ x: 0, y: 0, w: VIEW_W, h: VIEW_H })
+    setVb(FULL_VIEW)
   }
 
   /* ---- card-hover map sync (auto-pan to a hovered card's city) ---- */
 
-  // Latest vb without retriggering the focus effect on every user pan.
-  const vbRef = useRef(vb)
-  vbRef.current = vb
   const autoPanFrame = useRef<number | null>(null)
 
   function stopAutoPan() {
@@ -1040,18 +1060,19 @@ export function BoardMap({
         </button>
         <button
           type="button"
-          className="bb2-board-ctrl"
+          className="bb2-board-ctrl is-home"
           onClick={resetView}
           aria-label="Reset view"
-          style={{ fontSize: 12 }}
         >
           ⌂
         </button>
       </div>
 
-      {/* legend */}
+      {/* legend — hidden on phones: it is decorative, and at 390px it runs
+          under the zoom controls and swallows the reset button, which is the
+          one control a pinched-in player needs to find their way back. */}
       <div
-        className="absolute bottom-3 left-3 z-10 flex items-center gap-4 rounded border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em]"
+        className="absolute bottom-3 left-3 z-10 hidden items-center gap-4 rounded border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] sm:flex"
         style={{
           background: 'rgba(20,16,11,.85)',
           borderColor: 'var(--bb-brass-hairline-soft)',

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -248,10 +248,17 @@ export function BoardMap({
 }: BoardMapProps) {
   const svgRef = useRef<SVGSVGElement | null>(null)
   const [vb, setVb] = useState<ViewBox>(FULL_VIEW)
-  // Latest vb for the gesture handlers and the focus effect, without
-  // retriggering either on every user pan.
+  // Latest COMMITTED vb for the gesture handlers and the focus effect, without
+  // retriggering either on every user pan. Written from an effect, NEVER in the
+  // render body: React may discard or replay a render, which would otherwise
+  // leave this ref describing a view the DOM never adopted. Safe at passive
+  // timing because every read is at a gesture BOUNDARY (pointerdown, the
+  // one-finger handoff, an animation start) — a pinch or pan in flight works
+  // off the view it captured when the gesture began, never off this ref.
   const vbRef = useRef(vb)
-  vbRef.current = vb
+  useEffect(() => {
+    vbRef.current = vb
+  }, [vb])
   const drag = useRef<{
     px: number
     py: number

--- a/src/components/board/pan-into-view.ts
+++ b/src/components/board/pan-into-view.ts
@@ -10,6 +10,8 @@
 // SETTLE margin — so the destination never sits on the trigger boundary and
 // a re-hover of the same card is a no-op.
 
+import { clampAxis } from './viewport'
+
 export interface ViewBox {
   x: number
   y: number
@@ -100,11 +102,4 @@ export function planPanToCity(
   }
 
   return { x, y, w, h }
-}
-
-/** Clamp a viewBox origin so the view stays over the board. */
-function clampAxis(v: number, size: number, boundSize: number): number {
-  const lo = Math.min(0, boundSize - size)
-  const hi = Math.max(0, boundSize - size)
-  return Math.min(Math.max(v, lo), hi)
 }

--- a/src/components/board/viewport.test.ts
+++ b/src/components/board/viewport.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest'
+import { VIEW_H, VIEW_W } from './board-data'
+import {
+  FULL_VIEW,
+  MAX_VIEW_W,
+  MIN_VIEW_W,
+  type ViewBox,
+  clampView,
+  contentBox,
+  panByPixels,
+  pinchView,
+  pointFraction,
+  sizeForWidth,
+  zoomAtFraction,
+} from './viewport'
+
+/** A phone-shaped board frame: taller than the board, so it letterboxes. */
+const PHONE = { left: 18, top: 260, width: 354, height: 391 }
+/** A desktop-shaped frame: wider than the board — letterboxes sideways. */
+const DESKTOP = { left: 0, top: 0, width: 1200, height: 700 }
+
+describe('contentBox', () => {
+  it('letterboxes vertically in a frame taller than the board', () => {
+    const c = contentBox(PHONE)
+    expect(c.width).toBeCloseTo(354, 5)
+    expect(c.height).toBeCloseTo(354 / (VIEW_W / VIEW_H), 5)
+    // centred: equal bars top and bottom
+    expect(c.top - PHONE.top).toBeCloseTo(
+      PHONE.top + PHONE.height - (c.top + c.height),
+      5,
+    )
+    expect(c.height).toBeLessThan(PHONE.height)
+  })
+
+  it('letterboxes horizontally in a frame wider than the board', () => {
+    const c = contentBox(DESKTOP)
+    expect(c.height).toBeCloseTo(700, 5)
+    expect(c.width).toBeCloseTo(700 * (VIEW_W / VIEW_H), 5)
+    expect(c.width).toBeLessThan(DESKTOP.width)
+  })
+
+  it('is the rect itself when the aspects match', () => {
+    const exact = { left: 5, top: 7, width: VIEW_W, height: VIEW_H }
+    const c = contentBox(exact)
+    expect(c).toEqual(exact)
+  })
+
+  it('survives a zero-sized rect (pre-layout render)', () => {
+    const zero = { left: 0, top: 0, width: 0, height: 0 }
+    expect(contentBox(zero)).toEqual(zero)
+    expect(pointFraction(zero, 10, 10)).toEqual({ fx: 0.5, fy: 0.5 })
+  })
+})
+
+describe('pointFraction', () => {
+  it('measures against the content box, not the element rect', () => {
+    const c = contentBox(PHONE)
+    // The top of the PAINTED board — inside the element, below its top edge.
+    expect(pointFraction(PHONE, c.left, c.top).fy).toBeCloseTo(0, 5)
+    // Measuring against the raw rect would have said ~0.17 here.
+    expect((c.top - PHONE.top) / PHONE.height).toBeGreaterThan(0.15)
+    expect(pointFraction(PHONE, c.left + c.width, c.top + c.height)).toEqual({
+      fx: 1,
+      fy: 1,
+    })
+    expect(
+      pointFraction(PHONE, c.left + c.width / 2, c.top + c.height / 2),
+    ).toEqual({ fx: 0.5, fy: 0.5 })
+  })
+})
+
+describe('sizeForWidth', () => {
+  it('keeps the board aspect', () => {
+    const s = sizeForWidth(800)
+    expect(s.w / s.h).toBeCloseTo(VIEW_W / VIEW_H, 10)
+  })
+
+  it('clamps both zoom bounds', () => {
+    expect(sizeForWidth(1).w).toBe(MIN_VIEW_W)
+    expect(sizeForWidth(999_999).w).toBe(MAX_VIEW_W)
+  })
+})
+
+describe('clampView', () => {
+  it('keeps a zoomed-in view over the board', () => {
+    const v: ViewBox = { x: -900, y: -900, w: 400, h: 400 / (VIEW_W / VIEW_H) }
+    const c = clampView(v)
+    expect(c.x).toBe(0)
+    expect(c.y).toBe(0)
+    const far = clampView({ ...v, x: 9999, y: 9999 })
+    expect(far.x).toBe(VIEW_W - v.w)
+    expect(far.y).toBe(VIEW_H - v.h)
+  })
+
+  it('leaves the full-board view alone', () => {
+    expect(clampView(FULL_VIEW)).toEqual(FULL_VIEW)
+  })
+
+  it('centres a view wider than the board instead of fighting it', () => {
+    const wide = {
+      x: 5000,
+      y: 5000,
+      w: MAX_VIEW_W,
+      h: MAX_VIEW_W / (VIEW_W / VIEW_H),
+    }
+    const c = clampView(wide)
+    expect(c.x).toBe(0)
+    expect(c.y).toBe(0)
+    const under = clampView({ ...wide, x: -5000, y: -5000 })
+    expect(under.x).toBe(VIEW_W - wide.w)
+    expect(under.y).toBe(VIEW_H - wide.h)
+  })
+})
+
+describe('zoomAtFraction', () => {
+  it('holds the anchored board point still while zooming in', () => {
+    const v = FULL_VIEW
+    const fx = 0.3
+    const fy = 0.7
+    const before = { x: v.x + v.w * fx, y: v.y + v.h * fy }
+    const z = zoomAtFraction(v, 1 / 2, fx, fy)
+    expect(z.w).toBeCloseTo(VIEW_W / 2, 5)
+    expect(z.x + z.w * fx).toBeCloseTo(before.x, 5)
+    expect(z.y + z.h * fy).toBeCloseTo(before.y, 5)
+  })
+
+  it('matches the centre-anchored maths the +/- buttons use', () => {
+    const v = { x: 100, y: 50, w: 800, h: 800 / (VIEW_W / VIEW_H) }
+    const z = zoomAtFraction(v, 1 / 1.3, 0.5, 0.5)
+    const w = v.w / 1.3
+    const h = w / (VIEW_W / VIEW_H)
+    expect(z).toEqual(
+      clampView({ x: v.x + (v.w - w) / 2, y: v.y + (v.h - h) / 2, w, h }),
+    )
+  })
+
+  it('never zooms past the bounds', () => {
+    let v: ViewBox = FULL_VIEW
+    for (let i = 0; i < 40; i++) v = zoomAtFraction(v, 1 / 1.3, 0.5, 0.5)
+    expect(v.w).toBe(MIN_VIEW_W)
+    for (let i = 0; i < 40; i++) v = zoomAtFraction(v, 1.3, 0.5, 0.5)
+    expect(v.w).toBe(MAX_VIEW_W)
+  })
+})
+
+describe('panByPixels', () => {
+  it('moves the board with the finger, in both axes', () => {
+    const v = { x: 400, y: 300, w: 400, h: 400 / (VIEW_W / VIEW_H) }
+    const c = contentBox(PHONE)
+    const p = panByPixels(v, PHONE, 20, 20)
+    // Dragging right/down moves the viewBox left/up by the same board distance.
+    expect(v.x - p.x).toBeCloseTo((20 / c.width) * v.w, 5)
+    expect(v.y - p.y).toBeCloseTo((20 / c.height) * v.h, 5)
+    // Both axes share the same px→board scale (the letterbox bug made the
+    // vertical one ~1.5x too slow on a phone).
+    expect((v.x - p.x) / (v.y - p.y)).toBeCloseTo(1, 5)
+  })
+
+  it('cannot pan the board out of view', () => {
+    const v = { x: 0, y: 0, w: 400, h: 400 / (VIEW_W / VIEW_H) }
+    const p = panByPixels(v, PHONE, 100_000, 100_000)
+    expect(p.x).toBe(0)
+    expect(p.y).toBe(0)
+  })
+})
+
+describe('pinchView', () => {
+  const start = { view: FULL_VIEW, fx: 0.5, fy: 0.5, dist: 100 }
+
+  it('zooms in as the fingers spread, about their midpoint', () => {
+    const v = pinchView(start, 200, 0.5, 0.5)
+    expect(v.w).toBeCloseTo(VIEW_W / 2, 5)
+    // The grabbed board point stays under the midpoint.
+    expect(v.x + v.w * 0.5).toBeCloseTo(VIEW_W / 2, 5)
+    expect(v.y + v.h * 0.5).toBeCloseTo(VIEW_H / 2, 5)
+  })
+
+  it('zooms out as the fingers close', () => {
+    const inner = { ...start, view: { x: 600, y: 400, w: 400, h: 287.5 } }
+    expect(pinchView(inner, 50, 0.5, 0.5).w).toBeCloseTo(800, 5)
+  })
+
+  it('pans when both fingers move together (no distance change)', () => {
+    const inner = {
+      view: { x: 600, y: 400, w: 400, h: 287.5 },
+      fx: 0.5,
+      fy: 0.5,
+      dist: 100,
+    }
+    const v = pinchView(inner, 100, 0.75, 0.75)
+    expect(v.w).toBeCloseTo(400, 5)
+    // Midpoint moved a quarter-viewport right/down ⇒ the board follows it.
+    expect(v.x).toBeCloseTo(600 - 0.25 * 400, 5)
+    expect(v.y).toBeCloseTo(400 - 0.25 * 287.5, 5)
+  })
+
+  it('holds still on a degenerate distance', () => {
+    expect(pinchView(start, 0, 0.5, 0.5)).toEqual(start.view)
+    expect(pinchView({ ...start, dist: 0 }, 100, 0.5, 0.5)).toEqual(start.view)
+  })
+
+  it('respects the zoom bounds and the board edges', () => {
+    const v = pinchView(start, 100_000, 0.5, 0.5)
+    expect(v.w).toBe(MIN_VIEW_W)
+    const out = pinchView(start, 0.0001, 0.5, 0.5)
+    expect(out.w).toBe(MAX_VIEW_W)
+    const edge = pinchView(start, 400, 0, 0)
+    expect(edge.x).toBeGreaterThanOrEqual(0)
+    expect(edge.y).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/src/components/board/viewport.ts
+++ b/src/components/board/viewport.ts
@@ -1,0 +1,165 @@
+// Board pan/zoom maths — the PURE half of the map's gesture handling, so the
+// awkward parts (letterboxing, zoom bounds, pinch about a MOVING midpoint) are
+// unit-testable without a DOM. The event plumbing lives in `board-map.tsx`.
+//
+// The one non-obvious thing here is the CONTENT BOX. The svg is drawn with the
+// default `preserveAspectRatio="xMidYMid meet"`, so the board is letterboxed
+// inside its element whenever the element's aspect differs from the board's —
+// on a phone that is ~68px of empty bar above and below a 391px-tall frame.
+// Client→board maths must measure against that content box, not the element
+// rect: measuring against the rect made vertical panning ~1.5x too slow on a
+// phone and slid the pinch focal point away from the fingers.
+
+import { VIEW_H, VIEW_W } from './board-data'
+
+export interface ViewBox {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+export interface Box {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+/** Deepest zoom-in, as a viewBox width. 1600/6 ⇒ ~69px city slots at 390px. */
+export const MIN_VIEW_W = VIEW_W / 6
+/** Furthest zoom-out — a little wider than the board, for context. */
+export const MAX_VIEW_W = VIEW_W * 1.3
+/** Every view keeps the board's aspect, so the map never distorts. */
+export const VIEW_ASPECT = VIEW_W / VIEW_H
+
+/** The whole-board view — what the reset/home control returns to. */
+export const FULL_VIEW: ViewBox = { x: 0, y: 0, w: VIEW_W, h: VIEW_H }
+
+/**
+ * Clamp a viewBox origin so the view stays over the board. When the view is
+ * WIDER than the board the valid range inverts — the board then floats with
+ * void on both sides, so the clamp centres rather than fights it.
+ */
+export function clampAxis(v: number, size: number, boundSize: number): number {
+  const lo = Math.min(0, boundSize - size)
+  const hi = Math.max(0, boundSize - size)
+  return Math.min(Math.max(v, lo), hi)
+}
+
+/** Size a view from a requested width: board aspect kept, zoom bounds applied. */
+export function sizeForWidth(w: number): { w: number; h: number } {
+  const cw = Math.min(Math.max(w, MIN_VIEW_W), MAX_VIEW_W)
+  return { w: cw, h: cw / VIEW_ASPECT }
+}
+
+/** Keep the view over the board (both axes). */
+export function clampView(v: ViewBox): ViewBox {
+  return {
+    x: clampAxis(v.x, v.w, VIEW_W),
+    y: clampAxis(v.y, v.h, VIEW_H),
+    w: v.w,
+    h: v.h,
+  }
+}
+
+/**
+ * The letterboxed content box of the board inside its element — where the
+ * board is ACTUALLY painted under `preserveAspectRatio="xMidYMid meet"`.
+ */
+export function contentBox(rect: Box): Box {
+  if (rect.width <= 0 || rect.height <= 0) return rect
+  const boxAspect = rect.width / rect.height
+  const width = boxAspect > VIEW_ASPECT ? rect.height * VIEW_ASPECT : rect.width
+  const height =
+    boxAspect > VIEW_ASPECT ? rect.height : rect.width / VIEW_ASPECT
+  return {
+    left: rect.left + (rect.width - width) / 2,
+    top: rect.top + (rect.height - height) / 2,
+    width,
+    height,
+  }
+}
+
+/**
+ * Where a client point sits inside the content box, as a 0..1 fraction.
+ * Points in the letterbox bars fall outside 0..1 — deliberately not clamped,
+ * so a zoom anchored there still leans the right way.
+ */
+export function pointFraction(
+  rect: Box,
+  clientX: number,
+  clientY: number,
+): { fx: number; fy: number } {
+  const c = contentBox(rect)
+  if (c.width <= 0 || c.height <= 0) return { fx: 0.5, fy: 0.5 }
+  return {
+    fx: (clientX - c.left) / c.width,
+    fy: (clientY - c.top) / c.height,
+  }
+}
+
+/**
+ * Zoom by `factor` (>1 zooms OUT — it scales the viewBox) while the board
+ * point under the content-box fraction (fx, fy) stays put.
+ */
+export function zoomAtFraction(
+  v: ViewBox,
+  factor: number,
+  fx: number,
+  fy: number,
+): ViewBox {
+  const { w, h } = sizeForWidth(v.w * factor)
+  return clampView({
+    x: v.x + (v.w - w) * fx,
+    y: v.y + (v.h - h) * fy,
+    w,
+    h,
+  })
+}
+
+/** Pan by a client-pixel delta measured on the element `rect`. */
+export function panByPixels(
+  v: ViewBox,
+  rect: Box,
+  dxPx: number,
+  dyPx: number,
+): ViewBox {
+  const c = contentBox(rect)
+  if (c.width <= 0 || c.height <= 0) return v
+  return clampView({
+    x: v.x - (dxPx / c.width) * v.w,
+    y: v.y - (dyPx / c.height) * v.h,
+    w: v.w,
+    h: v.h,
+  })
+}
+
+/** Everything a pinch needs to remember from the moment it began. */
+export interface PinchStart {
+  view: ViewBox
+  /** Content-box fraction of the two fingers' midpoint at gesture start. */
+  fx: number
+  fy: number
+  /** Distance between the fingers at gesture start, in client px. */
+  dist: number
+}
+
+/**
+ * One pinch frame: scale about the midpoint AND follow it, so two fingers
+ * moving together pan the board (a phone player expects both from one
+ * gesture). Falls back to the start view for a degenerate distance.
+ */
+export function pinchView(
+  start: PinchStart,
+  dist: number,
+  fx: number,
+  fy: number,
+): ViewBox {
+  if (dist <= 0 || start.dist <= 0) return start.view
+  const { w, h } = sizeForWidth(start.view.w * (start.dist / dist))
+  // The board point the fingers grabbed, now placed under where they are.
+  const wx = start.view.x + start.view.w * start.fx
+  const wy = start.view.y + start.view.h * start.fy
+  return clampView({ x: wx - w * fx, y: wy - h * fy, w, h })
+}

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -724,6 +724,22 @@ button.bb2-card {
   background: rgba(195, 149, 56, 0.18);
   border-color: var(--bb-brass);
 }
+/* Finger-sized on touch. The board's zoom controls are the ONLY way back to
+   a readable scale on a phone, so they must not stay a 30px mouse target.
+   Coarse-pointer only — desktop keeps the compact 30px buttons. */
+.bb2-board-ctrl.is-home {
+  font-size: 12px;
+}
+@media (pointer: coarse) {
+  .bb2-board-ctrl {
+    width: 42px;
+    height: 42px;
+    font-size: 19px;
+  }
+  .bb2-board-ctrl.is-home {
+    font-size: 16px;
+  }
+}
 
 /* legal-target pulse on SVG nodes */
 @keyframes bb2-target-pulse {


### PR DESCRIPTION
## The problem

On a phone the whole board is scaled into ~354px of width, so a city slot renders at **~11px** —
painted, but unreadable and untappable.

Pinch and pan already existed in `board-map.tsx`. Three things kept them from rescuing the phone player:

1. **Letterboxing was ignored.** All client→board maths measured against the element *rect*, but the
   svg is drawn with the default `preserveAspectRatio="xMidYMid meet"` — at 390px that is ~68px of
   empty bar above and below the painted board. Vertical panning ran **~1.5× too slow** and the pinch
   focal point slid away from the fingers. (Desktop was ~2% off horizontally for the same reason.)
2. **The home/reset control sat *under* the legend** at phone widths — the one control that gets you
   back to a readable view was unclickable — and every control was a 30px mouse target.
3. **Nothing bounded the view**, so a pan could slide the board off screen entirely.

## The fix

All pan/zoom maths moved into a new pure module, `src/components/board/viewport.ts`
(`contentBox` / `pointFraction` / `zoomAtFraction` / `panByPixels` / `pinchView`), measuring the real
**content box** and `clampView`-bounding every result. `clampAxis` moved there too — `pan-into-view.ts`
now imports it instead of keeping its own copy.

Also: two fingers now **pan as well as zoom** (one gesture, both effects), and lifting one finger of a
pinch **hands the gesture to the other** instead of dropping it. Legend is `sm:`-gated; `.bb2-board-ctrl`
is 42px under `@media (pointer: coarse)`.

**No relayout** — scope stayed on the zoom/pan interaction, per the brief.

## Desktop is unchanged by design

Same wheel factors, same +/− steps, same 30px controls, same legend, same click/drag/hover. Only the
focal maths got more exact. The existing `atlas.spec.ts` desktop wheel-zoom + drag-pan + reset journey
passes untouched, and this was re-verified in a browser at 1440px (wheel zoom anchors to 0.2px, drag
pans, zoom-out clamps, reset restores).

![desktop unchanged](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr96-desktop.png)

## Before / after — 390px

Before: ~11px tiles, and the legend swallows the ⌂ home button whole (only + and − poke out).

![before at 390px](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr96-before-390.png)

After, same fit-the-board default: all three controls clear.

![after at 390px, default view](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr96-after-390-default.png)

After a pinch: industry glyphs, level numerals and resource cubes all readable, tap targets ~69px.

![after at 390px, pinched in](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr96-after-390-zoomed.png)

## 430px

![after at 430px, pinched in](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr96-after-430-zoomed.png)

## Verification

- **Browser-verified at 390px, 430px and 1440px.** Pinch anchoring measured at **0–1px drift** on both
  phone widths (city plate 26.5px → 93.8px at 390, 29.6px → 104.4px at 430); one-finger pan, two-finger
  pan, finger-handoff and reset all exercised; hit-testing confirmed on the zoomed plate.
- `src/components/board/viewport.test.ts` — 20 pure cases (letterbox geometry, zoom bounds, clamping,
  focal invariance, two-finger pan, degenerate inputs).
- `e2e/board-touch-zoom.spec.ts` — 3 journeys driving **real trusted multi-touch** through CDP
  `Input.dispatchTouchEvent`. Playwright's own touchscreen API is single-point, and synthetic pointer
  events would not prove the browser gesture path — the same blind spot that once hid the
  `setPointerCapture` click-eating bug.
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (764 passed), `pnpm build` — all green.
- Full Playwright run (rebased on `main`): 60 passed, 3 failed — `coverage.spec.ts` Develop,
  `mp-playthrough.spec.ts` and `multiplayer.spec.ts`. All three were **confirmed failing with this
  branch's changes reverted in place over `origin/main`** — pre-existing, not from this PR. (The first
  two are stale copy assertions left by the develop-on-the-mat change, #81.) CI does not run Playwright.
- GOTCHA worth knowing for anyone running e2e in a shared worktree pool: Playwright's
  `reuseExistingServer: true` will happily reuse **another lane's** dev server on :3199 and silently
  test their checkout — that produced one confusing green and one confusing red here. Run against a
  private port when in doubt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved board zooming and panning with mouse and touch gestures.
  - Added pinch-to-zoom and touch panning support on mobile devices.
  - Improved gesture accuracy when interacting with board locations.

- **UI Improvements**
  - Updated mobile board controls with larger, easier-to-tap buttons.
  - Simplified the mobile zoom controls display.

- **Bug Fixes**
  - Prevented viewport jumps when transitioning between pinch and pan gestures.
  - Improved zoom behavior around the pointer or touch midpoint.

- **Tests**
  - Added automated coverage for board zoom, pan, pinch, and touch interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->