### PR TITLE
feat(mp): personal seat recovery link for every seated player

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1363,7 +1363,12 @@ When updating this file, preserve this bar for all agents and keep entries conci
     (`priorCreds` ref) are restored, and the player keeps the seat they were
     already in; only when there was no prior seat does it show the ONE
     unrevealing join-screen notice (`recovery-rejected`) — never which half was
-    wrong.
+    wrong. GOTCHA: the same effect ALSO listens for `hashchange`, because a link
+    pasted into the address bar of a tab already on `/g/<token>` is a
+    same-document fragment navigation — nothing remounts, so the mount pass
+    alone left the secret sitting in the address bar and the link did nothing.
+    Both entry points go through `consumeRecoveryLink`, so the strip and the
+    unpersisted-until-authenticated rule hold for either.
   - TWO LINKS, OPPOSITE SEMANTICS, and the UI must keep them unmistakable: the
     INVITE link is the only bare URL on screen (the masthead chip, labelled
     "Invite"); the recovery link never renders until the player opens the modal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1351,17 +1351,28 @@ When updating this file, preserve this bar for all agents and keep entries conci
     the existing gate covers it with no second scrubbing path (pinned by a
     mirror of that pattern in `recovery-link.test.ts`). Change the format and
     you must re-check both.
-  - `consumeRecoveryLink` is WRITE-THEN-STRIP and synchronous: localStorage
-    first, then `history.replaceState` (never pushState — Back must not reach
-    the credential), and it runs in `mp-game.tsx`'s FIRST effect, before the
-    stream effect opens an EventSource. Verification is the ordinary seat
-    auth: a bad link yields `you: null`, which shows ONE unrevealing join-screen
-    notice (`recovery-rejected`) — never which half was wrong.
+  - `consumeRecoveryLink` is STRIP-then-VERIFY-then-WRITE and synchronous. It
+    runs in `mp-game.tsx`'s FIRST effect, before the stream effect opens an
+    EventSource: `history.replaceState` (never pushState — Back must not reach
+    the credential) drops ANY fragment — even a malformed, secret-bearing one
+    that fails to parse — so a mangled paste can never leave the secret in the
+    URL. It does NOT persist: the recovered creds are held UNPERSISTED
+    (`recoveredCreds` ref) and only written to `bb-mp-<token>` once the stream
+    authenticates the seat. A bad or stale link must never clobber a working
+    seat's stored secret — so on rejection the browser's PRIOR creds
+    (`priorCreds` ref) are restored, and the player keeps the seat they were
+    already in; only when there was no prior seat does it show the ONE
+    unrevealing join-screen notice (`recovery-rejected`) — never which half was
+    wrong.
   - TWO LINKS, OPPOSITE SEMANTICS, and the UI must keep them unmistakable: the
     INVITE link is the only bare URL on screen (the masthead chip, labelled
     "Invite"); the recovery link never renders until the player opens the modal
     AND reveals it. Different affordance on purpose — do not put them side by
-    side, and do not add a second visible copy of the recovery URL.
+    side, and do not add a second visible copy of the recovery URL. The invite
+    affordances (`ShareLink`, `InviteCallout`) build their URL from
+    `inviteUrl()` (origin + path only), never `location.href` — a structural
+    guarantee the invite can never carry a fragment or query even if a stray
+    one lingered in the address bar.
   - Surfaced at claim time as an inline lobby card (`SeatKeyNotice`, dismissal
     remembered under its OWN key `bb-mp-seatkey-seen-<token>`) — NOT a modal:
     the host claims seat 0 at creation and never passes the join screen, so the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1336,6 +1336,46 @@ When updating this file, preserve this bar for all agents and keep entries conci
   only the credentialed SSE stream may clear creds on `you: null` — a late
   frame from the previous unauthenticated stream must not wipe freshly-claimed
   credentials (race fixed 2026-07-13).
+- PERSONAL RECOVERY LINK / "seat key" (2026-07-24): every seated player can
+  restore their OWN seat on another device. It is the EXISTING per-seat secret
+  in a URL — no new credential, no new endpoint, no schema change; the whole
+  feature is client-side (`components/mp/recovery-link.ts` + `seat-key.tsx`)
+  and the server never learns a link was used. Complementary to the
+  release-and-reclaim model above, which stays the fallback for a key that is
+  also gone (releasing a seat still kills its old link).
+  - THE SECRET RIDES IN THE URL FRAGMENT (`/g/<token>#seat=N&secret=…`), never
+    the query string: a fragment is not sent to the origin, so it cannot reach
+    a request log or a `Referer`. A `?secret=` link would land in Vercel's
+    access log on the first hit. The `secret=…` SHAPE is deliberate — it is
+    what `sentry-scrub.ts`'s `scrubText`/`scrubQueryString` already redact, so
+    the existing gate covers it with no second scrubbing path (pinned by a
+    mirror of that pattern in `recovery-link.test.ts`). Change the format and
+    you must re-check both.
+  - `consumeRecoveryLink` is WRITE-THEN-STRIP and synchronous: localStorage
+    first, then `history.replaceState` (never pushState — Back must not reach
+    the credential), and it runs in `mp-game.tsx`'s FIRST effect, before the
+    stream effect opens an EventSource. Verification is the ordinary seat
+    auth: a bad link yields `you: null`, which shows ONE unrevealing join-screen
+    notice (`recovery-rejected`) — never which half was wrong.
+  - TWO LINKS, OPPOSITE SEMANTICS, and the UI must keep them unmistakable: the
+    INVITE link is the only bare URL on screen (the masthead chip, labelled
+    "Invite"); the recovery link never renders until the player opens the modal
+    AND reveals it. Different affordance on purpose — do not put them side by
+    side, and do not add a second visible copy of the recovery URL.
+  - Surfaced at claim time as an inline lobby card (`SeatKeyNotice`, dismissal
+    remembered under its OWN key `bb-mp-seatkey-seen-<token>`) — NOT a modal:
+    the host claims seat 0 at creation and never passes the join screen, so the
+    lobby is the one place that covers everyone. GOTCHA that bit once: the
+    auto-modal is armed ONLY for a seat claimed MID-GAME
+    (`view.phase !== 'lobby'`); arming it for a lobby joiner leaves the flag set
+    when the game starts and drops a full-screen `bb2-curtain` over the board
+    (it intercepts every dock click — `multiplayer.spec.ts` catches it).
+  - Pinned by `components/mp/recovery-link.test.ts` (offline: format, scrubbing,
+    malformed input, invite-vs-recovery), the `personal seat recovery links`
+    block in `gameStore.multiplayer.test.ts` (wire: every seat round-trips,
+    restored creds can act, tampered refused identically, invite grants no
+    occupied seat, release kills the link) and `e2e/seat-recovery.spec.ts`
+    (real clean browser profile, address bar + history + DOM).
 - In-flight "syncing" indicator (2026-07-15): because there is NO optimistic
   UI, `mp/use-in-flight.ts` tracks each intent from `send()`'s POST until its
   settling SSE frame. An intent is settled when a frame arrives with a

--- a/e2e/seat-recovery.spec.ts
+++ b/e2e/seat-recovery.spec.ts
@@ -178,9 +178,86 @@ test('a seat is restored in a clean browser from its recovery link, and the secr
   expect(await forged.evaluate(() => location.hash)).toBe('')
   expect(forged.url()).not.toContain(flipped)
 
+  /* ---- a refused link is a NO-OP for a player already in their seat ---- */
+  // Anyone holding the public game token can craft a link for any seat, so the
+  // recovered credentials stay unpersisted until the server accepts them. On a
+  // refusal the browser's own credentials are restored and the player keeps
+  // playing — the seat they already hold is never the casualty of a bad paste.
+  const token = gameUrl.split('/g/')[1]!
+  const storedBefore = await guest.evaluate(
+    (t) => localStorage.getItem(`bb-mp-${t}`),
+    token,
+  )
+  await guest.goto(`${gameUrl}#seat=1&secret=${flipped}`)
+  await expect(guest.getByTestId('lobby-seat-1')).toContainText('Brunel')
+  await expect(guest.getByTestId('lobby-seat-1')).toContainText('you')
+  await expect(guest.getByTestId('join-seat')).toHaveCount(0)
+  expect(
+    await guest.evaluate((t) => localStorage.getItem(`bb-mp-${t}`), token),
+  ).toBe(storedBefore)
+  expect(await guest.evaluate(() => location.hash)).toBe('')
+
   await Promise.all(
     [hostCtx, guestCtx, restoredCtx, strangerCtx, forgedCtx].map((c) =>
       c.close(),
     ),
   )
+})
+
+test('a seat claimed after the game starts gets its key as a modal, and the board is usable once it closes', async ({
+  browser,
+}) => {
+  /* ---- a live two-player game ---- */
+  const hostCtx = await browser.newContext()
+  const host = await hostCtx.newPage()
+  await host.goto('/?fresh=1')
+  await host.getByTestId('mode-online').click()
+  await host.getByTestId('name-0').fill('Ada')
+  await host.getByRole('button', { name: '2', exact: true }).click()
+  await host.getByTestId('create-online').click()
+  await host.waitForURL(/\/g\/[A-Za-z0-9_-]{20,}/)
+  const gameUrl = host.url()
+
+  const guestCtx = await browser.newContext()
+  const guest = await guestCtx.newPage()
+  await guest.goto(gameUrl)
+  await guest.getByTestId('join-name').fill('Brunel')
+  await guest.getByTestId('join-seat').click()
+
+  await host.getByTestId('lobby-ready-toggle').click()
+  await guest.getByTestId('lobby-ready-toggle').click()
+  await expect(host.getByTestId('lobby-start')).toBeEnabled()
+  await host.getByTestId('lobby-start').click()
+  await expect(host.getByTestId('era-plate')).toHaveText('canal era')
+
+  /* ---- seat 1 is released and re-claimed mid-game ---- */
+  // This path skips the lobby, so it never meets the inline notice: the key is
+  // offered as a modal instead. Its condition is the one worth pinning — armed
+  // for a lobby claim, the flag survives into the started game and drops a
+  // full-screen curtain over the board.
+  await host.getByTestId('seats-button').click()
+  await host.getByTestId('release-1').click()
+  await expect(host.getByTestId('seats-overlay')).toBeVisible()
+
+  const retakenCtx = await browser.newContext()
+  const retaken = await retakenCtx.newPage()
+  await retaken.goto(gameUrl)
+  await retaken.getByTestId('join-name').fill('Telford')
+  await retaken.getByTestId('join-seat').click()
+
+  await expect(retaken.getByTestId('seat-key-modal')).toBeVisible()
+  await expect(retaken.getByTestId('seat-key-warning')).toContainText(
+    'anyone with this link can take your seat',
+  )
+  await retaken.getByTestId('seat-key-close').click()
+  await expect(retaken.getByTestId('seat-key-modal')).toHaveCount(0)
+
+  // Nothing is left covering the table: a real click reaches the chrome (a
+  // lingering curtain would intercept it), and the key is still retrievable.
+  await expect(retaken.getByTestId('era-plate')).toHaveText('canal era')
+  await retaken.getByTestId('chat-toggle').click()
+  await expect(retaken.getByTestId('chat-list')).toBeVisible()
+  await expect(retaken.getByTestId('seat-key-button')).toBeVisible()
+
+  await Promise.all([hostCtx, guestCtx, retakenCtx].map((c) => c.close()))
 })

