### PR TITLE
perf(e2e): cap Playwright's local workers at 2

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,6 +36,14 @@ if (localDb) {
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
+  // Playwright's local default is half the logical cores (5 here), and each
+  // worker is a browser plus its share of the dev server — enough that a few
+  // concurrent runs on one machine saturate it. The cap is PER REPO COPY, so N
+  // worktrees testing at once is still N × this; it lowers the multiplier
+  // rather than bounding the machine. PW_WORKERS widens or narrows a single run
+  // without editing this file. CI machines are dedicated, so they keep the
+  // default.
+  workers: process.env.CI ? undefined : Number(process.env.PW_WORKERS ?? 2),
   retries: 0,
   reporter: [['list']],
   globalSetup: './e2e/global-db.ts',


### PR DESCRIPTION
## The arithmetic first

`playwright.config.ts` set no `workers` key, so Playwright used its own default: **half the logical core count**, which on this M1 Pro (10 logical) resolves to **5** — not some larger number. Verified rather than assumed:

```
$ pnpm exec playwright test --list --reporter=json | jq .config.workers
5
```

That matters, because the obvious-looking `workers: 4` would be a **20% reduction and would achieve essentially nothing**. The problem was never one run's width — it is several runs multiplying. So the cap is **2**.

## What was happening

Three suites running at once produced **99 chrome-headless and 68 node processes (4.6G + 4.3G)**, 123 runnable threads on 10 cores, and a one-minute load average of **366** with under 700M of swap free. Docker was 552M and never the issue.

## The change

```ts
workers: process.env.CI ? undefined : Number(process.env.PW_WORKERS ?? 2),
```

- **CI is untouched** — `undefined` restores Playwright's own default, so CI machines are not slowed down.
- **Local gets the cap.**
- **`PW_WORKERS` is deliberate**: it widens or narrows a single run for a one-off without editing tracked config, which is exactly what a load situation needs. Documented in a comment beside the option.

Verified all three paths resolve correctly:

| condition | resolved workers |
|---|---|
| local (default) | 2 |
| `PW_WORKERS=4` | 4 |
| `CI=1` | 5 (Playwright's default for this box) |

## The cap is per repo copy

This reduces the multiplier; it does **not** bound the machine. Several worktrees testing at once is still N × 2. Anyone reading the config later needs to know that, or they will assume the machine is protected when it is not — hence the comment saying so in the file itself.

## Wall-clock cost

Full e2e suite, same machine, back to back:

| workers | wall clock | CPU (user+sys) |
|---|---|---|
| 5 (before) | **203s** (3.4m) | 612s |
| 2 (after) | **175s** (2.9m) | 456s |

The capped run was **faster**, not slower, and used 25% less CPU. That is not a free-lunch claim about the cap in general — it is a measurement taken while the machine was genuinely contended (one-minute load average ranged 24–110 across the two runs), which is precisely the condition this change exists for. Under contention, 5 workers is past the point of useful parallelism and the extra processes just fight each other.

Honest caveat: I could not get an idle machine to measure the isolated single-run cost. On an otherwise-quiet box, capping 5 → 2 should cost time; the suite is 18 files at ~3 minutes, so the realistic worst case is somewhere under 2× and probably nearer 1.3×, because the DB-backed specs are round-trip bound rather than CPU bound. If that trade is unwanted for a solo run, `PW_WORKERS=5` restores the old behaviour for that invocation.

## Scope

One config key plus its comment. `fullyParallel`, the webServer, and the database wiring are untouched.

## Pre-existing failures, not from this change

Both runs showed failures under load. `coverage.spec.ts:249 "Develop: scrap the lowest tile, consuming iron"` fails **on clean HEAD in isolation too** (`expect(locator).toBeVisible() failed / element(s) not found`) — verified by reverting the config and re-running that single spec. The other failures (`mp-playthrough`, `multiplayer`) differed between runs and are the load-sensitive DB-backed specs timing out; they are flaky under this machine load, not caused by the worker count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)