### PR TITLE
ci: run the end-to-end suite on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,85 @@ jobs:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
           branch: ci-run-${{ github.run_id }}-${{ github.run_attempt }}
           api_key: ${{ secrets.NEON_API_KEY }}
+
+  e2e:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24.18.0'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: '10.4.1'
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Resolve Playwright version
+        id: playwright
+        run: |
+          echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      # A cold browser download is the single biggest cost of this job, and the
+      # binaries only change when Playwright does — so the cache is keyed on its
+      # version, not the lockfile.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright.outputs.version }}
+
+      # Chromium only: playwright.config.ts declares one project, so firefox and
+      # webkit would be pure download time.
+      - name: Install Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      # The suite's DB-backed journeys (multiplayer, versus-AI) talk to Postgres
+      # through the Neon HTTP proxy, so compose.yaml's stack is what they need —
+      # not a bare postgres service container. It is also faster and secret-free
+      # compared with the Neon branch the unit job uses, which matters here
+      # because every assertion is a round trip. Isolation still holds twice
+      # over: the container is this runner's alone, and playwright.config.ts
+      # mints a fresh database inside it per run.
+      - name: Start local Postgres + Neon proxy
+        run: pnpm db:local
+
+      - name: Run end-to-end tests
+        run: pnpm exec playwright test
+
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Stop local database
+        if: always()
+        run: docker compose down -v

