### PR TITLE
feat(ui): spotlight every resource-source option on the board, on both surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,12 +384,21 @@ What this means in practice:
     public board state, so `filterSnapshotForSeat` needs nothing; a forged MP
     pick is refused by the same guard/`explainRefusal`. Pinned by
     `gameStore.coaltiechoice.test.ts` + `intent.test.ts`; UI picker in
-    `action-dock.tsx` (`CoalSourcePicker`) + board spotlight in `game.tsx`.
+    `action-dock.tsx` (`CoalSourcePicker`).
   - Beer/iron are a free "any source" pick. The staged sale/picks reference
     only public board state, so `filterSnapshotForSeat` needs nothing; a forged
     MP pick is refused by the same guard. Pinned by
     `gameStore.sourcechoice.test.ts`, `legal-moves.test.ts`, `intent.test.ts`,
     `e2e/beer-source.spec.ts` + `?demo=beerchoice`.
+  - THE MAP LIGHTS THE ANSWERS, from ONE shared seam:
+    `components/source-spotlight.ts` (`sourceCandidateCities`) reads the
+    `pending{Beer,Iron,Coal}Choice` selectors and feeds BoardMap's
+    `hoverCities` on BOTH `game.tsx` and `mp/mp-game.tsx` — same reason as
+    `legal-targets.ts`, and it re-derives no rule. Off-board sources (market
+    iron) light nothing; a bystander's filtered view carries no staged
+    selection, so the engine reports no choice and nothing lights for them.
+    Plates carry `data-hinted`. Pinned by `source-spotlight.test.ts` +
+    `e2e/iron-source.spec.ts`.
 - COAL "NEAREST MINE" CONSUMPTION (`consumeCoalFromSources` +
   `findConnectedCoalMines`, `market/marketActions.ts` + `shared/gameUtils.ts`):
   `findConnectedCoalMines` returns EVERY connected stocked mine ordered