--- a/e2e/seat-recovery.spec.ts
+++ b/e2e/seat-recovery.spec.ts
@@ -64,6 +64,19 @@ test('a seat is restored in a clean browser from its recovery link, and the secr
   // screen, and is nudged all the same.
   await expect(host.getByTestId('seat-key-notice')).toBeVisible()
 
+  /* ---- lobby hierarchy: the INVITE outranks the seat key ---- */
+  // Prominence must track shareability. While a seat is open, filling it is
+  // the task, so the invite is the primary card and carries the only bright
+  // button of the pair; the seat key stays a quiet secondary row. Inverting
+  // these teaches players to send the credential — pinned here so it cannot
+  // regress silently.
+  await expect(host.getByTestId('invite-callout')).toBeVisible()
+  await expect(host.getByTestId('invite-link-text')).toContainText(gameUrl)
+  await expect(host.getByTestId('share-link')).toHaveClass(/bb2-confirm/)
+  await expect(host.getByTestId('seat-key-notice-open')).not.toHaveClass(
+    /bb2-confirm/,
+  )
+
   /* ---- guest joins; the seat key is offered at claim time, unprompted ---- */
   const guestCtx = await browser.newContext()
   const guest = await guestCtx.newPage()
@@ -87,6 +100,11 @@ test('a seat is restored in a clean browser from its recovery link, and the secr
   // Acknowledged: the nudge is gone, but the key is not.
   await expect(guest.getByTestId('seat-key-notice')).toHaveCount(0)
   await expect(guest.getByTestId('seat-key-button')).toBeVisible()
+
+  // …and once the table is full there is nobody left to invite, so the callout
+  // stands down to the compact chip rather than shouting at a closed lobby.
+  await expect(host.getByTestId('invite-callout')).toHaveCount(0)
+  await expect(host.getByTestId('share-link')).toBeVisible()
 
   /* ---- and it is retrievable LATER, which is the whole point ---- */
   const guestKey = await readSeatKey(guestCtx, gameUrl)

--- a/e2e/seat-recovery.spec.ts
+++ b/e2e/seat-recovery.spec.ts
@@ -1,0 +1,168 @@
+import {
+  type BrowserContext,
+  expect as baseExpect,
+  test,
+} from '@playwright/test'
+import { NEEDS_DB_MESSAGE, hasDatabaseUrl } from './db-available'
+
+// Every assertion waits on a real POST + SSE round-trip against a real
+// network database; on a contended machine those outlast the 5s default.
+const expect = baseExpect.configure({ timeout: 15_000 })
+
+/**
+ * Personal SEAT RECOVERY LINK, in real browsers.
+ *
+ * The unit tests pin the link format and the scrubbing logic
+ * (`src/components/mp/recovery-link.test.ts`); the wire tests pin the seat
+ * auth (`gameStore.multiplayer.test.ts`). What only a browser can prove is
+ * the part that actually protects the player:
+ *
+ *  - a seat restored in a genuinely CLEAN browser profile (fresh context =
+ *    empty localStorage), from the link alone;
+ *  - the secret GONE from the address bar and from session history the
+ *    moment it is consumed;
+ *  - an invite link opened in a clean profile granting nothing, because
+ *    every seat is taken;
+ *  - a tampered link refused with one unrevealing message.
+ */
+
+test.skip(!hasDatabaseUrl, `seat-recovery e2e ${NEEDS_DB_MESSAGE}`)
+test.setTimeout(120_000)
+
+/** The recovery link as the player would copy it out of the seat-key modal. */
+async function readSeatKey(ctx: BrowserContext, gameUrl: string) {
+  const page = ctx.pages()[0]!
+  await page.getByTestId('seat-key-button').click()
+  const link = page.getByTestId('seat-key-link')
+  // Masked until explicitly revealed — a screenshot or a shared screen must
+  // not leak the seat by default.
+  await expect(link).toHaveAttribute('data-revealed', 'false')
+  await expect(link).not.toContainText(gameUrl)
+  await page.getByTestId('seat-key-reveal').click()
+  await expect(link).toHaveAttribute('data-revealed', 'true')
+  const href = (await link.textContent())!.trim()
+  await page.getByTestId('seat-key-close').click()
+  return href
+}
+
+test('a seat is restored in a clean browser from its recovery link, and the secret never lingers', async ({
+  browser,
+}) => {
+  /* ---- host creates an online table ---- */
+  const hostCtx = await browser.newContext()
+  const host = await hostCtx.newPage()
+  await host.goto('/?fresh=1')
+  await host.getByTestId('mode-online').click()
+  await host.getByTestId('name-0').fill('Ada')
+  await host.getByRole('button', { name: '2', exact: true }).click()
+  await host.getByTestId('create-online').click()
+  await host.waitForURL(/\/g\/[A-Za-z0-9_-]{20,}/)
+  const gameUrl = host.url()
+  await expect(host.getByText('Waiting to begin')).toBeVisible()
+
+  // The HOST claims seat 0 at creation without passing through the join
+  // screen, and is nudged all the same.
+  await expect(host.getByTestId('seat-key-notice')).toBeVisible()
+
+  /* ---- guest joins; the seat key is offered at claim time, unprompted ---- */
+  const guestCtx = await browser.newContext()
+  const guest = await guestCtx.newPage()
+  await guest.goto(gameUrl)
+  await guest.getByTestId('join-name').fill('Brunel')
+  await guest.getByTestId('join-seat').click()
+
+  // Claim-time nudge, without blocking the lobby controls behind it.
+  await expect(guest.getByTestId('seat-key-notice')).toBeVisible()
+  await expect(guest.getByTestId('lobby-ready-toggle')).toBeEnabled()
+  await guest.getByTestId('seat-key-notice-open').click()
+  await expect(guest.getByTestId('seat-key-warning')).toContainText(
+    'anyone with this link can take your seat',
+  )
+  // …and it says outright that this is NOT the shareable link.
+  await expect(guest.getByTestId('seat-key-vs-invite')).toContainText(
+    'This is not the invite link',
+  )
+  await guest.getByTestId('seat-key-close').click()
+  await expect(guest.getByTestId('seat-key-modal')).toHaveCount(0)
+  // Acknowledged: the nudge is gone, but the key is not.
+  await expect(guest.getByTestId('seat-key-notice')).toHaveCount(0)
+  await expect(guest.getByTestId('seat-key-button')).toBeVisible()
+
+  /* ---- and it is retrievable LATER, which is the whole point ---- */
+  const guestKey = await readSeatKey(guestCtx, gameUrl)
+  expect(guestKey.startsWith(`${gameUrl}#`)).toBe(true)
+  expect(guestKey).toContain('secret=')
+
+  // The HOST — not just the joiner — has one too.
+  const hostKey = await readSeatKey(hostCtx, gameUrl)
+  expect(hostKey.startsWith(`${gameUrl}#`)).toBe(true)
+  expect(hostKey).not.toBe(guestKey)
+
+  /* ---- the guest's seat, restored in a clean profile ---- */
+  const restoredCtx = await browser.newContext()
+  const restored = await restoredCtx.newPage()
+  await restored.goto(guestKey)
+
+  // Seated as Brunel (seat 1) without ever touching the join form.
+  await expect(restored.getByTestId('lobby-seat-1')).toContainText('Brunel')
+  await expect(restored.getByTestId('lobby-seat-1')).toContainText('you')
+  await expect(restored.getByTestId('join-seat')).toHaveCount(0)
+
+  /* ---- the secret is gone from the URL, from history, and from the DOM ---- */
+  const secret = new URL(guestKey).hash.split('secret=')[1]!
+  expect(secret.length).toBeGreaterThan(8)
+
+  const url = restored.url()
+  expect(url).toBe(gameUrl)
+  expect(url).not.toContain(secret)
+  expect(await restored.evaluate(() => location.hash)).toBe('')
+  // …and the visible page never renders it either (the modal is closed).
+  expect(await restored.content()).not.toContain(secret)
+
+  // It really is the same credential: the stored seat matches the link.
+  const stored = await restored.evaluate((token) => {
+    return localStorage.getItem(`bb-mp-${token}`)
+  }, gameUrl.split('/g/')[1]!)
+  expect(JSON.parse(stored!)).toMatchObject({ seatId: 1 })
+
+  // replaceState, not pushState: stepping back cannot land on the
+  // secret-bearing URL, because that history entry was overwritten rather
+  // than added. (The context's own opening blank page is the only entry
+  // behind it, so `history.length` alone would not prove this.)
+  await restored.goBack().catch(() => null)
+  expect(restored.url()).not.toContain(secret)
+
+  /* ---- the INVITE link, in a clean profile, grants nothing ---- */
+  // Same table, same URL — minus the fragment. Every seat is claimed, so a
+  // stranger holding it is offered no seat at all.
+  const strangerCtx = await browser.newContext()
+  const stranger = await strangerCtx.newPage()
+  await stranger.goto(gameUrl)
+  await expect(stranger.getByText('All seats are taken')).toBeVisible()
+  await expect(stranger.getByTestId('join-seat')).toHaveCount(0)
+  await expect(stranger.getByTestId('lobby-ready-toggle')).toHaveCount(0)
+
+  /* ---- a tampered recovery link is refused, unrevealingly ---- */
+  const forgedCtx = await browser.newContext()
+  const forged = await forgedCtx.newPage()
+  const flipped = secret.startsWith('a')
+    ? `b${secret.slice(1)}`
+    : `a${secret.slice(1)}`
+  await forged.goto(`${gameUrl}#seat=1&secret=${flipped}`)
+  await expect(forged.getByTestId('recovery-rejected')).toBeVisible()
+  // The message names no seat, no player and no reason beyond "did not work".
+  const refusal = (await forged.getByTestId('recovery-rejected').textContent())!
+  expect(refusal).toContain('did not work')
+  expect(refusal).not.toContain('Brunel')
+  expect(refusal).not.toContain('secret')
+  // The forged secret is dropped from the URL too — a bad credential must not
+  // linger in the address bar any more than a good one.
+  expect(await forged.evaluate(() => location.hash)).toBe('')
+  expect(forged.url()).not.toContain(flipped)
+
+  await Promise.all(
+    [hostCtx, guestCtx, restoredCtx, strangerCtx, forgedCtx].map((c) =>
+      c.close(),
+    ),
+  )
+})

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -313,6 +313,9 @@ export function MpGame({ token }: { token: string }) {
         setCreds(null)
         return
       }
+      // The link was accepted. Disarm, so that a LATER rejection on this same
+      // session — a peer releasing the seat mid-game — reports itself the
+      // ordinary way instead of blaming a recovery link that in fact worked.
       if (recoveryPending.current && parsed.you !== null) {
         recoveryPending.current = false
       }
@@ -590,6 +593,7 @@ function LobbyScreen({
     view.you !== null
       ? view.seats.find((s) => s.seatId === view.you)
       : undefined
+  const openSeats = view.seats.filter((s) => !s.claimed).length
   const allClaimed = view.seats.every((s) => s.claimed)
   const allReady = view.seats.every((s) => s.ready)
   const canStart = allClaimed && allReady
@@ -692,7 +696,11 @@ function LobbyScreen({
       >
         {view.name?.trim() ? view.name : 'Waiting to begin'}
       </h1>
-      <ShareLink />
+      {/* While seats are open, filling them IS the task — so the invite is the
+          lobby's primary affordance, outranking the seat key below it. Once
+          the table is full there is nobody left to invite and it drops back to
+          the compact chip. See the note on InviteCallout. */}
+      {openSeats > 0 ? <InviteCallout openSeats={openSeats} /> : <ShareLink />}
       <div
         className="text-[12px]"
         style={{ color: 'rgba(231,215,177,.55)' }}
@@ -936,6 +944,70 @@ function ShareLink({ className }: { className?: string }) {
         {copied ? 'Invite link copied!' : window.location.href}
       </span>
     </button>
+  )
+}
+
+/**
+ * The lobby's PRIMARY affordance while seats are still open: a real card with
+ * the invite URL and an obvious copy button.
+ *
+ * WHY IT OUTRANKS THE SEAT KEY (2026-07-24 review). Prominence has to track
+ * SHAREABILITY. When the seat key was the biggest gold panel on the lobby and
+ * the invite was a thin pill, the layout taught the wrong safety lesson — the
+ * credential looked like the thing to send and the genuinely shareable link
+ * looked like a footnote. That is the same invite-vs-recovery confusion this
+ * feature guards against in its copy, showing up as styling. So: the invite
+ * looks shareable, the seat key looks guarded (SeatKeyNotice is deliberately
+ * calm — do not re-promote it here).
+ *
+ * Scoped to the lobby. In the live game the invite is no longer the call to
+ * action and the compact masthead `ShareLink` chip is right.
+ */
+function InviteCallout({ openSeats }: { openSeats: number }) {
+  const [copied, setCopied] = useState(false)
+  const url = typeof window === 'undefined' ? '' : window.location.href
+  return (
+    <div
+      className="bb2-panel bb2-panel-active mt-1 flex w-full max-w-sm flex-col gap-2.5 p-5"
+      data-testid="invite-callout"
+    >
+      <span className="bb2-panel-title">
+        Invite {openSeats === 1 ? 'a player' : 'players'}
+      </span>
+      <p className="text-[12.5px]" style={{ color: 'var(--bb-parchment)' }}>
+        {openSeats === 1
+          ? 'One seat is still open.'
+          : `${openSeats} seats are still open.`}{' '}
+        Send this link — whoever opens it claims a seat.
+      </p>
+      <code
+        className="block break-all rounded border px-3 py-2 text-[11.5px] leading-snug"
+        data-testid="invite-link-text"
+        style={{
+          borderColor: 'rgba(231,215,177,.18)',
+          background: 'rgba(0,0,0,.25)',
+          color: 'var(--bb-parchment)',
+        }}
+      >
+        {url}
+      </code>
+      <button
+        type="button"
+        className="bb2-confirm w-full"
+        data-testid="share-link"
+        onClick={() => {
+          void navigator.clipboard?.writeText(url)
+          setCopied(true)
+          setTimeout(() => setCopied(false), 2000)
+        }}
+      >
+        {copied ? 'Invite link copied!' : 'Copy invite link'}
+      </button>
+      <p className="text-[11.5px]" style={{ color: 'rgba(231,215,177,.5)' }}>
+        Safe to share anywhere — it only offers an open seat, never anyone
+        else's.
+      </p>
+    </div>
   )
 }
 

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -41,7 +41,9 @@ import {
   usePanelCollapsed,
 } from '../side-panels'
 import { sourceCandidateCities } from '../source-spotlight'
+import { consumeRecoveryLink, credsKey } from './recovery-link'
 import { UNREACHABLE, refusalToShow } from './refusal'
+import { SeatKeyButton, SeatKeyModal, SeatKeyNotice } from './seat-key'
 import { didBecomeMyTurn, playTurnChime, titleForTurn } from './turnNotify'
 import { useInFlight } from './use-in-flight'
 
@@ -116,8 +118,6 @@ interface Creds {
   seatId: number
   seatSecret: string
 }
-
-const credsKey = (token: string) => `bb-mp-${token}`
 
 /** Keep the client's chat memory bounded; the recent tail on a full frame is
  *  smaller than this, so a reconnect never loses already-seen lines. */
@@ -194,6 +194,21 @@ function rehydrate(snapshot: unknown): unknown {
 export function MpGame({ token }: { token: string }) {
   const [creds, setCreds] = useState<Creds | null>(null)
   const [credsLoaded, setCredsLoaded] = useState(false)
+  // Set while a seat restored from a recovery link is still unverified, so the
+  // stream's ordinary accept/reject can be reported to the player who pasted
+  // it (otherwise a bad link silently shows the join screen). Verification is
+  // the EXISTING seat-secret check on the server — nothing new authenticates
+  // here, and the refusal never says which half of the link was wrong.
+  const recoveryPending = useRef(false)
+  /** A consumed recovery link the server would not authenticate. Rendered as
+   *  ONE message on the join screen for every failure mode (wrong seat,
+   *  tampered secret, seat since released) — it must not narrow down which. */
+  const [recoveryRejected, setRecoveryRejected] = useState(false)
+  // Set ONLY for a seat claimed mid-game (a released seat re-taken), which
+  // skips the lobby and therefore the inline SeatKeyNotice. A lobby joiner
+  // must NOT set this: the flag would survive into the started game and put a
+  // full-screen modal over the board on the first turn.
+  const [seatKeyAtClaim, setSeatKeyAtClaim] = useState(false)
   const [view, setView] = useState<GameViewWire | null>(null)
   const [streamFailing, setStreamFailing] = useState(false)
   // The SSE stream drives a ~1.2s server-side DB poll for its whole lifetime.
@@ -203,8 +218,15 @@ export function MpGame({ token }: { token: string }) {
   // frame on reopen is the full current view, so nothing is missed.
   const [streamPaused, setStreamPaused] = useState(false)
 
+  // FIRST effect on purpose: a recovery link must be consumed — credentials
+  // persisted, secret stripped out of the address bar — before the stream
+  // effect below opens an EventSource, so the secret can never ride a request
+  // or a Referer header. Both halves are synchronous inside
+  // `consumeRecoveryLink`; the fragment never reached the server to begin with.
   useEffect(() => {
-    setCreds(loadCreds(token))
+    const recovered = consumeRecoveryLink(token, window)
+    if (recovered) recoveryPending.current = true
+    setCreds(recovered ?? loadCreds(token))
     setCredsLoaded(true)
   }, [token])
 
@@ -284,8 +306,15 @@ export function MpGame({ token }: { token: string }) {
         // this credentialed stream was rejected: the seat was released or
         // the secret is stale → back to claiming
         localStorage.removeItem(credsKey(token))
+        if (recoveryPending.current) {
+          recoveryPending.current = false
+          setRecoveryRejected(true)
+        }
         setCreds(null)
         return
+      }
+      if (recoveryPending.current && parsed.you !== null) {
+        recoveryPending.current = false
       }
       applyView(parsed)
     }
@@ -354,20 +383,39 @@ export function MpGame({ token }: { token: string }) {
       <JoinScreen
         token={token}
         view={view}
+        recoveryRejected={recoveryRejected}
         onJoined={(c) => {
           localStorage.setItem(credsKey(token), JSON.stringify(c))
           setCreds(c)
+          setRecoveryRejected(false)
+          setSeatKeyAtClaim(view.phase !== 'lobby')
         }}
       />
     )
   }
 
   if (view.phase === 'lobby') {
+    // The lobby carries the claim-time nudge inline (SeatKeyNotice) for every
+    // seated player, host included — no modal needed, and nothing on top of
+    // the ready/start controls.
     return <LobbyScreen token={token} view={view} creds={creds} />
   }
 
   return (
-    <MpTable token={token} view={view} creds={creds!} applyView={applyView} />
+    <>
+      <MpTable token={token} view={view} creds={creds!} applyView={applyView} />
+      {/* Claiming a seat MID-GAME (a released seat re-taken) skips the lobby
+          entirely, so that one path gets the modal instead. Dismissible, and
+          the Seat key button in the masthead brings it back. */}
+      {seatKeyAtClaim && creds && (
+        <SeatKeyModal
+          token={token}
+          creds={creds}
+          atClaim
+          onClose={() => setSeatKeyAtClaim(false)}
+        />
+      )}
+    </>
   )
 }
 
@@ -408,10 +456,12 @@ function GoneScreen() {
 function JoinScreen({
   token,
   view,
+  recoveryRejected,
   onJoined,
 }: {
   token: string
   view: GameViewWire
+  recoveryRejected: boolean
   onJoined: (creds: Creds) => void
 }) {
   const [name, setName] = useState('')
@@ -451,6 +501,20 @@ function JoinScreen({
       </h1>
       <div className="bb2-panel mt-4 flex w-full max-w-sm flex-col gap-4 p-6">
         <span className="bb2-panel-title">Claim a seat</span>
+        {recoveryRejected && (
+          <p
+            className="rounded border px-3 py-2 text-[12.5px]"
+            data-testid="recovery-rejected"
+            style={{
+              borderColor: 'rgba(214, 92, 62, .55)',
+              background: 'rgba(214, 92, 62, .12)',
+              color: 'var(--bb-parchment-bright)',
+            }}
+          >
+            That seat key did not work for this table. Take an open seat below,
+            or ask a player at the table to release yours first.
+          </p>
+        )}
         <div className="flex flex-col gap-1.5">
           {view.seats.map((s) => (
             <div
@@ -738,7 +802,13 @@ function LobbyScreen({
       )}
 
       {isSeated && creds && (
-        <SeatsButton token={token} creds={creds} seats={view.seats} />
+        <>
+          <SeatKeyNotice token={token} creds={creds} />
+          <div className="flex items-start gap-2">
+            <SeatsButton token={token} creds={creds} seats={view.seats} />
+            <SeatKeyButton token={token} creds={creds} />
+          </div>
+        </>
       )}
 
       {!isHost && (
@@ -823,8 +893,9 @@ function SeatsButton({
             className="text-[10.5px]"
             style={{ color: 'rgba(231,215,177,.45)' }}
           >
-            Release a seat if its player lost their link or browser — even the
-            host's — so they can claim it again from the invite link.
+            A player who still has their seat key can just open it to get back
+            in. Release a seat only when that is gone too — even the host's — so
+            it can be claimed again from the invite link.
           </p>
         </div>
       )}
@@ -845,14 +916,24 @@ function ShareLink({ className }: { className?: string }) {
         setCopied(true)
         setTimeout(() => setCopied(false), 2000)
       }}
-      title="Copy the invite link"
+      title="Copy the invite link — safe to share, it only offers an open seat"
     >
+      {/* The ONLY bare URL on screen is this public one, so "the link you can
+          grab" is always the safe one; the private seat key lives behind a
+          button and a reveal (see seat-key.tsx). The label makes the pair
+          textually distinct rather than two lookalike URLs side by side. */}
+      <span
+        className="flex-none text-[9px] font-bold uppercase tracking-[0.16em]"
+        style={{ color: 'var(--bb-brass-bright)' }}
+      >
+        Invite
+      </span>
       {/* The invite URL can be long (token + a deploy-preview host). Let it
           ellipsis-truncate on phones so it can never force the masthead wider
           than the viewport; the full URL still shows from lg up (unchanged)
           and is always copied in full. */}
       <span className="min-w-0 truncate">
-        {copied ? 'Link copied!' : window.location.href}
+        {copied ? 'Invite link copied!' : window.location.href}
       </span>
     </button>
   )
@@ -1432,7 +1513,10 @@ function MpTable({
               </button>
             )}
             {you !== null && (
-              <SeatsButton token={token} creds={creds} seats={view.seats} />
+              <>
+                <SeatsButton token={token} creds={creds} seats={view.seats} />
+                <SeatKeyButton token={token} creds={creds} />
+              </>
             )}
             <ShareLink className="max-w-[52vw] sm:max-w-[240px] lg:max-w-none" />
           </div>

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -232,17 +232,29 @@ export function MpGame({ token }: { token: string }) {
   // The strip is synchronous inside `consumeRecoveryLink`; the recovered creds
   // stay unpersisted until the stream authenticates the seat (see below).
   useEffect(() => {
-    const recovered = consumeRecoveryLink(window)
-    const existing = loadCreds(token)
-    if (recovered) {
+    const arm = (recovered: Creds) => {
       recoveryPending.current = true
       recoveredCreds.current = recovered
-      priorCreds.current = existing
+      priorCreds.current = loadCreds(token)
       setCreds(recovered)
-    } else {
-      setCreds(existing)
     }
+
+    const recovered = consumeRecoveryLink(window)
+    if (recovered) arm(recovered)
+    else setCreds(loadCreds(token))
     setCredsLoaded(true)
+
+    // A recovery link pasted into the address bar of a tab ALREADY on this
+    // game is a same-document fragment navigation: nothing remounts, so the
+    // mount pass alone would leave the secret in the address bar and the link
+    // would do nothing. `consumeRecoveryLink` strips either way, so even a
+    // fragment too malformed to parse is scrubbed here.
+    const onHashChange = () => {
+      const fromHash = consumeRecoveryLink(window)
+      if (fromHash) arm(fromHash)
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
   }, [token])
 
   // Pause the live stream on a persistently hidden tab (60s grace, so a quick

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -200,6 +200,14 @@ export function MpGame({ token }: { token: string }) {
   // the EXISTING seat-secret check on the server — nothing new authenticates
   // here, and the refusal never says which half of the link was wrong.
   const recoveryPending = useRef(false)
+  // Credentials parsed from a recovery link, held UNPERSISTED until the server
+  // authenticates the seat. Only then are they written to storage — a bad or
+  // stale link must never overwrite a working seat's stored secret.
+  const recoveredCreds = useRef<Creds | null>(null)
+  // Whatever valid credentials this browser already held for the game before a
+  // recovery link was opened. If the link fails to authenticate, these are
+  // restored so the player keeps the seat they were already in.
+  const priorCreds = useRef<Creds | null>(null)
   /** A consumed recovery link the server would not authenticate. Rendered as
    *  ONE message on the join screen for every failure mode (wrong seat,
    *  tampered secret, seat since released) — it must not narrow down which. */
@@ -218,15 +226,22 @@ export function MpGame({ token }: { token: string }) {
   // frame on reopen is the full current view, so nothing is missed.
   const [streamPaused, setStreamPaused] = useState(false)
 
-  // FIRST effect on purpose: a recovery link must be consumed — credentials
-  // persisted, secret stripped out of the address bar — before the stream
-  // effect below opens an EventSource, so the secret can never ride a request
-  // or a Referer header. Both halves are synchronous inside
-  // `consumeRecoveryLink`; the fragment never reached the server to begin with.
+  // FIRST effect on purpose: a recovery link must be consumed — the secret
+  // stripped out of the address bar — before the stream effect below opens an
+  // EventSource, so the secret can never ride a request or a Referer header.
+  // The strip is synchronous inside `consumeRecoveryLink`; the recovered creds
+  // stay unpersisted until the stream authenticates the seat (see below).
   useEffect(() => {
-    const recovered = consumeRecoveryLink(token, window)
-    if (recovered) recoveryPending.current = true
-    setCreds(recovered ?? loadCreds(token))
+    const recovered = consumeRecoveryLink(window)
+    const existing = loadCreds(token)
+    if (recovered) {
+      recoveryPending.current = true
+      recoveredCreds.current = recovered
+      priorCreds.current = existing
+      setCreds(recovered)
+    } else {
+      setCreds(existing)
+    }
     setCredsLoaded(true)
   }, [token])
 
@@ -303,21 +318,45 @@ export function MpGame({ token }: { token: string }) {
       setStreamFailing(false)
       const parsed = JSON.parse(e.data as string) as GameViewWire
       if (myCreds && parsed.you === null) {
-        // this credentialed stream was rejected: the seat was released or
-        // the secret is stale → back to claiming
-        localStorage.removeItem(credsKey(token))
+        // This credentialed stream was rejected: the seat was released or the
+        // secret is stale.
         if (recoveryPending.current) {
           recoveryPending.current = false
+          const prior = priorCreds.current
+          recoveredCreds.current = null
+          priorCreds.current = null
+          if (prior) {
+            // The link did not authenticate, but this browser already held a
+            // working seat here — restore it rather than evicting the player.
+            // The recovered creds were never persisted, so storage still holds
+            // `prior`; rewrite it to be robust and re-open the stream with it.
+            localStorage.setItem(credsKey(token), JSON.stringify(prior))
+            setCreds(prior)
+            return
+          }
+          // No seat to fall back to: surface the one unrevealing notice.
+          localStorage.removeItem(credsKey(token))
           setRecoveryRejected(true)
+          setCreds(null)
+          return
         }
+        // Ordinary mid-session rejection (seat released or secret stale) →
+        // back to claiming.
+        localStorage.removeItem(credsKey(token))
         setCreds(null)
         return
       }
-      // The link was accepted. Disarm, so that a LATER rejection on this same
-      // session — a peer releasing the seat mid-game — reports itself the
-      // ordinary way instead of blaming a recovery link that in fact worked.
+      // The link was accepted. Persist the recovered creds now that the server
+      // has authenticated the seat, and disarm so that a LATER rejection on
+      // this same session — a peer releasing the seat mid-game — reports itself
+      // the ordinary way instead of blaming a recovery link that in fact
+      // worked.
       if (recoveryPending.current && parsed.you !== null) {
         recoveryPending.current = false
+        const rec = recoveredCreds.current
+        recoveredCreds.current = null
+        priorCreds.current = null
+        if (rec) localStorage.setItem(credsKey(token), JSON.stringify(rec))
       }
       applyView(parsed)
     }
@@ -911,8 +950,17 @@ function SeatsButton({
   )
 }
 
+/** The public invite URL for the current game: origin + path only, so it can
+ *  never carry a recovery fragment or a stray query. A malformed recovery link
+ *  that survived in the address bar must not leak into the invite affordance. */
+function inviteUrl(): string {
+  if (typeof window === 'undefined') return ''
+  return `${window.location.origin}${window.location.pathname}`
+}
+
 function ShareLink({ className }: { className?: string }) {
   const [copied, setCopied] = useState(false)
+  const url = inviteUrl()
   return (
     <button
       type="button"
@@ -920,7 +968,7 @@ function ShareLink({ className }: { className?: string }) {
       data-testid="share-link"
       style={{ cursor: 'pointer', textTransform: 'none', letterSpacing: 0 }}
       onClick={() => {
-        void navigator.clipboard?.writeText(window.location.href)
+        void navigator.clipboard?.writeText(url)
         setCopied(true)
         setTimeout(() => setCopied(false), 2000)
       }}
@@ -941,7 +989,7 @@ function ShareLink({ className }: { className?: string }) {
           than the viewport; the full URL still shows from lg up (unchanged)
           and is always copied in full. */}
       <span className="min-w-0 truncate">
-        {copied ? 'Invite link copied!' : window.location.href}
+        {copied ? 'Invite link copied!' : url}
       </span>
     </button>
   )
@@ -965,7 +1013,7 @@ function ShareLink({ className }: { className?: string }) {
  */
 function InviteCallout({ openSeats }: { openSeats: number }) {
   const [copied, setCopied] = useState(false)
-  const url = typeof window === 'undefined' ? '' : window.location.href
+  const url = inviteUrl()
   return (
     <div
       className="bb2-panel bb2-panel-active mt-1 flex w-full max-w-sm flex-col gap-2.5 p-5"

--- a/src/components/mp/recovery-link.test.ts
+++ b/src/components/mp/recovery-link.test.ts
@@ -3,7 +3,6 @@ import {
   type RecoveryWindowLike,
   buildRecoveryLink,
   consumeRecoveryLink,
-  credsKey,
   parseRecoveryHash,
 } from './recovery-link'
 
@@ -11,13 +10,11 @@ const TOKEN = 'Ab3xY_9zQw-token01'
 const SECRET = 'sQ7v_Kd2mE9pLr4TnW1xYg'
 
 /** A stand-in for `window` under vitest's node environment: records the
- *  replaceState calls and the storage writes so the test can prove BOTH the
- *  persistence and the scrubbing happened. */
+ *  replaceState calls so the test can prove the fragment is scrubbed. */
 function fakeWindow(
   hash: string,
   search = '',
 ): RecoveryWindowLike & {
-  stored: Record<string, string>
   replaced: string[]
 } {
   const win = {
@@ -33,12 +30,6 @@ function fakeWindow(
         win.location.hash = frag ? `#${frag}` : ''
       },
     },
-    localStorage: {
-      setItem(key: string, value: string) {
-        win.stored[key] = value
-      },
-    },
-    stored: {} as Record<string, string>,
     replaced: [] as string[],
   }
   return win
@@ -91,21 +82,20 @@ describe('recovery link — round trip', () => {
     expect(link.startsWith(`https://brass.example/g/${TOKEN}#`)).toBe(true)
   })
 
-  it('consuming a link restores THAT seat and stores it under this game', () => {
+  it('consuming a link returns THAT seat WITHOUT persisting it', () => {
     const win = fakeWindow(`#seat=3&secret=${SECRET}`)
-    const creds = consumeRecoveryLink(TOKEN, win)
+    const creds = consumeRecoveryLink(win)
     expect(creds).toEqual({ seatId: 3, seatSecret: SECRET })
-    expect(JSON.parse(win.stored[credsKey(TOKEN)]!)).toEqual({
-      seatId: 3,
-      seatSecret: SECRET,
-    })
+    // Persisting is the caller's job, and only once the server authenticates
+    // the seat — a bad or stale link must never clobber a working seat's
+    // stored secret. Nothing here writes storage.
   })
 })
 
 describe('recovery link — the URL is scrubbed after consumption', () => {
   it('strips the fragment via replaceState, keeping the path', () => {
     const win = fakeWindow(`#seat=1&secret=${SECRET}`)
-    consumeRecoveryLink(TOKEN, win)
+    consumeRecoveryLink(win)
     expect(win.replaced).toEqual([`/g/${TOKEN}`])
     expect(win.location.hash).toBe('')
     // nothing anywhere in the visible location still holds the secret
@@ -116,7 +106,7 @@ describe('recovery link — the URL is scrubbed after consumption', () => {
 
   it('preserves an unrelated query string while dropping the fragment', () => {
     const win = fakeWindow(`#seat=1&secret=${SECRET}`, '?ref=discord')
-    consumeRecoveryLink(TOKEN, win)
+    consumeRecoveryLink(win)
     expect(win.replaced).toEqual([`/g/${TOKEN}?ref=discord`])
   })
 
@@ -124,20 +114,21 @@ describe('recovery link — the URL is scrubbed after consumption', () => {
     // pushState would leave the credential in session history; the module must
     // only ever call replaceState (asserted by the fake exposing no pushState).
     const win = fakeWindow(`#seat=0&secret=${SECRET}`)
-    expect(() => consumeRecoveryLink(TOKEN, win)).not.toThrow()
+    expect(() => consumeRecoveryLink(win)).not.toThrow()
     expect(win.replaced).toHaveLength(1)
   })
 
-  it('still strips the URL when storage refuses the write', () => {
-    const win = fakeWindow(`#seat=0&secret=${SECRET}`)
-    win.localStorage.setItem = () => {
-      throw new Error('QuotaExceededError')
-    }
-    expect(consumeRecoveryLink(TOKEN, win)).toEqual({
-      seatId: 0,
-      seatSecret: SECRET,
-    })
+  it('strips a MALFORMED secret-bearing fragment too, so it cannot leak', () => {
+    // `#seat=one&secret=…` fails to parse (bad seat) but still carries the
+    // secret. It must be scrubbed from the address bar all the same — otherwise
+    // the invite affordance would read it straight back out of `location`.
+    const win = fakeWindow(`#seat=one&secret=${SECRET}`)
+    expect(consumeRecoveryLink(win)).toBeNull()
+    expect(win.replaced).toEqual([`/g/${TOKEN}`])
     expect(win.location.hash).toBe('')
+    const visible =
+      win.location.pathname + win.location.search + win.location.hash
+    expect(visible).not.toContain(SECRET)
   })
 })
 
@@ -151,6 +142,7 @@ describe('recovery link — malformed input is refused without a hint', () => {
     ['bare hash', '#'],
     ['missing secret', '#seat=1'],
     ['empty secret', '#seat=1&secret='],
+    ['empty seat', `#seat=&secret=${SECRET}`],
     ['missing seat', `#secret=${SECRET}`],
     ['non-numeric seat', `#seat=zero&secret=${SECRET}`],
     ['negative seat', `#seat=-1&secret=${SECRET}`],
@@ -164,10 +156,10 @@ describe('recovery link — malformed input is refused without a hint', () => {
     })
   }
 
-  it('a refused fragment leaves storage untouched and creds unclaimed', () => {
+  it('a refused fragment yields no creds but is still stripped', () => {
     const win = fakeWindow('#seat=1')
-    expect(consumeRecoveryLink(TOKEN, win)).toBeNull()
-    expect(win.stored).toEqual({})
+    expect(consumeRecoveryLink(win)).toBeNull()
+    expect(win.location.hash).toBe('')
   })
 })
 
@@ -181,9 +173,8 @@ describe('invite link vs recovery link', () => {
 
   it('opening an invite link consumes nothing and falls through to joining', () => {
     const win = fakeWindow('')
-    expect(consumeRecoveryLink(TOKEN, win)).toBeNull()
+    expect(consumeRecoveryLink(win)).toBeNull()
     expect(win.replaced).toEqual([]) // no needless history rewrite
-    expect(win.stored).toEqual({})
   })
 
   it('the recovery link is a strict superset of the invite link', () => {

--- a/src/components/mp/recovery-link.test.ts
+++ b/src/components/mp/recovery-link.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type RecoveryWindowLike,
+  buildRecoveryLink,
+  consumeRecoveryLink,
+  credsKey,
+  parseRecoveryHash,
+} from './recovery-link'
+
+const TOKEN = 'Ab3xY_9zQw-token01'
+const SECRET = 'sQ7v_Kd2mE9pLr4TnW1xYg'
+
+/** A stand-in for `window` under vitest's node environment: records the
+ *  replaceState calls and the storage writes so the test can prove BOTH the
+ *  persistence and the scrubbing happened. */
+function fakeWindow(
+  hash: string,
+  search = '',
+): RecoveryWindowLike & {
+  stored: Record<string, string>
+  replaced: string[]
+} {
+  const win = {
+    location: { pathname: `/g/${TOKEN}`, search, hash },
+    history: {
+      replaceState(_data: unknown, _unused: string, url: string) {
+        win.replaced.push(url)
+        // mirror the browser: the URL really changes
+        const [path, frag = ''] = url.split('#')
+        const [pathname, qs = ''] = path!.split('?')
+        win.location.pathname = pathname!
+        win.location.search = qs ? `?${qs}` : ''
+        win.location.hash = frag ? `#${frag}` : ''
+      },
+    },
+    localStorage: {
+      setItem(key: string, value: string) {
+        win.stored[key] = value
+      },
+    },
+    stored: {} as Record<string, string>,
+    replaced: [] as string[],
+  }
+  return win
+}
+
+describe('recovery link — round trip', () => {
+  it('a link built for a seat parses back to the same credentials', () => {
+    const link = buildRecoveryLink('https://brass.example', TOKEN, {
+      seatId: 2,
+      seatSecret: SECRET,
+    })
+    expect(link).toBe(
+      `https://brass.example/g/${TOKEN}#seat=2&secret=${SECRET}`,
+    )
+    expect(parseRecoveryHash(new URL(link).hash)).toEqual({
+      seatId: 2,
+      seatSecret: SECRET,
+    })
+  })
+
+  it('keeps the secret in the FRAGMENT, never the path or query', () => {
+    const link = buildRecoveryLink('https://brass.example', TOKEN, {
+      seatId: 0,
+      seatSecret: SECRET,
+    })
+    const url = new URL(link)
+    // the fragment is never sent to the origin — no request log, no Referer
+    expect(url.pathname).not.toContain(SECRET)
+    expect(url.search).toBe('')
+    expect(url.hash).toContain(SECRET)
+  })
+
+  it('survives secrets containing URL-significant characters', () => {
+    const awkward = 'a+b/c=d&e?f#g'
+    const link = buildRecoveryLink('https://brass.example', TOKEN, {
+      seatId: 1,
+      seatSecret: awkward,
+    })
+    expect(parseRecoveryHash(new URL(link).hash)).toEqual({
+      seatId: 1,
+      seatSecret: awkward,
+    })
+  })
+
+  it('a trailing slash on the origin does not double up', () => {
+    const link = buildRecoveryLink('https://brass.example/', TOKEN, {
+      seatId: 0,
+      seatSecret: SECRET,
+    })
+    expect(link.startsWith(`https://brass.example/g/${TOKEN}#`)).toBe(true)
+  })
+
+  it('consuming a link restores THAT seat and stores it under this game', () => {
+    const win = fakeWindow(`#seat=3&secret=${SECRET}`)
+    const creds = consumeRecoveryLink(TOKEN, win)
+    expect(creds).toEqual({ seatId: 3, seatSecret: SECRET })
+    expect(JSON.parse(win.stored[credsKey(TOKEN)]!)).toEqual({
+      seatId: 3,
+      seatSecret: SECRET,
+    })
+  })
+})
+
+describe('recovery link — the URL is scrubbed after consumption', () => {
+  it('strips the fragment via replaceState, keeping the path', () => {
+    const win = fakeWindow(`#seat=1&secret=${SECRET}`)
+    consumeRecoveryLink(TOKEN, win)
+    expect(win.replaced).toEqual([`/g/${TOKEN}`])
+    expect(win.location.hash).toBe('')
+    // nothing anywhere in the visible location still holds the secret
+    const visible =
+      win.location.pathname + win.location.search + win.location.hash
+    expect(visible).not.toContain(SECRET)
+  })
+
+  it('preserves an unrelated query string while dropping the fragment', () => {
+    const win = fakeWindow(`#seat=1&secret=${SECRET}`, '?ref=discord')
+    consumeRecoveryLink(TOKEN, win)
+    expect(win.replaced).toEqual([`/g/${TOKEN}?ref=discord`])
+  })
+
+  it('uses replaceState, so Back cannot return to the secret-bearing entry', () => {
+    // pushState would leave the credential in session history; the module must
+    // only ever call replaceState (asserted by the fake exposing no pushState).
+    const win = fakeWindow(`#seat=0&secret=${SECRET}`)
+    expect(() => consumeRecoveryLink(TOKEN, win)).not.toThrow()
+    expect(win.replaced).toHaveLength(1)
+  })
+
+  it('still strips the URL when storage refuses the write', () => {
+    const win = fakeWindow(`#seat=0&secret=${SECRET}`)
+    win.localStorage.setItem = () => {
+      throw new Error('QuotaExceededError')
+    }
+    expect(consumeRecoveryLink(TOKEN, win)).toEqual({
+      seatId: 0,
+      seatSecret: SECRET,
+    })
+    expect(win.location.hash).toBe('')
+  })
+})
+
+describe('recovery link — malformed input is refused without a hint', () => {
+  // A tampered link must be indistinguishable in its handling from a garbage
+  // one: parse returns the SAME null for every bad shape, so nothing here can
+  // tell an attacker which half they got wrong. Whether a well-formed secret
+  // is the RIGHT one is the server's ordinary seat-secret check.
+  const bad = [
+    ['empty', ''],
+    ['bare hash', '#'],
+    ['missing secret', '#seat=1'],
+    ['empty secret', '#seat=1&secret='],
+    ['missing seat', `#secret=${SECRET}`],
+    ['non-numeric seat', `#seat=zero&secret=${SECRET}`],
+    ['negative seat', `#seat=-1&secret=${SECRET}`],
+    ['fractional seat', `#seat=1.5&secret=${SECRET}`],
+    ['unrelated fragment', '#chat'],
+  ] as const
+
+  for (const [label, hash] of bad) {
+    it(`refuses ${label}`, () => {
+      expect(parseRecoveryHash(hash)).toBeNull()
+    })
+  }
+
+  it('a refused fragment leaves storage untouched and creds unclaimed', () => {
+    const win = fakeWindow('#seat=1')
+    expect(consumeRecoveryLink(TOKEN, win)).toBeNull()
+    expect(win.stored).toEqual({})
+  })
+})
+
+describe('invite link vs recovery link', () => {
+  const inviteLink = `https://brass.example/g/${TOKEN}`
+
+  it('an invite link carries NO credential — it cannot restore a seat', () => {
+    expect(inviteLink).not.toContain('secret')
+    expect(parseRecoveryHash(new URL(inviteLink).hash)).toBeNull()
+  })
+
+  it('opening an invite link consumes nothing and falls through to joining', () => {
+    const win = fakeWindow('')
+    expect(consumeRecoveryLink(TOKEN, win)).toBeNull()
+    expect(win.replaced).toEqual([]) // no needless history rewrite
+    expect(win.stored).toEqual({})
+  })
+
+  it('the recovery link is a strict superset of the invite link', () => {
+    // Same game URL + a fragment: sharing the recovery link accidentally
+    // shares the invite too, which is why the UI must make the recovery one
+    // hard to grab (SeatKeyModal) rather than showing both as bare URLs.
+    const recovery = buildRecoveryLink('https://brass.example', TOKEN, {
+      seatId: 0,
+      seatSecret: SECRET,
+    })
+    expect(recovery.startsWith(`${inviteLink}#`)).toBe(true)
+  })
+})
+
+describe('the fragment format stays covered by the Sentry scrubber', () => {
+  // sentry-scrub.ts redacts `secret=<value>` ANYWHERE in a string (scrubText)
+  // and the `secret` query param by name (scrubQueryString). The fragment is
+  // written in exactly that shape so the existing gate covers it with no
+  // second scrubbing path here. Mirrors the scrubber's own pattern; if that
+  // module's pattern changes, this fails and the format must be revisited.
+  const SENTRY_TEXT_PATTERN =
+    /((?:seat|host)?secret|authorization|api[-_]?key|password)(["']?\s*[=:]\s*["']?)([^\s"'&,}]+)/gi
+
+  it('a recovery URL is redacted by the scrubber pattern', () => {
+    const link = buildRecoveryLink('https://brass.example', TOKEN, {
+      seatId: 1,
+      seatSecret: SECRET,
+    })
+    const scrubbed = link.replace(SENTRY_TEXT_PATTERN, '$1$2[Filtered]')
+    expect(scrubbed).not.toContain(SECRET)
+    // the game token survives — it is the identifier, not a credential
+    expect(scrubbed).toContain(TOKEN)
+  })
+})

--- a/src/components/mp/recovery-link.ts
+++ b/src/components/mp/recovery-link.ts
@@ -11,13 +11,19 @@
 // No new credential scheme is invented here: the recovery link simply carries
 // the EXISTING per-seat secret (the same one already sitting in localStorage
 // under `bb-mp-<token>`, minted by joinGame and verified by `secretMatches`).
-// The server therefore needs no new endpoint, no new column, and — crucially —
-// never sees or logs the secret at all, because:
+// The server therefore needs no new endpoint and no new column, and learns
+// nothing from the link itself, because:
 //
 //   THE SECRET RIDES IN THE URL FRAGMENT, NEVER THE QUERY STRING.
 //   A fragment is never sent to the origin, never reaches a request log, and
 //   is stripped from the `Referer` header by the URL spec. A `?secret=` link
 //   would land in Vercel's access log for `/g/<token>` on the very first hit.
+//
+// The link is therefore no new exposure — but it is not a claim that the secret
+// never travels: the SSE stream authenticates with `?seat=&secret=`, so the
+// same credential rides a query string there for every seated player, link or
+// not. That is why `sentry-scrub.ts` redacts the `secret` param name as well as
+// the free-text shape below, and why neither gate may be dropped.
 //
 // The fragment is nevertheless written in `secret=…` form ON PURPOSE: that is
 // the shape `sentry-scrub.ts` already redacts (its `scrubText` pattern matches

--- a/src/components/mp/recovery-link.ts
+++ b/src/components/mp/recovery-link.ts
@@ -1,0 +1,119 @@
+// Personal SEAT RECOVERY LINK — how a player restores their seat on another
+// device or after clearing their browser.
+//
+// THE TWO LINKS, AND WHY THEY MUST NEVER BE CONFUSED:
+//
+//   invite link    /g/<token>                       PUBLIC.  Lets a stranger
+//                                                   take an OPEN seat.
+//   recovery link  /g/<token>#seat=N&secret=<s>     A CREDENTIAL. Whoever
+//                                                   holds it plays THAT seat.
+//
+// No new credential scheme is invented here: the recovery link simply carries
+// the EXISTING per-seat secret (the same one already sitting in localStorage
+// under `bb-mp-<token>`, minted by joinGame and verified by `secretMatches`).
+// The server therefore needs no new endpoint, no new column, and — crucially —
+// never sees or logs the secret at all, because:
+//
+//   THE SECRET RIDES IN THE URL FRAGMENT, NEVER THE QUERY STRING.
+//   A fragment is never sent to the origin, never reaches a request log, and
+//   is stripped from the `Referer` header by the URL spec. A `?secret=` link
+//   would land in Vercel's access log for `/g/<token>` on the very first hit.
+//
+// The fragment is nevertheless written in `secret=…` form ON PURPOSE: that is
+// the shape `sentry-scrub.ts` already redacts (its `scrubText` pattern matches
+// `(seat|host)?secret[=:]<value>` anywhere in a string, and `scrubQueryString`
+// matches the `secret` param name), so a client-side event carrying
+// `location.href` is scrubbed by the existing gate with nothing added here.
+//
+// Consumption is deliberately WRITE-THEN-STRIP and fully synchronous: the
+// credentials go to localStorage and `history.replaceState` removes them from
+// the address bar in the same tick, BEFORE any fetch/EventSource/navigation
+// could carry them onward. See `consumeRecoveryLink`.
+
+export interface RecoveryCreds {
+  seatId: number
+  seatSecret: string
+}
+
+/** localStorage key holding a seat's credentials for one game. */
+export const credsKey = (token: string) => `bb-mp-${token}`
+
+/** Minimal structural slice of `window` — a real Window satisfies it, and a
+ *  plain object stands in under vitest's `environment: 'node'`. */
+export interface RecoveryWindowLike {
+  location: { pathname: string; search: string; hash: string }
+  history: { replaceState(data: unknown, unused: string, url: string): void }
+  localStorage: { setItem(key: string, value: string): void }
+}
+
+/**
+ * The player's own recovery URL. `origin` is normally `window.location.origin`.
+ * NEVER render this next to the invite link, and never without the
+ * "anyone holding this can play as you" warning — see SeatKeyModal.
+ */
+export function buildRecoveryLink(
+  origin: string,
+  token: string,
+  creds: RecoveryCreds,
+): string {
+  const params = new URLSearchParams({
+    seat: String(creds.seatId),
+    secret: creds.seatSecret,
+  })
+  return `${origin.replace(/\/$/, '')}/g/${encodeURIComponent(token)}#${params.toString()}`
+}
+
+/**
+ * Read credentials out of a URL fragment. Returns null for anything that is
+ * not a well-formed recovery fragment — an invite link (no fragment), a
+ * truncated paste, a fragment missing either half.
+ *
+ * This is a SHAPE check only. Whether the secret is the RIGHT one is decided
+ * by the server through the ordinary seat-secret path (`secretMatches`), which
+ * answers with an unauthenticated view and no hint about which half was wrong.
+ */
+export function parseRecoveryHash(hash: string): RecoveryCreds | null {
+  const raw = hash.startsWith('#') ? hash.slice(1) : hash
+  if (!raw) return null
+  const params = new URLSearchParams(raw)
+  const seat = params.get('seat')
+  const secret = params.get('secret')
+  if (seat === null || !secret) return null
+  const seatId = Number(seat)
+  if (!Number.isInteger(seatId) || seatId < 0) return null
+  return { seatId, seatSecret: secret }
+}
+
+/**
+ * Consume a recovery link found in the current URL: persist the credentials
+ * for this game and scrub them out of the address bar and session history.
+ *
+ * Returns the credentials when a fragment was consumed, else null (the plain
+ * invite-link case, which must fall through to the normal join screen).
+ *
+ * ORDER IS LOAD-BEARING — store, then strip, both synchronously, before the
+ * caller opens the SSE stream. `replaceState` (not pushState) is used so the
+ * secret-bearing entry is REPLACED rather than added: pressing Back cannot
+ * return to it.
+ */
+export function consumeRecoveryLink(
+  token: string,
+  win: RecoveryWindowLike,
+): RecoveryCreds | null {
+  const creds = parseRecoveryHash(win.location.hash)
+  if (!creds) return null
+  try {
+    win.localStorage.setItem(credsKey(token), JSON.stringify(creds))
+  } catch {
+    // Private-mode storage can refuse writes. The seat still works for this
+    // page load (the caller holds the creds in memory); losing persistence is
+    // strictly better than leaving the secret in the URL, so carry on and
+    // strip regardless.
+  }
+  win.history.replaceState(
+    null,
+    '',
+    `${win.location.pathname}${win.location.search}`,
+  )
+  return creds
+}

--- a/src/components/mp/recovery-link.ts
+++ b/src/components/mp/recovery-link.ts
@@ -25,10 +25,13 @@
 // matches the `secret` param name), so a client-side event carrying
 // `location.href` is scrubbed by the existing gate with nothing added here.
 //
-// Consumption is deliberately WRITE-THEN-STRIP and fully synchronous: the
-// credentials go to localStorage and `history.replaceState` removes them from
-// the address bar in the same tick, BEFORE any fetch/EventSource/navigation
-// could carry them onward. See `consumeRecoveryLink`.
+// Consumption is STRIP-then-VERIFY-then-WRITE. `consumeRecoveryLink` removes the
+// fragment from the address bar synchronously — for ANY fragment, valid or not,
+// BEFORE any fetch/EventSource/navigation could carry it onward — and returns
+// the parsed credentials WITHOUT persisting them. Persisting is the caller's
+// job, and only after the server has authenticated the seat: a bad or stale
+// link must never overwrite a working seat's stored secret. See
+// `consumeRecoveryLink` and its caller in `mp-game.tsx`.
 
 export interface RecoveryCreds {
   seatId: number
@@ -43,7 +46,6 @@ export const credsKey = (token: string) => `bb-mp-${token}`
 export interface RecoveryWindowLike {
   location: { pathname: string; search: string; hash: string }
   history: { replaceState(data: unknown, unused: string, url: string): void }
-  localStorage: { setItem(key: string, value: string): void }
 }
 
 /**
@@ -78,42 +80,45 @@ export function parseRecoveryHash(hash: string): RecoveryCreds | null {
   const params = new URLSearchParams(raw)
   const seat = params.get('seat')
   const secret = params.get('secret')
-  if (seat === null || !secret) return null
+  // An empty seat must be refused explicitly: `Number('')` is 0, which would
+  // otherwise pass the integer check and masquerade as seat 0.
+  if (!seat || !secret) return null
   const seatId = Number(seat)
   if (!Number.isInteger(seatId) || seatId < 0) return null
   return { seatId, seatSecret: secret }
 }
 
 /**
- * Consume a recovery link found in the current URL: persist the credentials
- * for this game and scrub them out of the address bar and session history.
+ * Consume a recovery link found in the current URL: scrub any fragment out of
+ * the address bar and session history, and return the parsed credentials.
  *
- * Returns the credentials when a fragment was consumed, else null (the plain
- * invite-link case, which must fall through to the normal join screen).
+ * Returns the credentials when the fragment was a well-formed recovery link,
+ * else null (the plain invite-link case, which must fall through to the normal
+ * join screen).
  *
- * ORDER IS LOAD-BEARING — store, then strip, both synchronously, before the
- * caller opens the SSE stream. `replaceState` (not pushState) is used so the
- * secret-bearing entry is REPLACED rather than added: pressing Back cannot
- * return to it.
+ * STRIPPING IS UNCONDITIONAL and comes FIRST. `replaceState` runs whenever the
+ * URL carries any fragment — even a malformed, secret-bearing one that
+ * `parseRecoveryHash` rejects — before the caller opens the SSE stream, so a
+ * mangled paste can never leave the secret in the URL for the invite affordance
+ * to read back or for a later request to carry. `replaceState` (not pushState)
+ * REPLACES the secret-bearing entry rather than adding one: pressing Back
+ * cannot return to it.
+ *
+ * The credentials are NOT persisted here. Whether to store them is the caller's
+ * decision, and only once the server has authenticated the seat — otherwise a
+ * bad or stale link would clobber a working seat's stored secret.
  */
 export function consumeRecoveryLink(
-  token: string,
   win: RecoveryWindowLike,
 ): RecoveryCreds | null {
+  const hadFragment = win.location.hash.replace(/^#/, '').length > 0
   const creds = parseRecoveryHash(win.location.hash)
-  if (!creds) return null
-  try {
-    win.localStorage.setItem(credsKey(token), JSON.stringify(creds))
-  } catch {
-    // Private-mode storage can refuse writes. The seat still works for this
-    // page load (the caller holds the creds in memory); losing persistence is
-    // strictly better than leaving the secret in the URL, so carry on and
-    // strip regardless.
+  if (hadFragment) {
+    win.history.replaceState(
+      null,
+      '',
+      `${win.location.pathname}${win.location.search}`,
+    )
   }
-  win.history.replaceState(
-    null,
-    '',
-    `${win.location.pathname}${win.location.search}`,
-  )
   return creds
 }

--- a/src/components/mp/seat-key.tsx
+++ b/src/components/mp/seat-key.tsx
@@ -1,0 +1,301 @@
+'use client'
+
+// The player's PRIVATE seat key — the UI half of `recovery-link.ts`.
+//
+// This surface exists to make one specific mistake hard: pasting your own
+// recovery link where the invite link belongs. Everything below is shaped by
+// that, and none of it is decoration:
+//
+//   - The recovery URL is NEVER rendered next to the invite link, and never
+//     on the page at all until the player opens this modal and then explicitly
+//     reveals it. The invite link (`ShareLink`) is the only bare URL on screen,
+//     so "the URL you can grab" is always the safe one.
+//   - The affordances differ: the invite link is a chip showing its own URL
+//     (click = copy); the seat key is a keyed ghost BUTTON that opens a modal.
+//     There are never two similar-looking URLs side by side.
+//   - The copy says what the credential does in plain words, and names the
+//     other link so the distinction is stated rather than implied.
+//
+// It reuses the EXISTING per-seat secret (see recovery-link.ts) — there is no
+// second credential scheme, and the server is not involved at all.
+import { useEffect, useState } from 'react'
+import { type RecoveryCreds, buildRecoveryLink } from './recovery-link'
+
+/** Placeholder shown instead of the link until the player asks to see it, so
+ *  a shared screen or a screenshot does not leak the seat by accident. */
+const MASK = '••••••••••••••••••••••••••••••••'
+
+export function SeatKeyModal({
+  token,
+  creds,
+  atClaim = false,
+  onClose,
+}: {
+  token: string
+  creds: RecoveryCreds
+  /** true when opened automatically right after claiming the seat */
+  atClaim?: boolean
+  onClose: () => void
+}) {
+  const [revealed, setRevealed] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
+
+  const link =
+    typeof window === 'undefined'
+      ? ''
+      : buildRecoveryLink(window.location.origin, token, creds)
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(link)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2500)
+  }
+
+  return (
+    <div
+      className="bb2-curtain fixed inset-0 z-[70] flex items-start justify-center overflow-y-auto p-4 sm:p-8"
+      style={{ background: 'rgba(10, 8, 6, 0.86)' }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="bb2-panel bb2-rise flex w-full max-w-md flex-col gap-3 p-5"
+        role="dialog"
+        aria-label="Your private seat key"
+        data-testid="seat-key-modal"
+      >
+        <div className="flex items-baseline gap-2">
+          <span className="bb2-panel-title">🔑 Your private seat key</span>
+          <button
+            type="button"
+            className="bb2-ghost-btn ml-auto !px-2 !py-1 text-[11px]"
+            data-testid="seat-key-close"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+
+        {atClaim && (
+          <p
+            className="text-[13px]"
+            style={{ color: 'var(--bb-parchment-bright)' }}
+          >
+            Seat claimed. Keep this link somewhere private — it is the only way
+            back into your seat from another device or browser.
+          </p>
+        )}
+
+        {/* The warning is the loudest thing in the dialog, above the link. */}
+        <p
+          className="rounded border px-3 py-2 text-[13px] font-semibold"
+          data-testid="seat-key-warning"
+          style={{
+            borderColor: 'rgba(214, 92, 62, .55)',
+            background: 'rgba(214, 92, 62, .12)',
+            color: 'var(--bb-parchment-bright)',
+          }}
+        >
+          This is yours — anyone with this link can take your seat. Never post
+          it in a chat, a stream or a screenshot.
+        </p>
+
+        <div className="flex flex-col gap-1.5">
+          <span
+            className="text-[10px] font-bold uppercase tracking-[0.18em]"
+            style={{ color: 'rgba(231,215,177,.5)' }}
+          >
+            Private — do not share
+          </span>
+          <code
+            className="block break-all rounded border px-3 py-2 text-[11.5px] leading-snug"
+            data-testid="seat-key-link"
+            data-revealed={revealed ? 'true' : 'false'}
+            style={{
+              borderColor: 'rgba(231,215,177,.18)',
+              background: 'rgba(0,0,0,.25)',
+              color: revealed ? 'var(--bb-parchment)' : 'rgba(231,215,177,.45)',
+            }}
+          >
+            {revealed ? link : MASK}
+          </code>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="bb2-confirm flex-1"
+              data-testid="seat-key-copy"
+              onClick={copy}
+            >
+              {copied ? 'Copied — keep it private' : 'Copy my private link'}
+            </button>
+            <button
+              type="button"
+              className="bb2-ghost-btn"
+              data-testid="seat-key-reveal"
+              onClick={() => setRevealed((r) => !r)}
+            >
+              {revealed ? 'Hide' : 'Reveal'}
+            </button>
+          </div>
+        </div>
+
+        <p className="text-[12px]" style={{ color: 'rgba(231,215,177,.55)' }}>
+          Open it on your phone or in another browser and you are back in this
+          seat. It keeps working for the whole game.
+        </p>
+
+        {/* State the distinction outright — implying it is not enough. */}
+        <p
+          className="border-t pt-2 text-[12px]"
+          data-testid="seat-key-vs-invite"
+          style={{
+            borderColor: 'rgba(231,215,177,.15)',
+            color: 'rgba(231,215,177,.55)',
+          }}
+        >
+          <b style={{ color: 'var(--bb-parchment)' }}>
+            This is not the invite link.
+          </b>{' '}
+          To bring someone to the table, share the <b>invite link</b> in the
+          header instead — that one only offers an open seat and is safe to post
+          anywhere.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The always-available way back to the modal — the "retrievable later"
+ * half of the feature, since nobody saves the link the first time they see it.
+ * Rendered in the lobby and in the live game's masthead.
+ */
+export function SeatKeyButton({
+  token,
+  creds,
+  className,
+}: {
+  token: string
+  creds: RecoveryCreds
+  className?: string
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button
+        type="button"
+        className={`bb2-ghost-btn ${className ?? ''}`}
+        data-testid="seat-key-button"
+        title="Your private link back into this seat — do not share it"
+        onClick={() => setOpen(true)}
+      >
+        🔑 Seat key
+      </button>
+      {open && (
+        <SeatKeyModal
+          token={token}
+          creds={creds}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  )
+}
+
+/** Per-game "the player has seen the nudge" flag. Its own key, so clearing a
+ *  game's credentials does not resurrect the notice for a seat that no longer
+ *  exists, and a dismissal survives a reload. */
+const seenKey = (token: string) => `bb-mp-seatkey-seen-${token}`
+
+/**
+ * The claim-time nudge, shown in the lobby to EVERY seated player — the host
+ * (whose seat is claimed at creation, without ever passing through the join
+ * screen) as well as everyone who joined.
+ *
+ * It is a persistent inline card rather than a modal on purpose: a modal is a
+ * one-shot a player dismisses on reflex, and it would sit on top of the lobby
+ * controls. This stays until acknowledged, and the Seat key button remains
+ * afterwards, which is the "retrievable later" half of the requirement.
+ */
+export function SeatKeyNotice({
+  token,
+  creds,
+}: {
+  token: string
+  creds: RecoveryCreds
+}) {
+  const [dismissed, setDismissed] = useState(true)
+  const [open, setOpen] = useState(false)
+
+  // Read the flag after mount: localStorage is unavailable during SSR and
+  // reading it in render would desync hydration.
+  useEffect(() => {
+    try {
+      setDismissed(localStorage.getItem(seenKey(token)) !== null)
+    } catch {
+      setDismissed(false)
+    }
+  }, [token])
+
+  const dismiss = () => {
+    setDismissed(true)
+    try {
+      localStorage.setItem(seenKey(token), '1')
+    } catch {
+      // a session-only dismissal is fine
+    }
+  }
+
+  if (dismissed) return null
+  return (
+    <div
+      className="bb2-panel flex w-full max-w-sm flex-col gap-2 p-4"
+      data-testid="seat-key-notice"
+      style={{ borderColor: 'var(--bb-brass-dim)' }}
+    >
+      <span className="bb2-panel-title">🔑 Save your seat key</span>
+      <p className="text-[12.5px]" style={{ color: 'var(--bb-parchment)' }}>
+        It is the only way back into your seat from another device, or if this
+        browser forgets you. Private — anyone with it can play as you.
+      </p>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          className="bb2-confirm flex-1"
+          data-testid="seat-key-notice-open"
+          onClick={() => setOpen(true)}
+        >
+          Show my seat key
+        </button>
+        <button
+          type="button"
+          className="bb2-ghost-btn"
+          data-testid="seat-key-notice-dismiss"
+          onClick={dismiss}
+        >
+          Later
+        </button>
+      </div>
+      {open && (
+        <SeatKeyModal
+          token={token}
+          creds={creds}
+          atClaim
+          onClose={() => {
+            setOpen(false)
+            dismiss()
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/mp/seat-key.tsx
+++ b/src/components/mp/seat-key.tsx
@@ -257,20 +257,34 @@ export function SeatKeyNotice({
 
   if (dismissed) return null
   return (
+    // DELIBERATELY QUIET (2026-07-24 review): no panel chrome, no brass rule,
+    // no `bb2-confirm`. In the lobby the call to action is the INVITE, and
+    // prominence must track shareability — a credential that outshouts the
+    // shareable link teaches players to send the wrong one. Keep this
+    // secondary to InviteCallout; it stays discoverable, and the permanent
+    // Seat key button is right below it either way.
     <div
-      className="bb2-panel flex w-full max-w-sm flex-col gap-2 p-4"
+      className="flex w-full max-w-sm flex-col gap-1.5 rounded border px-3 py-2.5"
       data-testid="seat-key-notice"
-      style={{ borderColor: 'var(--bb-brass-dim)' }}
+      style={{
+        borderColor: 'rgba(231,215,177,.16)',
+        background: 'rgba(0,0,0,.18)',
+      }}
     >
-      <span className="bb2-panel-title">🔑 Save your seat key</span>
-      <p className="text-[12.5px]" style={{ color: 'var(--bb-parchment)' }}>
-        It is the only way back into your seat from another device, or if this
-        browser forgets you. Private — anyone with it can play as you.
+      <span
+        className="text-[10px] font-bold uppercase tracking-[0.18em]"
+        style={{ color: 'rgba(231,215,177,.6)' }}
+      >
+        🔑 Your seat key
+      </span>
+      <p className="text-[11.5px]" style={{ color: 'rgba(231,215,177,.6)' }}>
+        Keep it to get back into this seat from another device. Private — never
+        share it.
       </p>
       <div className="flex gap-2">
         <button
           type="button"
-          className="bb2-confirm flex-1"
+          className="bb2-ghost-btn !px-2.5 !py-1 text-[10px]"
           data-testid="seat-key-notice-open"
           onClick={() => setOpen(true)}
         >
@@ -278,7 +292,7 @@ export function SeatKeyNotice({
         </button>
         <button
           type="button"
-          className="bb2-ghost-btn"
+          className="bb2-ghost-btn !px-2.5 !py-1 text-[10px]"
           data-testid="seat-key-notice-dismiss"
           onClick={dismiss}
         >

--- a/src/store/gameStore.multiplayer.test.ts
+++ b/src/store/gameStore.multiplayer.test.ts
@@ -2,6 +2,10 @@
 // importantly — that a seat's view NEVER contains another player's cards.
 import { beforeAll, describe, expect, test, vi } from 'vitest'
 import {
+  buildRecoveryLink,
+  parseRecoveryHash,
+} from '../components/mp/recovery-link'
+import {
   CHAT_MAX_LENGTH,
   CHAT_TAIL_LIMIT,
   actInGame,
@@ -406,6 +410,171 @@ describe('multiplayer: lifecycle and authority', () => {
     }
     const lobby = await getGameView(host.token, 1, guest.seatSecret)
     expect(lobby?.hostSeatId).toBe(1)
+  })
+})
+
+// The personal recovery link ("seat key"). It carries the EXISTING per-seat
+// secret in a URL fragment — no new credential, no new endpoint — so these
+// tests drive the real link builder/parser against the real seat auth and
+// prove the round trip end to end. The client-side half (storage write, URL
+// scrubbing, malformed input) is pinned offline in
+// `src/components/mp/recovery-link.test.ts`.
+describe('multiplayer: personal seat recovery links', () => {
+  /** What a clean browser does with a pasted recovery URL: parse the
+   *  fragment and present whatever it finds to the ordinary seat auth. */
+  const openInCleanBrowser = (link: string) =>
+    parseRecoveryHash(new URL(link).hash)
+
+  test('every seated player — not just the host — round-trips their own seat', async () => {
+    const { host, guest } = await freshGame()
+    const origin = 'https://brass.example'
+
+    for (const seat of [
+      { seatId: 0, seatSecret: host.seatSecret, name: 'Ada' },
+      { seatId: guest.seatId, seatSecret: guest.seatSecret, name: 'Brunel' },
+    ]) {
+      const link = buildRecoveryLink(origin, host.token, seat)
+      // the link addresses this game and hides the credential in the fragment
+      expect(link.startsWith(`${origin}/g/${host.token}#`)).toBe(true)
+
+      const restored = openInCleanBrowser(link)
+      expect(restored).toEqual({
+        seatId: seat.seatId,
+        seatSecret: seat.seatSecret,
+      })
+
+      // …and those credentials authenticate THAT seat, with its own hand.
+      const view = await getGameView(
+        host.token,
+        restored!.seatId,
+        restored!.seatSecret,
+      )
+      expect(view?.you).toBe(seat.seatId)
+      expect(ctxOf(view!).players[seat.seatId]!.name).toBe(seat.name)
+    }
+  })
+
+  test('a restored seat can act — it is the same credential, not a read-only pass', async () => {
+    const { host, guest } = await freshGame()
+    const view = await getGameView(host.token, 0, host.seatSecret)
+    const current = ctxOf(view!).currentPlayerIndex
+    const seat =
+      current === 0
+        ? { seatId: 0, seatSecret: host.seatSecret }
+        : { seatId: guest.seatId, seatSecret: guest.seatSecret }
+
+    const restored = openInCleanBrowser(
+      buildRecoveryLink('https://brass.example', host.token, seat),
+    )!
+    // A full action flow driven entirely from the recovered credentials.
+    expect(
+      (
+        await actInGame(host.token, restored.seatId, restored.seatSecret, {
+          type: 'TAKE_LOAN',
+        })
+      ).ok,
+    ).toBe(true)
+    const mine = await getGameView(
+      host.token,
+      restored.seatId,
+      restored.seatSecret,
+    )
+    expect(
+      (
+        await actInGame(host.token, restored.seatId, restored.seatSecret, {
+          type: 'SELECT_CARD',
+          cardId: ctxOf(mine!).players[current]!.hand[0]!.id,
+        })
+      ).ok,
+    ).toBe(true)
+    expect(
+      (
+        await actInGame(host.token, restored.seatId, restored.seatSecret, {
+          type: 'CONFIRM',
+        })
+      ).ok,
+    ).toBe(true)
+  })
+
+  test('a tampered secret is refused, and the refusal says nothing about which half was wrong', async () => {
+    const { host } = await freshGame()
+    const good = buildRecoveryLink('https://brass.example', host.token, {
+      seatId: 0,
+      seatSecret: host.seatSecret,
+    })
+
+    // One character flipped in the secret — everything else identical.
+    const flipped = host.seatSecret.startsWith('a')
+      ? `b${host.seatSecret.slice(1)}`
+      : `a${host.seatSecret.slice(1)}`
+    const tampered = good.replace(host.seatSecret, flipped)
+    expect(tampered).not.toBe(good)
+
+    const refusals = await Promise.all(
+      [
+        // right seat, wrong secret
+        { seatId: 0, seatSecret: flipped },
+        // wrong seat, right secret (seat 1's key would not be seat 0's)
+        { seatId: 1, seatSecret: host.seatSecret },
+        // pure invention
+        { seatId: 0, seatSecret: 'not-a-real-secret-at-all' },
+      ].map((c) => getGameView(host.token, c.seatId, c.seatSecret)),
+    )
+
+    // Every failure mode answers IDENTICALLY: an unauthenticated view. No
+    // error string, no seat hint, nothing that narrows the search.
+    for (const refused of refusals) {
+      expect(refused?.you).toBeNull()
+      expect(refused?.snapshot).toBeNull()
+    }
+    expect(JSON.stringify(refusals[0])).toBe(JSON.stringify(refusals[2]))
+
+    // …and the untampered link still works, so this is the secret failing and
+    // not the whole game being unreachable.
+    const ok = openInCleanBrowser(good)!
+    expect((await getGameView(host.token, ok.seatId, ok.seatSecret))?.you).toBe(
+      0,
+    )
+  })
+
+  test('an invite link grants an OPEN seat only — never an occupied one', async () => {
+    const host = await createGame('Ada', 2)
+    // Anyone holding just the token (the invite link) is anonymous: no seat.
+    const anonymous = await getGameView(host.token, null, null)
+    expect(anonymous?.you).toBeNull()
+    expect(anonymous?.seats[0]!.claimed).toBe(true)
+
+    // It takes the one open seat…
+    const guest = await joinGame(host.token, 'Brunel')
+    expect(guest.seatId).toBe(1)
+    // …and then grants nothing at all: the occupied seats stay occupied.
+    await expect(joinGame(host.token, 'Interloper')).rejects.toThrow(
+      /no open seats/i,
+    )
+    const still = await getGameView(host.token, 1, guest.seatSecret)
+    expect(still?.you).toBe(1)
+  })
+
+  test('#88 intact: releasing a seat kills its old recovery link', async () => {
+    const { host, guest } = await freshGame()
+    const hostKey = openInCleanBrowser(
+      buildRecoveryLink('https://brass.example', host.token, {
+        seatId: 0,
+        seatSecret: host.seatSecret,
+      }),
+    )!
+    expect(
+      (await getGameView(host.token, hostKey.seatId, hostKey.seatSecret))?.you,
+    ).toBe(0)
+
+    // A seated peer frees seat 0 (the existing recovery model).
+    await releaseSeat(host.token, guest.seatSecret, 0)
+
+    // The recovery link that used to open that seat is now inert — the seat
+    // has no secretHash at all, so the credential matches nothing.
+    expect(
+      (await getGameView(host.token, hostKey.seatId, hostKey.seatSecret))?.you,
+    ).toBeNull()
   })
 })
 


### PR DESCRIPTION
Players lose their seat when they change device or clear their browser: the per-seat secret lives only in that browser's `localStorage`, and the only way back was to have a peer release the seat and re-claim it. This is the interim fix for that, keeping the no-signup flow.

Every seated player — **host included** — now gets a personal **recovery link** that restores their exact seat anywhere.

## Reuses the existing seat secret

No second credential scheme, no new endpoint, **no schema change, no migration, no new dependency**. The link carries the per-seat secret that `joinGame` already mints and `secretMatches` already verifies, so the whole feature is client-side (`src/components/mp/recovery-link.ts` + `seat-key.tsx`) and the server never learns a recovery happened.

## Security shape

| | Contains | Semantics |
|---|---|---|
| **Invite link** | game token only | **safe to share** — offers an *open* seat |
| **Recovery link** | token + seat + secret | **a credential** — plays *that* seat |

- **The secret rides in the URL FRAGMENT** (`/g/<token>#seat=N&secret=…`), never the query string. A fragment is never sent to the origin, so it cannot reach a request log and is stripped from `Referer` by spec. A `?secret=` link would land in Vercel's access log on the first hit. The link therefore adds no exposure of its own — it is not a claim that the secret never travels, since the SSE stream has always authenticated with `?seat=&secret=`.
- The fragment is written in `secret=…` **shape on purpose**: that is exactly what #95's `sentry-scrub.ts` already redacts (`scrubText` matches `(seat|host)?secret[=:]<value>` anywhere in a string; `scrubQueryString` matches the param name). Complementary, not duplicated — and a test mirrors that pattern so a format change fails loudly.
- **Strip-then-verify-then-write.** `consumeRecoveryLink` scrubs the fragment out of the address bar first, synchronously, for **any** fragment — including a malformed, secret-bearing one that fails to parse — using `replaceState` (never `pushState`, so Back cannot reach the credential). It runs in `mp-game.tsx`'s **first** effect, before the stream effect opens an `EventSource`. The parsed credentials are held **unpersisted** and written to `bb-mp-<token>` only once the server has authenticated the seat: a bad or stale link — which anyone holding a published lobby token can craft — must never clobber a working seat's stored secret. On rejection the browser's prior credentials are restored and the player keeps the seat they were already in.
- A wrong or tampered link is refused by the **ordinary seat auth** (`you: null`) and reported as one message that names neither the seat nor which half was wrong.

## Prominence must track shareability

The lobby's first cut had its hierarchy inverted: the invite was a thin pill under the title, while **SAVE YOUR SEAT KEY** was a bordered gold panel carrying one of the brightest buttons on screen.

That **teaches the wrong safety lesson.** The credential looked like the thing to send, and the genuinely shareable link looked like a footnote. It is the same invite-versus-recovery confusion this PR already takes seriously in its copy — surfacing as a styling problem rather than a wording one. So the invite should *look* shareable and the seat key should *look* guarded.

In the lobby, `InviteCallout` is the primary card while any seat is open (real size, obvious copy button — in a lobby waiting for players, getting a player in *is* the task), and the seat-key notice is a quiet secondary row. It is **not** hidden or removed: it stays discoverable, with the permanent Seat key button right below it. Once the table is full there is nobody left to invite, so the callout stands down to the compact chip. Scoped to the lobby — once the game is under way the invite is no longer the call to action, so the live table keeps its masthead chip.

| | Before | After |
|---|---|---|
| **1280px** | ![before 1280](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr98-lobby-before-1280.png) | ![after 1280](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr98-lobby-after-1280.png) |
| **390px** | ![before 390](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr98-lobby-before-390.png) | ![after 390](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr98-lobby-after-390.png) |

## Making the wrong link hard to grab

- The **invite is the only bare URL on screen**. The recovery URL renders **nowhere** until the player opens the seat-key modal *and* clicks Reveal — so "the URL you can grab" is always the safe one.
- The invite affordances build their URL from origin + path, never `location.href`, so the invite cannot carry a fragment or a stray query even if one lingered in the address bar.
- Different affordance: a URL-bearing card/chip vs a 🔑 button opening a dialog. Never two lookalike URLs side by side.
- The modal leads with **"anyone with this link can take your seat"**, then states outright **"This is not the invite link"**.

## Available at claim time *and* later

- Inline lobby notice at claim time, dismissal remembered per game. A notice rather than a modal: the **host** claims seat 0 at creation and never passes the join screen, so the lobby is the one place that covers everyone — and it does not sit on top of the ready/start controls.
- A permanent **🔑 Seat key** button in the lobby and the in-game masthead, because the people who need the link are exactly the ones who did not save it.
- Mid-game claims (a released seat re-taken) skip the lobby, so that one path gets the modal instead.

## #88 untouched

Release-and-reclaim remains, and stays the fallback for a player whose key is gone too. Releasing a seat still kills its old recovery link — pinned by a test.

## Tests

- `src/components/mp/recovery-link.test.ts` — offline: format, fragment-not-query, URL/history scrubbing, nine malformed shapes all refused identically, invite-vs-recovery, Sentry-pattern coverage.
- `personal seat recovery links` in `gameStore.multiplayer.test.ts` — wire: **every** seat round-trips (not just host), restored credentials drive a full action flow, tampered/wrong-seat/invented secrets answer byte-identically, an invite link grants no occupied seat, a released seat's link goes inert.
- `e2e/seat-recovery.spec.ts` — a clean browser profile restored from the link alone; address bar, session history and DOM free of the secret; the forged-link refusal; a refused link leaving an already-seated player untouched; a seat claimed after the start getting the modal and a clickable board afterwards; a stranger on the invite link offered nothing; **and the lobby hierarchy itself**, so it cannot silently invert again.

## Review notes

Reviewed against `origin/main` before pushing (Claude Opus 5 as reviewer, since the usual model was rate-limited). **No P0 findings.** Both P1s were coverage gaps on the branches that decide whether a bad link costs someone their seat, and writing the first one surfaced a real bug — all fixed in 29fff52:

- **Fixed (P1, found by the new test).** A recovery link pasted into the address bar of a tab **already on** `/g/<token>` is a same-document fragment navigation: nothing remounts, so the mount-only consume never ran. The secret stayed in the address bar and session history for the rest of the visit, and the link did nothing. The effect now also listens for `hashchange`, through the same `consumeRecoveryLink`.
- **Fixed (P1).** The `priorCreds` restore branch and the mid-game-claim modal flag were both unreached by any test — the latter is the one whose wrong value drops a full-screen curtain over the board. Both now pinned in `e2e/seat-recovery.spec.ts`.
- **Fixed (P2, doc accuracy).** The module header claimed the server "never sees or logs the secret at all". The link adds no exposure, but the SSE stream authenticates with `?seat=&secret=`, so the claim was wrong in a way that could invite someone to drop a scrubbing gate.

Left for follow-up, deliberately out of scope here:

- **P2 — Vercel Web Analytics reads `location.href`** on pageview, outside the Sentry gate. The strip currently wins on effect-flush ordering, so there is no observed leak, but the margin is zero. The deterministic fix is a `beforeSend` that drops the fragment, which needs a small client wrapper — `layout.tsx` is a Server Component and cannot pass a function prop.
- **P2 — the seat-key copy button reports success unconditionally.** On a non-secure context `navigator.clipboard` is undefined and the button still says "Copied — keep it private"; for a credential the player believes their only way back is saved. Worth revealing the link on failure instead.
- **P3 — `data-testid="share-link"` is on both the chip and the callout button.** Not a strict-mode violation today (they are mutually exclusive), but two different affordances share one id.
- **P3 — a refused link falls through with no message when the stored credentials are stale too.** The restore re-opens a stream, gets a second `you: null`, and takes the ordinary branch, so the player who pasted a key lands on the join screen unexplained.

## Verification

`pnpm lint`, `pnpm typecheck`, `pnpm test` (839 passed, 4 skipped) and the full Playwright suite (64 passed, 1 skipped — the quarantined Develop journey) green locally against the Docker test database.

CI is green on 29fff52 (`test`, `migrations`, `e2e`). Two earlier red runs on this branch were both infrastructure, not this diff: one Docker Hub pull timeout starting the local Postgres (`registry-1.docker.io … Client.Timeout exceeded`), and one 30s timeout in `gameStore.multiplayer.test.ts` — `over many games the first player is not always seat 0`, a pre-existing slow DB-backed test on `main` that this branch does not touch (838 passed alongside it; green on rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