--- a/e2e/ai-opponent.spec.ts
+++ b/e2e/ai-opponent.spec.ts
@@ -47,8 +47,12 @@ test('found a company against an AI rival and watch it take its turn', async ({
   await expect(page.getByText(/Ada took a loan/)).toBeVisible()
 
   /* ---- the AI turn runs server-side without any input ---- */
-  // The mock rival also prefers a loan — its move lands in the journal…
-  await expect(page.getByText(/The Apprentice took a loan/)).toBeVisible()
+  // The mock rival also prefers a loan — its move lands in the journal. It
+  // may well have taken a second one by the time this resolves (round 2 gives
+  // two actions), so match the first line rather than demanding exactly one.
+  await expect(
+    page.getByText(/The Apprentice took a loan/).first(),
+  ).toBeVisible()
   // …its one-line rationale (and the spend meter) in the rival's journal…
   await expect(page.getByTestId('ai-rationale').first()).toContainText(
     'Mock rationale.',

--- a/e2e/coverage.spec.ts
+++ b/e2e/coverage.spec.ts
@@ -251,11 +251,12 @@ test('Develop: scrap the lowest tile, consuming iron', async ({ page }) => {
   await page.getByTestId('action-develop').click()
   await page.locator('button.bb2-card:not([disabled])').first().click()
 
-  // "Develop lowest available" auto-picks the cheapest developable tile,
-  // then the confirm step spells out the cost before executing.
-  await page.getByRole('button', { name: 'Develop lowest available' }).click()
+  // The develop steps open the player mat, which owns the whole flow:
+  // "Develop lowest available" auto-picks the cheapest developable tile, then
+  // the confirm step names what is about to be scrapped.
+  await page.getByTestId('develop-lowest').click()
   await expect(
-    page.getByText(/Scrapping: .*lowest available tile.* — consumes iron/),
+    page.getByText('Scrapping the lowest available tile.'),
   ).toBeVisible()
   await page.getByTestId('confirm-action').click()
 

--- a/e2e/mp-playthrough.spec.ts
+++ b/e2e/mp-playthrough.spec.ts
@@ -393,18 +393,16 @@ test('two browsers play a realistic opening: every action, both source pickers, 
 
         // The legal pick — the merchant's barrel — executes the sale.
         await sources.filter({ hasText: "merchant's barrel" }).first().click()
-        await expect(page.getByText(/Flipped 1 industry/).first()).toBeVisible()
         // Selling to the Gloucester merchant grants a develop bonus, which
-        // stops for a tile choice when the mat offers more than one track.
+        // stops for a tile choice when the mat offers more than one track —
+        // that step owns the dock, so it comes BEFORE the flip count is shown.
+        const flipped = page.getByText(/Flipped 1 industry/).first()
         const developPicker = page.getByTestId('develop-tile')
-        if (
-          await developPicker
-            .first()
-            .isVisible()
-            .catch(() => false)
-        ) {
+        await expect(flipped.or(developPicker.first())).toBeVisible()
+        if (await developPicker.first().isVisible()) {
           await developPicker.first().click()
         }
+        await expect(flipped).toBeVisible()
         await page.getByTestId('confirm-action').click()
         await settle(page)
 

--- a/e2e/multiplayer.spec.ts
+++ b/e2e/multiplayer.spec.ts
@@ -77,35 +77,52 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
   // the game starts for BOTH, live
   await expect(host.getByTestId('era-plate')).toHaveText('canal era')
   await expect(guest.getByTestId('era-plate')).toHaveText('canal era')
-  // Ada opens; the guest is spectating her turn behind the waiting panel
-  await expect(guest.getByTestId('waiting-panel')).toBeVisible()
-  await expect(guest.getByText('Waiting for Ada to act…')).toBeVisible()
 
-  /* ---- host acts; the guest's screen converges without any input ---- */
-  await host.getByTestId('action-loan').click()
-  await host.locator('button.bb2-card:not([disabled])').first().click()
-  await host.getByTestId('confirm-action').click()
-  await expect(guest.getByText(/Ada took a loan/)).toBeVisible()
-  await expect(treasuryOf(guest, 'Ada')).toHaveText('£47')
+  // The service picks the starting seat at random, so bind the roles to
+  // whoever actually opens instead of assuming the host leads. Both spends
+  // stay at £0 this round, so the tie keeps this order for round 2 as well.
+  await expect(
+    host.getByTestId('waiting-panel').or(host.getByTestId('action-loan')),
+  ).toBeVisible()
+  const hostOpens = await host.getByTestId('action-loan').isVisible()
+  const opener = hostOpens ? host : guest
+  const watcher = hostOpens ? guest : host
+  const openerName = hostOpens ? 'Ada' : 'Brunel'
+  const watcherSeat = hostOpens ? 1 : 0
 
-  /* ---- turn passes to the guest; both converge on round 2 ---- */
-  await expect(guest.getByTestId('action-pass')).toBeVisible()
-  await expect(host.getByTestId('waiting-panel')).toBeVisible()
-  // turn notification cues: the guest's tab title flags the turn, the
-  // host's does not; the unobtrusive permission bell is available
-  await expect(guest).toHaveTitle(/● Your turn — Brass/)
-  await expect(host).toHaveTitle(/^Brass: Birmingham$/)
+  // the idle player spectates the opener's turn behind the waiting panel
+  await expect(watcher.getByTestId('waiting-panel')).toBeVisible()
+  await expect(
+    watcher.getByText(`Waiting for ${openerName} to act…`),
+  ).toBeVisible()
+
+  /* ---- the opener acts; the other screen converges without any input ---- */
+  await opener.getByTestId('action-loan').click()
+  await opener.locator('button.bb2-card:not([disabled])').first().click()
+  await opener.getByTestId('confirm-action').click()
+  await expect(
+    watcher.getByText(new RegExp(`${openerName} took a loan`)),
+  ).toBeVisible()
+  await expect(treasuryOf(watcher, openerName)).toHaveText('£47')
+
+  /* ---- turn passes to the other player; both converge on round 2 ---- */
+  await expect(watcher.getByTestId('action-pass')).toBeVisible()
+  await expect(opener.getByTestId('waiting-panel')).toBeVisible()
+  // turn notification cues: the tab whose turn it is flags it in the title,
+  // the other does not; the unobtrusive permission bell is available
+  await expect(watcher).toHaveTitle(/● Your turn — Brass/)
+  await expect(opener).toHaveTitle(/^Brass: Birmingham$/)
   // the permission bell shows only while permission is undecided — the
   // test browser may auto-grant/deny, so gate the assertion on it
-  const notifyPermission = await guest.evaluate(() => Notification.permission)
+  const notifyPermission = await watcher.evaluate(() => Notification.permission)
   if (notifyPermission === 'default') {
-    await expect(guest.getByTestId('notify-enable')).toBeVisible()
+    await expect(watcher.getByTestId('notify-enable')).toBeVisible()
   } else {
-    await expect(guest.getByTestId('notify-enable')).toHaveCount(0)
+    await expect(watcher.getByTestId('notify-enable')).toHaveCount(0)
   }
   // Two-tap pass: arm, then confirm.
-  await guest.getByTestId('action-pass').click()
-  await guest.getByTestId('action-pass').click()
+  await watcher.getByTestId('action-pass').click()
+  await watcher.getByTestId('action-pass').click()
   await expect(host.getByTestId('round-chip')).toHaveText('Round 2/11')
   await expect(guest.getByTestId('round-chip')).toHaveText('Round 2/11')
 
@@ -132,26 +149,26 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
   await guest.reload()
   await expect(guest.getByTestId('round-chip')).toHaveText('Round 2/11')
 
-  /* ---- the host opens a Network action and picks a route, but does NOT
-     confirm: every step is a persisted intent that broadcasts, so this is
+  /* ---- the player to act opens a Network action and picks a route, but does
+     NOT confirm: every step is a persisted intent that broadcasts, so this is
      exactly the moment an opponent could watch the pick live ---- */
-  await expect(host.getByTestId('action-network')).toBeVisible()
-  await host.getByTestId('action-network').click()
+  await expect(opener.getByTestId('action-network')).toBeVisible()
+  await opener.getByTestId('action-network').click()
   await expect(
-    host.locator('button.bb2-card:not([disabled])').first(),
+    opener.locator('button.bb2-card:not([disabled])').first(),
   ).toBeVisible()
-  await host.locator('button.bb2-card:not([disabled])').first().click()
+  await opener.locator('button.bb2-card:not([disabled])').first().click()
   await expect(
-    host.getByText(/Choose a canal route — \d+ available/),
+    opener.getByText(/Choose a canal route — \d+ available/),
   ).toBeVisible()
-  const legalRoute = host.locator('path[data-conn][data-legal="true"]')
+  const legalRoute = opener.locator('path[data-conn][data-legal="true"]')
   await expect(legalRoute).not.toHaveCount(0)
   const pickedConn = (await legalRoute.first().getAttribute('data-conn'))!
-  await clickRoute(host, pickedConn)
-  await expect(host.getByTestId('confirm-action')).toBeEnabled()
+  await clickRoute(opener, pickedConn)
+  await expect(opener.getByTestId('confirm-action')).toBeEnabled()
 
-  /* ---- wire hygiene: read the guest's OWN stream bytes and inspect ---- */
-  const rawEvent = await guest.evaluate(
+  /* ---- wire hygiene: read the watching seat's OWN stream bytes ---- */
+  const rawEvent = await watcher.evaluate(
     async ({ token }) => {
       const creds = JSON.parse(localStorage.getItem(`bb-mp-${token}`)!) as {
         seatId: number
@@ -202,21 +219,22 @@ test('two browsers: create → join → live convergence → seat reclaim → wi
       }
     }
   }
-  expect(payload.you).toBe(1)
+  expect(payload.you).toBe(watcherSeat)
   const ctx = payload.snapshot.context
-  // the guest's own hand is real…
-  expect(ctx.players[1]!.hand.length).toBeGreaterThan(0)
-  expect(ctx.players[1]!.hand.every((c) => !c.id.startsWith('hidden-'))).toBe(
-    true,
-  )
-  // …the host's hand and the deck are placeholders, counts only
-  expect(ctx.players[0]!.hand.length).toBeGreaterThan(0)
-  expect(ctx.players[0]!.hand.every((c) => c.id.startsWith('hidden-'))).toBe(
-    true,
-  )
+  const openerSeat = watcherSeat === 1 ? 0 : 1
+  // the watching seat's own hand is real…
+  expect(ctx.players[watcherSeat]!.hand.length).toBeGreaterThan(0)
+  expect(
+    ctx.players[watcherSeat]!.hand.every((c) => !c.id.startsWith('hidden-')),
+  ).toBe(true)
+  // …the acting seat's hand and the deck are placeholders, counts only
+  expect(ctx.players[openerSeat]!.hand.length).toBeGreaterThan(0)
+  expect(
+    ctx.players[openerSeat]!.hand.every((c) => c.id.startsWith('hidden-')),
+  ).toBe(true)
   expect(ctx.drawPile.every((c) => c.id.startsWith('hidden-'))).toBe(true)
-  // …and the host's IN-PROGRESS selection is redacted: the route she just
-  // picked is nowhere in the guest's frame, so it cannot light up their map.
+  // …and the acting seat's IN-PROGRESS selection is redacted: the route just
+  // picked is nowhere in this frame, so it cannot light up their map.
   expect(ctx.selectedLink).toBeNull()
   expect(ctx.selectedSecondLink).toBeNull()
   expect(ctx.selectedLocation).toBeNull()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -63,7 +63,9 @@ export default defineConfig({
     // GOTCHA: an already-running `pnpm dev` on :3199 is reused as-is, and it
     // reads DATABASE_URL from `.env` — so this run's database is NOT what it
     // talks to. Stop your dev server for a faithful DB-backed e2e run.
-    reuseExistingServer: true,
+    // Never reuse on CI: nothing should be listening there, and a stray server
+    // would be serving a different database than this run created.
+    reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     // Next only fills gaps from `.env*`, so an explicit value wins: this is what
     // points the dev server at this run's database.


### PR DESCRIPTION
Adds a Playwright job to CI, so the browser-level suite runs on every pull request instead of only when someone remembers to run it locally.

This is the "add" half only. The routine local loop is unchanged: no `package.json` script moved, no policy written down yet. That follows once this is green and has a few runs behind it.

## Why now

Nothing has been running the browser suite automatically, and it showed — four journeys had rotted against features that shipped past them, and they fail on `main` today:

- `coverage.spec` still asserted the dock's `Scrapping: …` note, but Develop moved onto the player mat and the dock renders a pointer aside instead.
- `multiplayer.spec` assumed the host takes the first turn. The service picks the starting seat at random (#89), so this test was a coin flip; it now binds its roles to whoever actually opens.
- `mp-playthrough` expected the flip count straight after the beer pick, but a Gloucester sale stops on the develop-bonus tile choice first, and that step owns the dock.

A fourth surfaced only on CI: `ai-opponent` demanded exactly one "took a loan" journal line from the mock rival, which breaks the moment it gets far enough to take a second. All four are fixed here; the suite is 63/63 green.

## How the job is set up

- **Database: compose.yaml's Postgres + Neon HTTP proxy, not a Neon branch.** The suite is round-trip bound (every assertion is a POST + SSE hop), so a local stack is much faster than us-east-1; it needs no secrets, so it also works on forks; and it costs nothing on a public repo. Isolation still holds twice over — the container belongs to that runner alone, and `playwright.config.ts` mints a fresh database inside it per run. `docker compose down -v` runs in an `always()` step, so cleanup happens on failure too. The unit `test` job keeps its per-run Neon branch, untouched.
- **Chromium only, cached.** The config declares one project, so firefox/webkit would be pure download time. The cache is keyed on the Playwright version rather than the lockfile, since that is what actually changes the binaries.
- **`reuseExistingServer` is now off on CI.** Locally it still reuses a running `pnpm dev`; on CI nothing should be listening, and a stray server would be pointed at a different database than the run created.
- Traces upload as an artifact on failure (7-day retention).

## Cost and the tradeoff

- Measured on this PR: the e2e job takes **5m30s** end to end — 3m46s of that is the suite itself (63 tests, 2 workers), plus ~40s installing Chromium on a cold cache and ~25s bringing the database stack up. Locally the same suite is ~3.7 min at the repo's 2-worker cap on a 10-core machine, so the 4 vCPU runner is roughly at parity here; it is slower per test but nothing else is competing for the machine. It runs in parallel with `test` (1m40s), so the workflow's critical path goes from ~1m40s to ~5m30s.
- brass is a public repo, so `ubuntu-latest` minutes are free and unlimited. The account-wide concurrency cap is 20 jobs and this workflow is 3 jobs per run, so queueing is not a practical concern at current usage.
- **Failure mode, stated plainly:** if GitHub Actions is down (there was a ~40-minute outage last night), a CI-owned e2e path means no browser-level verification until it returns. The escape hatch is unchanged and stays one command away — `pnpm db:local` then `pnpm exec playwright test`, or a single spec with `pnpm exec playwright test e2e/multiplayer.spec.ts`.