--- a/e2e/iron-source.spec.ts
+++ b/e2e/iron-source.spec.ts
@@ -30,6 +30,11 @@ test('the iron picker offers every works but never the market, and the develop c
   // unflipped works holds iron it must never be on offer.
   await expect(sources.filter({ hasText: /market/i })).toHaveCount(0)
 
+  // The answers are places, so the map spotlights them — one plate per works
+  // on offer, and the off-board market lights nothing.
+  const hinted = page.locator('g[data-city][data-hinted]')
+  expect(await hinted.count()).toBeGreaterThanOrEqual(2)
+
   // Answering the question moves the flow on to the confirm step.
   await sources.first().click()
   const confirm = page.getByTestId('confirm-action')

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -564,16 +564,25 @@ function coalSourceCaption(option: CoalSourceOption): string {
  */
 function CoalSourcePicker({
   options,
+  required,
+  picks,
   onPick,
 }: {
   options: CoalSourceOption[]
+  /** Cubes the whole action spends — a double rail asks twice. */
+  required: number
+  /** Cubes already assigned — the machine's own record, not UI staging. */
+  picks: CoalSourceOption['source'][]
   onPick: (source: CoalSourceOption['source']) => void
 }) {
   const { handlersFor } = useLocateCity()
+  const tied = `${options.length} mines are equally close`
   return (
     <div className="flex flex-col gap-1.5">
       <Note>
-        {options.length} mines are equally close — choose which to drain.
+        {required > 1
+          ? `Coal ${Math.min(picks.length + 1, required)} of ${required} — ${tied}.`
+          : `${tied} — choose which to drain.`}
       </Note>
       {options.map((option) => (
         <button
@@ -1276,6 +1285,8 @@ export function ActionDock({
         {choice && (
           <CoalSourcePicker
             options={choice.options}
+            required={choice.required}
+            picks={c.chosenCoalSources ?? []}
             onPick={(source) => send({ type: 'SELECT_COAL_SOURCE', source })}
           />
         )}
@@ -1377,6 +1388,8 @@ export function ActionDock({
         {choice && (
           <CoalSourcePicker
             options={choice.options}
+            required={choice.required}
+            picks={c.chosenCoalSources ?? []}
             onPick={(source) => send({ type: 'SELECT_COAL_SOURCE', source })}
           />
         )}
@@ -1409,6 +1422,8 @@ export function ActionDock({
         {choice && (
           <CoalSourcePicker
             options={choice.options}
+            required={choice.required}
+            picks={c.chosenCoalSources ?? []}
             onPick={(source) => send({ type: 'SELECT_COAL_SOURCE', source })}
           />
         )}

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -1245,6 +1245,7 @@ function CityPlate({
       data-city={cityId}
       data-legal={isLegal || undefined}
       data-located={located || undefined}
+      data-hinted={hoverHint || undefined}
       opacity={dimmed && !located ? 0.45 : 1}
       onClick={onClick}
       role={clickable ? 'button' : undefined}

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -29,10 +29,6 @@ import {
 import { explainRefusal } from '~/store/refusal'
 import { refreshEmbeddedTileStats } from '~/store/saveMigration'
 import {
-  pendingBeerChoice,
-  pendingCoalChoice,
-} from '~/store/shared/resourceSources'
-import {
   ActionDock,
   type ConfirmOutcome,
   INDUSTRY_TYPES,
@@ -42,7 +38,6 @@ import {
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from './board/board-map'
 import { CommandPalette } from './command-palette'
 import { demoSnapshot } from './demo/demo-snapshot'
-import { developMatView } from './develop-mat'
 import { demoSnapshotBeerChoice } from './demo/demo-snapshot-beer-choice'
 import { demoSnapshotDoubleBeer } from './demo/demo-snapshot-double-beer'
 import { demoSnapshotEraEnd } from './demo/demo-snapshot-era-end'
@@ -51,18 +46,20 @@ import { demoSnapshotIronChoice } from './demo/demo-snapshot-iron-choice'
 import { demoSnapshotRail } from './demo/demo-snapshot-rail'
 import { demoSnapshotSell } from './demo/demo-snapshot-sell'
 import { demoSnapshotWilds } from './demo/demo-snapshot-wilds'
+import { developMatView } from './develop-mat'
 import { useHandOrder } from './hand-order'
 import { HandTray } from './hand-tray'
 import { computeHoverCities, focusCityFor } from './hover-highlight'
 import { IncomeTrackModal } from './income-track'
-import { legalCityTargets, legalLinkTargets } from './legal-targets'
 import { JournalPanel } from './journal'
+import { legalCityTargets, legalLinkTargets } from './legal-targets'
 import { LocateCityProvider, useLocateCityState } from './locate'
 import { GameOverScreen, PassGate, RoundCurtain } from './overlays'
 import { OpenMatButton, PlayerLedger } from './player-ledger'
 import { PlayerRail } from './player-rail'
 import { SetupScreen } from './setup-screen'
 import { MarketsPanel, SidePanelRail, usePanelCollapsed } from './side-panels'
+import { sourceCandidateCities } from './source-spotlight'
 
 const SAVE_KEY = 'bb2-save-v1'
 
@@ -732,46 +729,10 @@ function GameInner({
     setHoveredCard(null)
   }, [currentPlayer?.id])
 
-  // While the machine is asking WHERE beer comes from — a staged sale's
-  // barrels or the double rail's one — spotlight the places it could come
-  // from; the choice is about the board, so it belongs on it. Gated on the
-  // machine STATE (not on pendingSale) so the double-link beer step lights
-  // up too. Both the question and the answers are the engine's.
-  const beerCandidateCities = useMemo(() => {
-    if (
-      !state.matches('playing.action.selling.choosingBeerSource' as never) &&
-      !state.matches(
-        'playing.action.networking.choosingDoubleLinkBeer' as never,
-      )
-    ) {
-      return null
-    }
-    const choice = pendingBeerChoice(ctx)
-    if (!choice?.hasChoice) return null
-    return new Set<string>(
-      choice.options.map((option) => option.source.location),
-    )
-  }, [state, ctx])
-
-  // Same idea for a coal tie: while the machine is asking WHICH equally-close
-  // mine to drain (a build, a single or a double rail), spotlight the tied
-  // mines on the board. The choice is the engine's; we only render it.
-  const coalCandidateCities = useMemo(() => {
-    if (
-      !state.matches('playing.action.building.choosingCoalSource' as never) &&
-      !state.matches('playing.action.networking.choosingLinkCoal' as never) &&
-      !state.matches(
-        'playing.action.networking.choosingDoubleLinkCoal' as never,
-      )
-    ) {
-      return null
-    }
-    const choice = pendingCoalChoice(ctx)
-    if (!choice?.hasChoice) return null
-    return new Set<string>(
-      choice.options.map((option) => option.source.location),
-    )
-  }, [state, ctx])
+  // While the machine is asking WHERE a resource comes from, the answers are
+  // places — so the map lights them. Question and answers are both the
+  // engine's; the shared seam keeps this identical to the online surface.
+  const sourceCities = useMemo(() => sourceCandidateCities(state), [state])
 
   const boardPrompt = useMemo(() => {
     if (pickingSite) {
@@ -966,13 +927,7 @@ function GameInner({
                 networkColor={
                   needsReveal ? null : PLAYER_FILL[currentPlayer.color]
                 }
-                hoverCities={
-                  needsReveal
-                    ? null
-                    : (beerCandidateCities ??
-                      coalCandidateCities ??
-                      hoverCities)
-                }
+                hoverCities={needsReveal ? null : (sourceCities ?? hoverCities)}
                 locatedCities={locateState.locatedCities}
                 focusCity={
                   locateState.spotlightFocus ??

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -22,24 +22,25 @@ import {
 import { explainRefusal } from '~/store/refusal'
 import { refreshEmbeddedTileStats } from '~/store/saveMigration'
 import { ActionDock, SELLABLE, getHandSelection } from '../action-dock'
-import { developMatView } from '../develop-mat'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
 import { CommandPalette } from '../command-palette'
+import { developMatView } from '../develop-mat'
 import { useHandOrder } from '../hand-order'
 import { HandTray } from '../hand-tray'
 import { computeHoverCities, focusCityFor } from '../hover-highlight'
+import { JournalPanel } from '../journal'
 import { legalCityTargets, legalLinkTargets } from '../legal-targets'
 import { LocateCityProvider, useLocateCityState } from '../locate'
 import { GameOverScreen, RoundCurtain } from '../overlays'
 import { OpenMatButton, PlayerLedger } from '../player-ledger'
 import { PlayerRail } from '../player-rail'
-import { JournalPanel } from '../journal'
 import {
   CollapsiblePanel,
   MarketsPanel,
   SidePanelRail,
   usePanelCollapsed,
 } from '../side-panels'
+import { sourceCandidateCities } from '../source-spotlight'
 import { UNREACHABLE, refusalToShow } from './refusal'
 import { didBecomeMyTurn, playTurnChime, titleForTurn } from './turnNotify'
 import { useInFlight } from './use-in-flight'
@@ -1204,6 +1205,14 @@ function MpTable({
     [pickingLink, pickingSecondLink, state],
   )
 
+  // While the engine is asking WHERE a resource comes from, the answers are
+  // places — so the map lights them, exactly as on the hotseat surface. A
+  // bystander's view carries no staged selection, so nothing lights for them.
+  const sourceCities = useMemo(
+    () => (state ? sourceCandidateCities(state) : null),
+    [state],
+  )
+
   const boardPrompt = useMemo(() => {
     if (!ctx) return null
     if (pickingSite) {
@@ -1454,7 +1463,7 @@ function MpTable({
                 onLinkClick={onLinkClick}
                 networkCities={me ? playerNetworkCities(me) : null}
                 networkColor={me ? PLAYER_FILL[me.color] : null}
-                hoverCities={hoverCities}
+                hoverCities={sourceCities ?? hoverCities}
                 locatedCities={locateState.locatedCities}
                 focusCity={
                   locateState.spotlightFocus ?? focusCityFor(hoveredCard)

--- a/src/components/source-spotlight.test.ts
+++ b/src/components/source-spotlight.test.ts
@@ -1,0 +1,183 @@
+// The map's half of the resource-source question. These pins exist so the two
+// surfaces cannot drift: both feed BoardMap from this one enumeration, and it
+// lights exactly the places the engine put on offer — never a source the engine
+// did not name, and nothing at all outside a source step.
+import { describe, expect, it } from 'vitest'
+import type { GameState, Player } from '~/store/gameStore'
+import { sourceCandidateCities } from './source-spotlight'
+
+type Industry = Player['industries'][number]
+
+const tile = (over: Record<string, unknown> = {}) =>
+  ({
+    beerRequired: 0,
+    coalRequired: 0,
+    ironRequired: 0,
+    incomeAdvancement: 1,
+    ...over,
+  }) as unknown as Industry['tile']
+
+const industry = (
+  type: string,
+  location: string,
+  over: Record<string, unknown> = {},
+): Industry =>
+  ({
+    type,
+    location,
+    flipped: false,
+    level: 1,
+    coalCubesOnTile: 0,
+    ironCubesOnTile: 0,
+    beerBarrelsOnTile: 0,
+    tile: tile(),
+    ...over,
+  }) as unknown as Industry
+
+const player = (
+  id: string,
+  industries: Industry[],
+  links: Array<{ from: string; to: string }> = [],
+): Player =>
+  ({
+    id,
+    name: id,
+    money: 30,
+    income: 0,
+    incomeSpace: 10,
+    victoryPoints: 0,
+    hand: [],
+    industries,
+    links: links.map((l) => ({ ...l, type: 'canal' as const })),
+  }) as unknown as Player
+
+const context = (players: Player[], over: Partial<GameState> = {}): GameState =>
+  ({
+    players,
+    currentPlayerIndex: 0,
+    era: 'canal',
+    merchants: [],
+    selectedTilesForDevelop: [],
+    chosenBeerSources: [],
+    chosenIronSources: [],
+    chosenCoalSources: [],
+    coalMarket: [
+      { price: 1, cubes: 2, maxCubes: 2 },
+      { price: 8, cubes: 0, maxCubes: Number.POSITIVE_INFINITY },
+    ],
+    ironMarket: [
+      { price: 1, cubes: 2, maxCubes: 2 },
+      { price: 6, cubes: 0, maxCubes: Number.POSITIVE_INFINITY },
+    ],
+    ...over,
+  }) as unknown as GameState
+
+/** A snapshot parked in exactly one step. */
+const parkedAt = (path: string, ctx: GameState) => ({
+  matches: (p: never) => (p as unknown as string) === path,
+  context: ctx,
+})
+
+describe('sourceCandidateCities', () => {
+  it('lights both breweries a sale may drink from', () => {
+    const mine = player(
+      'p1',
+      [
+        industry('cotton', 'birmingham', { tile: tile({ beerRequired: 1 }) }),
+        industry('brewery', 'coventry', { beerBarrelsOnTile: 1 }),
+      ],
+      [{ from: 'birmingham', to: 'coventry' }],
+    )
+    const rival = player(
+      'p2',
+      [industry('brewery', 'dudley', { beerBarrelsOnTile: 1 })],
+      [{ from: 'birmingham', to: 'dudley' }],
+    )
+    const ctx = context([mine, rival], {
+      pendingSale: {
+        location: 'birmingham',
+        industryType: 'cotton',
+        merchant: 'oxford',
+      },
+    } as Partial<GameState>)
+
+    const lit = sourceCandidateCities(
+      parkedAt('playing.action.selling.choosingBeerSource', ctx),
+    )
+    expect(lit && [...lit].sort()).toEqual(['coventry', 'dudley'])
+  })
+
+  it('lights the rival iron works on offer but never the market', () => {
+    const mine = player('p1', [
+      industry('iron', 'coalbrookdale', { ironCubesOnTile: 2 }),
+    ])
+    const rival = player('p2', [
+      industry('iron', 'wednesbury', { ironCubesOnTile: 2 }),
+    ])
+    const ctx = context([mine, rival], {
+      pendingIronStep: 'build',
+      selectedIndustryTile: tile({ ironRequired: 1 }),
+    } as unknown as Partial<GameState>)
+
+    const lit = sourceCandidateCities(
+      parkedAt('playing.action.building.choosingIronSource', ctx),
+    )
+    expect(lit && [...lit].sort()).toEqual(['coalbrookdale', 'wednesbury'])
+  })
+
+  it('lights only the mines tied at the nearest distance', () => {
+    const mine = player(
+      'p1',
+      [
+        industry('coal', 'dudley', { coalCubesOnTile: 2 }),
+        // Two links out — never part of the nearest tier, so never lit.
+        industry('coal', 'wolverhampton', { coalCubesOnTile: 2 }),
+      ],
+      [
+        { from: 'birmingham', to: 'dudley' },
+        { from: 'birmingham', to: 'walsall' },
+        { from: 'dudley', to: 'wolverhampton' },
+      ],
+    )
+    const rival = player('p2', [
+      industry('coal', 'walsall', { coalCubesOnTile: 2 }),
+    ])
+    const ctx = context([mine, rival], {
+      pendingCoalStep: 'build',
+      selectedLocation: 'birmingham',
+      selectedIndustryTile: tile({ coalRequired: 1 }),
+    } as unknown as Partial<GameState>)
+
+    const lit = sourceCandidateCities(
+      parkedAt('playing.action.building.choosingCoalSource', ctx),
+    )
+    expect(lit && [...lit].sort()).toEqual(['dudley', 'walsall'])
+  })
+
+  it('lights nothing outside a source step', () => {
+    const ctx = context([
+      player('p1', [industry('coal', 'dudley', { coalCubesOnTile: 2 })]),
+    ])
+    expect(
+      sourceCandidateCities(
+        parkedAt('playing.action.building.selectingLocation', ctx),
+      ),
+    ).toBeNull()
+  })
+
+  it('lights nothing when the engine has only one source to give', () => {
+    const mine = player('p1', [
+      industry('iron', 'coalbrookdale', { ironCubesOnTile: 2 }),
+    ])
+    const ctx = context([mine], {
+      pendingIronStep: 'build',
+      selectedIndustryTile: tile({ ironRequired: 1 }),
+    } as unknown as Partial<GameState>)
+
+    expect(
+      sourceCandidateCities(
+        parkedAt('playing.action.building.choosingIronSource', ctx),
+      ),
+    ).toBeNull()
+  })
+})

--- a/src/components/source-spotlight.ts
+++ b/src/components/source-spotlight.ts
@@ -1,0 +1,78 @@
+// The board half of the resource-source question, shared by both surfaces.
+//
+// While the engine is asking WHERE a resource comes from, every answer is a
+// place — so the map lights the breweries, works and mines on offer. The choice
+// itself stays engine-owned: this reads `pending{Beer,Iron,Coal}Choice` and
+// re-derives no connectivity, ownership or market rule. Sharing the enumeration
+// is what keeps the hotseat and multiplayer shells from drifting apart.
+import type { GameState } from '~/store/gameStore'
+import {
+  pendingBeerChoice,
+  pendingCoalChoice,
+  pendingIronChoice,
+} from '~/store/shared/resourceSources'
+
+/** A live or rebuilt snapshot: the step it is parked in, and its context. */
+export interface SourceStepState {
+  matches: (path: never) => boolean
+  context: GameState
+}
+
+const BEER_STEPS = [
+  'playing.action.selling.choosingBeerSource',
+  'playing.action.networking.choosingDoubleLinkBeer',
+]
+
+const IRON_STEPS = [
+  'playing.action.building.choosingIronSource',
+  'playing.action.developing.choosingIronSource',
+]
+
+const COAL_STEPS = [
+  'playing.action.building.choosingCoalSource',
+  'playing.action.networking.choosingLinkCoal',
+  'playing.action.networking.choosingDoubleLinkCoal',
+]
+
+const inAnyStep = (state: SourceStepState, paths: string[]): boolean =>
+  paths.some((path) => state.matches(path as never))
+
+/**
+ * The cities holding the sources the open step is offering, or null when no
+ * source question is open (or the engine found nothing worth asking).
+ *
+ * In multiplayer a bystander's view has the acting player's staged selection
+ * stripped, so the engine reports no pending choice for them and nothing
+ * lights up — the spotlight cannot leak an opponent's in-progress pick.
+ */
+export function sourceCandidateCities(
+  state: SourceStepState,
+): Set<string> | null {
+  const locations: string[] = []
+
+  if (inAnyStep(state, BEER_STEPS)) {
+    const choice = pendingBeerChoice(state.context)
+    if (choice?.hasChoice) {
+      for (const option of choice.options)
+        locations.push(option.source.location)
+    }
+  } else if (inAnyStep(state, IRON_STEPS)) {
+    const choice = pendingIronChoice(state.context)
+    if (choice?.hasChoice) {
+      for (const option of choice.options) {
+        // Market iron sits off the board — there is no plate to light.
+        if (option.source.kind === 'ironworks') {
+          locations.push(option.source.location)
+        }
+      }
+    }
+  } else if (inAnyStep(state, COAL_STEPS)) {
+    const choice = pendingCoalChoice(state.context)
+    if (choice?.hasChoice) {
+      for (const option of choice.options)
+        locations.push(option.source.location)
+    }
+  }
+
+  return locations.length > 0 ? new Set(locations) : null
+}


### PR DESCRIPTION
## What

While the engine is asking where a resource comes from, every answer is a place — so the map should light them. It already did for beer and coal, but only in the hotseat shell, and never for iron at all.

This moves the enumeration into one shared seam, `src/components/source-spotlight.ts`, and uses it on both surfaces:

- **Multiplayer got no spotlight at all.** `game.tsx` had two inline `useMemo`s for beer and coal; `mp/mp-game.tsx` had neither, so a networked player picked a brewery or a mine with nothing marked on the board.
- **Iron was never spotlit**, on either surface, even though an iron works sits at a named city and the picker offers it by name.
- The coal picker now shows the same **"Coal 1 of 2"** progress line the beer and iron pickers already have, so a double rail's second question does not read as the first one failing to advance.

City plates carry `data-hinted` so the spotlight is assertable in e2e.

## Engine boundary

`sourceCandidateCities` asks the engine's own `pending{Beer,Iron,Coal}Choice` selectors and re-derives no rule — same contract as `legal-targets.ts`. Off-board sources (market iron) light nothing. In multiplayer a bystander's filtered view carries no staged selection, so the engine reports no pending choice for them and nothing lights up — the spotlight cannot leak an opponent's in-progress pick.

## Audit of the wider "let the player choose the source" question

I audited every place a resource is consumed against `ai-docs/brass-birmingham-rules.mdc`, and the choice itself is already engine-owned and complete on `main`:

| Consumption | Choice |
|---|---|
| Sell → beer | `selling.choosingBeerSource` |
| Double rail → beer | `networking.choosingDoubleLinkBeer` |
| Build → iron | `building.choosingIronSource` |
| Develop → iron | `developing.choosingIronSource` |
| Build → coal | `building.choosingCoalSource` |
| Rail link → coal | `networking.choosingLinkCoal` |
| Double rail → coal | `networking.choosingDoubleLinkCoal` |

All seven auto-skip via `always` + a `*ChoiceSatisfied` guard when only one source materially exists, and all three `SELECT_*_SOURCE` events are already in the multiplayer `ALLOWED_EVENTS` whitelist.

Two cases deliberately do **not** prompt, and both are correct under the rules:

- **Coal never offers "mine vs. market".** Coal must come from the closest connected unflipped mine (rules p.3); the market opens only when no connected mine has any, and then only with a connection to a coal-market merchant icon. The single genuine choice is the equal-distance tie ("If multiple Coal Mines are equally close, choose one"), which is what `choosingCoalSource` asks. Market coal still charges the escalating price, cheapest level first.
- **Iron never offers the market as an alternative.** Rules p.5 makes it a fallback, legal only when no unflipped works holds iron. `getIronSourceOptions` stamps it `fallbackOnly`; the choice filters it out and the planner refuses an explicit pick of it.

So the remaining gap was the board half of the mechanic, which is what this PR closes.

## Before / after

The develop-iron step with two rival works on offer. Before, the map says nothing about where Coventry and Dudley are; after, both plates carry the spotlight ring.

**Before**

![Before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr97-before.png)

**After**

![After](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr97-after.png)

## Testing

- `src/components/source-spotlight.test.ts` — new: lights both breweries a sale may drink from, both works a develop may take iron from, only the mines tied at the nearest distance; lights nothing outside a source step and nothing when the engine has a single source to give.
- `e2e/iron-source.spec.ts` — asserts the plates light while the iron picker is open.
- `pnpm test` 780 passed, `pnpm typecheck`, `pnpm lint`, `pnpm build` all green.
- Full Playwright suite: 58 passed. `coverage.spec.ts › Develop: scrap the lowest tile` and `mp-playthrough.spec.ts` fail identically on `main` at `a56916a` (verified in a clean worktree) — pre-existing, untouched here.
