### PR TITLE
fix(board): pin the board prompt to the viewport, not the board frame

### DIFF
--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -1025,11 +1025,19 @@ export function BoardMap({
         )}
       </svg>
 
-      {/* prompt banner — the board's own instruction, high contrast */}
+      {/* Prompt banner — the board's own instruction, high contrast.
+          Pinned to the VIEWPORT, not the board frame: below `lg` the page
+          itself scrolls, and an instruction anchored to the board scrolls
+          away the moment the player reaches down to the hand or the dock.
+          `fixed` escapes the frame's `overflow: hidden` because nothing
+          between here and the root carries a transform. */}
       {prompt && (
-        <div className="pointer-events-none absolute left-1/2 top-3 z-10 -translate-x-1/2">
+        <div
+          className="pointer-events-none fixed left-1/2 z-40 flex max-w-[min(100vw-1.5rem,32rem)] -translate-x-1/2 justify-center"
+          style={{ top: 'calc(env(safe-area-inset-top, 0px) + 0.75rem)' }}
+        >
           <div
-            className="bb2-rise flex items-center gap-2 rounded border px-4 py-2 text-[13px] font-semibold tracking-wide"
+            className="bb2-rise flex items-center gap-2 rounded border px-4 py-2 text-center text-[13px] font-semibold tracking-wide"
             style={{
               background: 'rgba(20, 16, 11, 0.92)',
               borderColor: 'var(--bb-brass)',
@@ -1039,7 +1047,7 @@ export function BoardMap({
             }}
           >
             <span
-              className="inline-block h-2 w-2 rounded-full"
+              className="inline-block h-2 w-2 shrink-0 rounded-full"
               style={{ background: 'var(--bb-brass-bright)' }}
             />
             {prompt}


### PR DESCRIPTION
The board's floating instruction (`Choose a site for your cotton — 1 legal city`, `Choose a canal route — N available`) was positioned against the board frame. Below `lg` the page itself scrolls — only at `lg` does the layout lock to viewport height — and the frame is `h-[52vh]`, so the instruction telling you what to do slid out of view the moment you reached down toward the hand or the dock. Measured at 390×844, the banner is fully above the fold the instant a card is picked (top `-93.7px`).

It is now pinned to the viewport on both mobile and desktop:

- `fixed` with `top: calc(env(safe-area-inset-top, 0px) + 0.75rem)`, so it clears a notch / dynamic island rather than assuming a pixel value.
- Width capped at `min(100vw - 1.5rem, 32rem)` so a long prompt wraps inside the screen instead of running off the edge at 390px; the dot marker is `shrink-0` so it survives the wrap.
- Still `pointer-events-none` — it never intercepts a tap on whatever is underneath.
- `z-40`, i.e. above the board and below the curtain overlays.

`fixed` escapes the frame's `overflow: hidden` because nothing between the banner and the root carries a transform.

### Clearance

The zoom controls and the legend are both bottom-anchored (`bottom-3 right-3` / `bottom-3 left-3`, as PR #96 left them), so there is no collision with a top-pinned banner. Measured with the banner at `top: 12`: reset button at `y=231` (390px) and `y=656` (1280px); the legend is hidden below `sm`.

On desktop the banner now sits over the masthead strip rather than over the map — so it covers no board content at all there, and because it is `pointer-events-none` the Find and New Game buttons behind it remain clickable. This is the same overlap the app's own top-right toasts already have with the masthead.

### Verification

Driven through a real build flow (BUILD → industry card → site picking) in Chromium at 390×844 (mobile emulation, touch) and 1280×800, with a real wheel scroll and a real pointer drag-pan plus wheel-zoom on the board — not static shots. Banner rect in viewport coordinates:

| | before | after |
|---|---|---|
| 390, after picking a card | `top -93.7` — **off-screen** | `top 12` — visible |
| 390, scrolled 600px further | `top -693.7` — **off-screen** | `top 12` — visible |
| 390, after pan + zoom | `top 272.3` | `top 12` |
| 1280, all three | `top 202.3` (inside the frame) | `top 12` |

**390px, scrolled down to the market and journal — before:**

![before 390 scrolled](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr101-before-390-scrolled.png)

**…and after — the instruction is still there:**

![after 390 scrolled](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr101-after-390-scrolled.png)

**390px, after a real pan + zoom:**

![after 390 pan zoom](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr101-after-390-panzoom.png)

**1280px, before → after:**

![before 1280](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr101-before-1280-panzoom.png)

![after 1280](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr101-after-1280-panzoom.png)

### Separate finding: the develop flow has no board prompt at all

Worth flagging because this was noticed while developing, and it may be the actual gap behind the original complaint. `boardPrompt` — in both `game.tsx` and `mp/mp-game.tsx` — is non-null only for `building.selectingLocation` and `networking.selectingLink` / `selectingSecondLink`. Develop never produces one, so there is no board banner during a develop at any scroll position; its instruction lives only in the dock and the player-mat modal. Sell, scout, loan and the resource-source choice steps are the same.

I have deliberately **not** touched that here — no develop wording and no new prompt state — since whether develop should get a board prompt (and what it should say when the mat modal already covers the board) is a separate call.

### Checks

`pnpm lint`, `pnpm typecheck`, `pnpm test` (810 passed) all green. Playwright run with `--workers=2`: 61 passed, 2 failed — `coverage.spec.ts` "Develop: scrap the lowest tile" reproduces identically on unmodified `main`, and `lobby-browser.spec.ts` passes on re-run (DB timing flake).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the prompt banner’s positioning so it remains properly visible and centered across different viewport sizes.
  * Added support for safe-area spacing on supported devices.
  * Prevented the banner’s decorative indicator from shrinking alongside the prompt text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->