### PR TITLE
test(e2e): quarantine the Develop journey instead of re-pointing it

### DIFF
--- a/e2e/coverage.spec.ts
+++ b/e2e/coverage.spec.ts
@@ -246,24 +246,30 @@ test('Scout: discard three cards for the two wilds', async ({ page }) => {
   await expect(page.getByTestId('round-chip')).toHaveText('Round 8/10')
 })
 
-test('Develop: scrap the lowest tile, consuming iron', async ({ page }) => {
-  await page.goto('/?demo')
-  await page.getByTestId('action-develop').click()
-  await page.locator('button.bb2-card:not([disabled])').first().click()
+// QUARANTINED, not repaired: this journey fails on unmodified main, and a
+// separate diagnosis is deciding whether the spec or the develop flow is the
+// wrong half. Its assertions are left exactly as they are so that diagnosis
+// has the original failure to work from. Re-enable with that decision.
+test.fixme(
+  'Develop: scrap the lowest tile, consuming iron',
+  async ({ page }) => {
+    await page.goto('/?demo')
+    await page.getByTestId('action-develop').click()
+    await page.locator('button.bb2-card:not([disabled])').first().click()
 
-  // The develop steps open the player mat, which owns the whole flow:
-  // "Develop lowest available" auto-picks the cheapest developable tile, then
-  // the confirm step names what is about to be scrapped.
-  await page.getByTestId('develop-lowest').click()
-  await expect(
-    page.getByText('Scrapping the lowest available tile.'),
-  ).toBeVisible()
-  await page.getByTestId('confirm-action').click()
+    // "Develop lowest available" auto-picks the cheapest developable tile,
+    // then the confirm step spells out the cost before executing.
+    await page.getByRole('button', { name: 'Develop lowest available' }).click()
+    await expect(
+      page.getByText(/Scrapping: .*lowest available tile.* — consumes iron/),
+    ).toBeVisible()
+    await page.getByTestId('confirm-action').click()
 
-  await expect(page.getByText(/Eliza developed removed 1 tile/)).toBeVisible()
-  // Her turn ends but the round continues with the next player.
-  await expect(page.getByTestId('round-chip')).toHaveText('Round 8/10')
-})
+    await expect(page.getByText(/Eliza developed removed 1 tile/)).toBeVisible()
+    // Her turn ends but the round continues with the next player.
+    await expect(page.getByTestId('round-chip')).toHaveText('Round 8/10')
+  },
+)
 
 test('era transition: one pass ends the Canal Era and opens the Rail Era', async ({
   page,


### PR DESCRIPTION
Follow-up to #100, which merged while this was being written.

`Develop: scrap the lowest tile, consuming iron` fails on unmodified `main`, and a separate diagnosis is under way on whether the spec or the develop flow is the wrong half. #100 repaired it by re-pointing the assertion at the player mat that now owns the flow — which makes it pass, but also removes the failure the diagnosis needs to work from, and pre-empts a call that is not mine to make.

This restores the original assertions verbatim and marks the test `fixme` instead. It reports as an explicit skip in the run output rather than quietly passing under a rewritten expectation:

```
  1 skipped
```

The re-pointed version is in #100's history if the diagnosis lands on "the spec was stale" — the fix is then to drop the `test.fixme` marker and take that diff back.

No other test is touched; the rest of the suite stays green.
