### PR TITLE
feat(ui): move next-step narration into each surface's own chrome

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -657,6 +657,21 @@ What this means in practice:
   (`legalCityTargets` / `legalLinkTargets`), used by both `game.tsx` and
   `mp/mp-game.tsx`. It enumerates and asks `can()`; it re-derives no rule. See
   "Legality is engine-owned" below.
+- NEXT-STEP NARRATION IS OWN-SURFACE (2026-07-24, supersedes the floating
+  banner + tray pill): nothing floats over the play area. The board's
+  instruction is a caption bar in the frame's NORMAL FLOW
+  (`components/board-caption.ts`, shared by both shells — site/route picks
+  AND the beer/iron/coal source steps, counts from the same sets the
+  spotlight uses); the tray's hint is `.bb2-tray-label` inside the tray band
+  (absolutely positioned, ZERO height reserve — `hintClearance` and the old
+  pill are gone, so the fan never moves when the hint changes; don't
+  reintroduce a hint that resizes the tray, that's the PR #81 jumping-hand
+  regression); dock and mat modal narrate themselves. On phones a wizard
+  step change scrolls the surface that owns the next tap into view
+  (`step-scroll.ts` pure decision + `use-step-scroll.ts` applied half; 2s
+  don't-fight-the-player window, `prefers-reduced-motion` honoured, no-op on
+  lg). The board legend sits top-right — the frame's bottom-left apron
+  belongs to the tray label.
 - Boot order in `game.tsx` (client-side, behind a mount gate):
   `/?preview=gameover` → `/?era=rail` (rail fixture) → `/?demo` (canal
   fixture) → `/?fresh=1` → localStorage save (`bb2-save-v1`) → setup

--- a/e2e/board-touch-zoom.spec.ts
+++ b/e2e/board-touch-zoom.spec.ts
@@ -187,6 +187,13 @@ test('phone: a tap after zooming selects the tile under the finger', async ({
     })
     .toBe(true)
   await svg.scrollIntoViewIfNeeded()
+  // The demo fixture boots with a stale lastError toast ("Insufficient
+  // coal…"); with the board scrolled to the viewport top, the toast overlays
+  // the exact spot Derby occupies, and a touch landing on it never reaches
+  // the svg. Wait for it to expire before dispatching real touches.
+  await expect(page.locator('[data-sonner-toast]')).toHaveCount(0, {
+    timeout: 10_000,
+  })
   const cdp = await page.context().newCDPSession(page)
   const board = await boardBox(page)
   const small = (await derby.boundingBox())!

--- a/e2e/board-touch-zoom.spec.ts
+++ b/e2e/board-touch-zoom.spec.ts
@@ -175,8 +175,17 @@ test('phone: a tap after zooming selects the tile under the finger', async ({
 
   // Pinch in on Derby itself, then tap it where it now sits.
   const svg = page.getByLabel('Game board map')
-  // Picking the card scrolled the phone page down to the hand tray — touch
-  // coordinates are viewport-relative, so bring the board back first.
+  // Entering the site step auto-scrolls the board into view with a SMOOTH
+  // animation (use-step-scroll) — touch coordinates are viewport-relative,
+  // so wait for the page to stop moving before measuring anything.
+  await expect
+    .poll(async () => {
+      const y1 = await page.evaluate(() => window.scrollY)
+      await page.waitForTimeout(250)
+      const y2 = await page.evaluate(() => window.scrollY)
+      return y1 === y2
+    })
+    .toBe(true)
   await svg.scrollIntoViewIfNeeded()
   const cdp = await page.context().newCDPSession(page)
   const board = await boardBox(page)

--- a/e2e/card-first.spec.ts
+++ b/e2e/card-first.spec.ts
@@ -54,7 +54,7 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   const held = page.getByTestId('card-brewery_2')
   await expect(held).toHaveAttribute('data-selected', 'true')
   await expect(
-    page.locator('.bb2-hand-hint').getByText(/^Holding /),
+    page.getByTestId('hand-hint').getByText(/^Holding /),
   ).toBeVisible()
 
   const legalRoute = page.locator('path[data-conn][data-legal="true"]')
@@ -67,7 +67,7 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   // Still held through the confirm step, right up until it's spent.
   await expect(held).toHaveAttribute('data-selected', 'true')
   await expect(
-    page.locator('.bb2-hand-hint').getByText(/^Holding /),
+    page.getByTestId('hand-hint').getByText(/^Holding /),
   ).toBeVisible()
   await confirm.click()
 
@@ -166,7 +166,7 @@ test('card-first: clicking another card mid-action cancels it and re-holds the n
   await birmingham.click()
   await page.getByTestId('action-network').click()
   await expect(
-    page.locator('.bb2-hand-hint').getByText(/^Holding /),
+    page.getByTestId('hand-hint').getByText(/^Holding /),
   ).toBeVisible()
   await expect(birmingham).toHaveAttribute('data-selected', 'true')
 

--- a/src/components/board-caption.test.ts
+++ b/src/components/board-caption.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import type { GameState } from '~/store/gameStore'
+import { boardCaption } from './board-caption'
+
+const stateAt = (step: string, context: Partial<GameState> = {}) => ({
+  matches: (path: never) => (path as string) === step,
+  context: context as GameState,
+})
+
+const none = { legalCities: null, legalLinks: null, sourceCities: null }
+
+describe('boardCaption', () => {
+  it('narrates the site pick with the tile name and legal count', () => {
+    const caption = boardCaption(
+      stateAt('playing.action.building.selectingLocation', {
+        selectedIndustryTile: { type: 'cotton' } as never,
+      }),
+      { ...none, legalCities: new Set(['birmingham', 'coventry']) },
+    )
+    expect(caption).toBe('Choose a site for your cotton — 2 legal cities')
+  })
+
+  it('renames manufacturer to goods works and singularizes one city', () => {
+    const caption = boardCaption(
+      stateAt('playing.action.building.selectingLocation', {
+        selectedIndustryTile: { type: 'manufacturer' } as never,
+      }),
+      { ...none, legalCities: new Set(['birmingham']) },
+    )
+    expect(caption).toBe('Choose a site for your goods works — 1 legal city')
+  })
+
+  it('narrates the route pick with the era and available count', () => {
+    const caption = boardCaption(
+      stateAt('playing.action.networking.selectingLink', { era: 'canal' }),
+      { ...none, legalLinks: new Set(['a|b', 'b|a', 'c|d', 'd|c']) },
+    )
+    expect(caption).toBe('Choose a canal route — 2 available')
+  })
+
+  it('narrates the second rail link as such', () => {
+    const caption = boardCaption(
+      stateAt('playing.action.networking.selectingSecondLink', {
+        era: 'rail',
+      }),
+      { ...none, legalLinks: new Set(['a|b', 'b|a']) },
+    )
+    expect(caption).toBe('Choose a second rail route — 1 available')
+  })
+
+  it.each([
+    ['playing.action.selling.choosingBeerSource', 'beer source'],
+    ['playing.action.networking.choosingDoubleLinkBeer', 'beer source'],
+    ['playing.action.building.choosingIronSource', 'iron works'],
+    ['playing.action.developing.choosingIronSource', 'iron works'],
+    ['playing.action.building.choosingCoalSource', 'coal mine'],
+    ['playing.action.networking.choosingLinkCoal', 'coal mine'],
+    ['playing.action.networking.choosingDoubleLinkCoal', 'coal mine'],
+  ])('captions the source step %s', (step, noun) => {
+    const caption = boardCaption(stateAt(step), {
+      ...none,
+      sourceCities: new Set(['stone', 'stafford']),
+    })
+    expect(caption).toBe(
+      `Choose ${noun === 'iron works' ? 'an' : 'a'} ${noun} — 2 lit on the map`,
+    )
+  })
+
+  it('shows nothing for a source step whose candidates are not on the board', () => {
+    // Market-only iron lights no city; a bystander's filtered view is null.
+    expect(
+      boardCaption(stateAt('playing.action.building.choosingIronSource'), {
+        ...none,
+        sourceCities: null,
+      }),
+    ).toBeNull()
+  })
+
+  it('shows nothing when the next tap is not on the board', () => {
+    for (const step of [
+      'playing.action.selectingAction',
+      'playing.action.building.confirmingBuild',
+      'playing.action.selling.selectingSale',
+    ]) {
+      expect(boardCaption(stateAt(step), none)).toBeNull()
+    }
+  })
+})

--- a/src/components/board-caption.ts
+++ b/src/components/board-caption.ts
@@ -1,0 +1,66 @@
+// The board's one-line caption: what the map is asking for right now, shown
+// in the board frame's own chrome (a strip in normal flow above the svg —
+// never an overlay on the play area). Shared by both surfaces, like
+// legal-targets.ts and source-spotlight.ts, so the wording cannot drift.
+//
+// It renders ONLY when the next tap is on the board: a build's site pick, a
+// network route pick, and the beer/iron/coal source steps whose candidates
+// the map already spotlights. Every count comes from sets the engine's own
+// guards produced — no rule is re-derived here.
+import type { GameState } from '~/store/gameStore'
+import {
+  BEER_STEPS,
+  COAL_STEPS,
+  IRON_STEPS,
+  type SourceStepState,
+} from './source-spotlight'
+
+export interface BoardCaptionInputs {
+  /** Legal SELECT_LOCATION targets (null = not picking a site). */
+  legalCities: ReadonlySet<string> | null
+  /** Legal link targets, keyed both orders (null = not picking a route). */
+  legalLinks: ReadonlySet<string> | null
+  /** Cities the open source step spotlights (sourceCandidateCities). */
+  sourceCities: ReadonlySet<string> | null
+}
+
+interface CaptionState {
+  matches: (path: never) => boolean
+  context: GameState
+}
+
+const inAnyStep = (state: SourceStepState, paths: readonly string[]): boolean =>
+  paths.some((path) => state.matches(path as never))
+
+export function boardCaption(
+  state: CaptionState,
+  { legalCities, legalLinks, sourceCities }: BoardCaptionInputs,
+): string | null {
+  const is = (path: string) => state.matches(path as never)
+  const ctx = state.context
+
+  if (is('playing.action.building.selectingLocation')) {
+    const t = ctx.selectedIndustryTile?.type
+    const n = legalCities?.size ?? 0
+    return `Choose a site for your ${t === 'manufacturer' ? 'goods works' : (t ?? 'industry')} — ${n} legal ${n === 1 ? 'city' : 'cities'}`
+  }
+
+  const pickingSecondLink = is('playing.action.networking.selectingSecondLink')
+  if (is('playing.action.networking.selectingLink') || pickingSecondLink) {
+    const n = (legalLinks?.size ?? 0) / 2
+    return `Choose ${pickingSecondLink ? 'a second' : 'a'} ${ctx.era} route — ${n} available`
+  }
+
+  // Source steps only park the machine when there is a real choice; a
+  // bystander's filtered view carries no staged selection, so their
+  // sourceCities is null and no caption shows for them.
+  if (sourceCities && sourceCities.size > 0) {
+    const n = sourceCities.size
+    const lit = `${n} lit on the map`
+    if (inAnyStep(state, BEER_STEPS)) return `Choose a beer source — ${lit}`
+    if (inAnyStep(state, IRON_STEPS)) return `Choose an iron works — ${lit}`
+    if (inAnyStep(state, COAL_STEPS)) return `Choose a coal mine — ${lit}`
+  }
+
+  return null
+}

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -580,594 +580,602 @@ export function BoardMap({
   /* ---------------- render ---------------- */
 
   return (
-    <div className="relative h-full w-full">
-      <svg
-        ref={svgRef}
-        viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
-        className="h-full w-full touch-none select-none"
-        onPointerDown={onPointerDown}
-        onPointerMove={onPointerMove}
-        onPointerUp={onPointerUp}
-        onPointerCancel={onPointerUp}
-        // NOT role="img": that would flatten the tree and hide the city /
-        // route buttons from assistive tech and accessibility tooling.
-        role="group"
-        aria-label="Game board map"
-      >
-        <defs>
-          <linearGradient id="bb2-plate" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stopColor="#efe2c0" />
-            <stop offset="0.7" stopColor="#e0cea2" />
-            <stop offset="1" stopColor="#d0ba89" />
-          </linearGradient>
-          <linearGradient id="bb2-merchant-plate" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0" stopColor="#3a3428" />
-            <stop offset="1" stopColor="#2a251b" />
-          </linearGradient>
-          <filter
-            id="bb2-plate-shadow"
-            x="-30%"
-            y="-30%"
-            width="160%"
-            height="170%"
-          >
-            <feDropShadow
-              dx="0"
-              dy="5"
-              stdDeviation="7"
-              floodColor="#000000"
-              floodOpacity="0.55"
-            />
-          </filter>
-        </defs>
-
-        {/* survey grid */}
-        <g stroke="#e7d7b1" strokeOpacity="0.035" strokeWidth="1">
-          {Array.from({ length: 11 }, (_, i) => (
-            <line
-              key={`v${i}`}
-              x1={i * 160}
-              y1={-40}
-              x2={i * 160}
-              y2={VIEW_H + 40}
-            />
-          ))}
-          {Array.from({ length: 8 }, (_, i) => (
-            <line
-              key={`h${i}`}
-              x1={-40}
-              y1={i * 160}
-              x2={VIEW_W + 40}
-              y2={i * 160}
-            />
-          ))}
-        </g>
-
-        {/* cartouche */}
-        <g transform="translate(105, 60)" opacity="0.9" pointerEvents="none">
-          <rect
-            x="0"
-            y="0"
-            width="255"
-            height="118"
-            fill="none"
-            stroke="#c39538"
-            strokeOpacity="0.55"
-            strokeWidth="1.5"
-          />
-          <rect
-            x="6"
-            y="6"
-            width="243"
-            height="106"
-            fill="none"
-            stroke="#c39538"
-            strokeOpacity="0.3"
-            strokeWidth="0.8"
-          />
-          <text
-            x="127"
-            y="52"
-            textAnchor="middle"
-            fill="#e6bd63"
-            style={{
-              fontFamily: 'var(--bb-display)',
-              fontWeight: 900,
-              fontSize: 34,
-              letterSpacing: '0.24em',
-            }}
-          >
-            BRASS
-          </text>
-          <text
-            x="127"
-            y="76"
-            textAnchor="middle"
-            fill="#e7d7b1"
-            fillOpacity="0.8"
-            style={{
-              fontFamily: 'var(--bb-display)',
-              fontStyle: 'italic',
-              fontSize: 13.5,
-            }}
-          >
-            Birmingham &amp; the West Midlands
-          </text>
-          <text
-            x="127"
-            y="96"
-            textAnchor="middle"
-            fill="#e7d7b1"
-            fillOpacity="0.5"
-            style={{
-              fontFamily: 'var(--bb-body)',
-              fontSize: 10,
-              letterSpacing: '0.3em',
-            }}
-          >
-            ANNO 1770 — 1870
-          </text>
-        </g>
-
-        {/* compass rose */}
-        <g
-          transform="translate(1480, 980)"
-          stroke="#c39538"
-          strokeOpacity="0.5"
-          fill="none"
-          pointerEvents="none"
+    <div className="flex h-full w-full flex-col">
+      {/* Caption bar — the board's own one-line instruction, part of the
+          frame chrome. In normal flow: it pushes the map down and can never
+          cover it. Rendered only while the next tap is on the board. */}
+      {prompt && (
+        <div
+          data-testid="board-caption"
+          className="flex flex-none items-center gap-2 truncate border-b px-3 py-1.5 text-[12px] font-semibold tracking-wide"
+          style={{
+            background: 'rgba(20, 16, 11, 0.92)',
+            borderColor: 'var(--bb-brass-hairline)',
+            color: 'var(--bb-parchment-bright)',
+          }}
         >
-          <circle r="46" strokeWidth="1" />
-          <circle r="34" strokeWidth="0.6" strokeOpacity="0.35" />
-          <path
-            d="M0 -58 L9 -9 L0 0 L-9 -9 Z"
-            fill="#c39538"
-            fillOpacity="0.55"
-            stroke="none"
+          <span
+            className="inline-block h-2 w-2 flex-none rounded-full"
+            style={{ background: 'var(--bb-brass-bright)' }}
           />
-          <path
-            d="M0 58 L9 9 L0 0 L-9 9 Z M-58 0 L-9 -9 L0 0 L-9 9 Z M58 0 L9 -9 L0 0 L9 9 Z"
-            fill="#c39538"
-            fillOpacity="0.25"
-            stroke="none"
-          />
-          <text
-            y="-66"
-            textAnchor="middle"
-            fill="#c39538"
-            fillOpacity="0.7"
-            stroke="none"
-            style={{ fontFamily: 'var(--bb-display)', fontSize: 18 }}
+          <span className="truncate">{prompt}</span>
+        </div>
+      )}
+      <div className="relative min-h-0 w-full flex-1">
+        <svg
+          ref={svgRef}
+          viewBox={`${vb.x} ${vb.y} ${vb.w} ${vb.h}`}
+          className="h-full w-full touch-none select-none"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          // NOT role="img": that would flatten the tree and hide the city /
+          // route buttons from assistive tech and accessibility tooling.
+          role="group"
+          aria-label="Game board map"
+        >
+          <defs>
+            <linearGradient id="bb2-plate" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor="#efe2c0" />
+              <stop offset="0.7" stopColor="#e0cea2" />
+              <stop offset="1" stopColor="#d0ba89" />
+            </linearGradient>
+            <linearGradient id="bb2-merchant-plate" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0" stopColor="#3a3428" />
+              <stop offset="1" stopColor="#2a251b" />
+            </linearGradient>
+            <filter
+              id="bb2-plate-shadow"
+              x="-30%"
+              y="-30%"
+              width="160%"
+              height="170%"
+            >
+              <feDropShadow
+                dx="0"
+                dy="5"
+                stdDeviation="7"
+                floodColor="#000000"
+                floodOpacity="0.55"
+              />
+            </filter>
+          </defs>
+
+          {/* survey grid */}
+          <g stroke="#e7d7b1" strokeOpacity="0.035" strokeWidth="1">
+            {Array.from({ length: 11 }, (_, i) => (
+              <line
+                key={`v${i}`}
+                x1={i * 160}
+                y1={-40}
+                x2={i * 160}
+                y2={VIEW_H + 40}
+              />
+            ))}
+            {Array.from({ length: 8 }, (_, i) => (
+              <line
+                key={`h${i}`}
+                x1={-40}
+                y1={i * 160}
+                x2={VIEW_W + 40}
+                y2={i * 160}
+              />
+            ))}
+          </g>
+
+          {/* cartouche */}
+          <g transform="translate(105, 60)" opacity="0.9" pointerEvents="none">
+            <rect
+              x="0"
+              y="0"
+              width="255"
+              height="118"
+              fill="none"
+              stroke="#c39538"
+              strokeOpacity="0.55"
+              strokeWidth="1.5"
+            />
+            <rect
+              x="6"
+              y="6"
+              width="243"
+              height="106"
+              fill="none"
+              stroke="#c39538"
+              strokeOpacity="0.3"
+              strokeWidth="0.8"
+            />
+            <text
+              x="127"
+              y="52"
+              textAnchor="middle"
+              fill="#e6bd63"
+              style={{
+                fontFamily: 'var(--bb-display)',
+                fontWeight: 900,
+                fontSize: 34,
+                letterSpacing: '0.24em',
+              }}
+            >
+              BRASS
+            </text>
+            <text
+              x="127"
+              y="76"
+              textAnchor="middle"
+              fill="#e7d7b1"
+              fillOpacity="0.8"
+              style={{
+                fontFamily: 'var(--bb-display)',
+                fontStyle: 'italic',
+                fontSize: 13.5,
+              }}
+            >
+              Birmingham &amp; the West Midlands
+            </text>
+            <text
+              x="127"
+              y="96"
+              textAnchor="middle"
+              fill="#e7d7b1"
+              fillOpacity="0.5"
+              style={{
+                fontFamily: 'var(--bb-body)',
+                fontSize: 10,
+                letterSpacing: '0.3em',
+              }}
+            >
+              ANNO 1770 — 1870
+            </text>
+          </g>
+
+          {/* compass rose */}
+          <g
+            transform="translate(1480, 980)"
+            stroke="#c39538"
+            strokeOpacity="0.5"
+            fill="none"
+            pointerEvents="none"
           >
-            N
-          </text>
-        </g>
+            <circle r="46" strokeWidth="1" />
+            <circle r="34" strokeWidth="0.6" strokeOpacity="0.35" />
+            <path
+              d="M0 -58 L9 -9 L0 0 L-9 -9 Z"
+              fill="#c39538"
+              fillOpacity="0.55"
+              stroke="none"
+            />
+            <path
+              d="M0 58 L9 9 L0 0 L-9 9 Z M-58 0 L-9 -9 L0 0 L-9 9 Z M58 0 L9 -9 L0 0 L9 9 Z"
+              fill="#c39538"
+              fillOpacity="0.25"
+              stroke="none"
+            />
+            <text
+              y="-66"
+              textAnchor="middle"
+              fill="#c39538"
+              fillOpacity="0.7"
+              stroke="none"
+              style={{ fontFamily: 'var(--bb-display)', fontSize: 18 }}
+            >
+              N
+            </text>
+          </g>
 
-        {/* ------------ routes ------------ */}
-        <g>
-          {linkStates.map((state) => {
-            const {
-              conn,
-              key,
-              d,
-              activeThisEra,
-              built,
-              isLegal,
-              isSelected,
-              isHighlighted,
-              renderType,
-              dimmed,
-            } = state
+          {/* ------------ routes ------------ */}
+          <g>
+            {linkStates.map((state) => {
+              const {
+                conn,
+                key,
+                d,
+                activeThisEra,
+                built,
+                isLegal,
+                isSelected,
+                isHighlighted,
+                renderType,
+                dimmed,
+              } = state
 
-            return (
-              <g key={key} opacity={dimmed ? 0.3 : 1}>
-                {/* hover-a-name spotlight: a colour halo under the owner's
+              return (
+                <g key={key} opacity={dimmed ? 0.3 : 1}>
+                  {/* hover-a-name spotlight: a colour halo under the owner's
                     route so their network reads at a glance */}
-                {isHighlighted && highlight && (
-                  <path
-                    d={d}
-                    fill="none"
-                    stroke={highlight.color}
-                    strokeOpacity="0.55"
-                    strokeWidth="12"
-                    strokeLinecap="round"
-                    pointerEvents="none"
-                  />
-                )}
-                {!activeThisEra && !built ? (
-                  // ghost — corridor exists but not in this era
-                  <path
-                    d={d}
-                    fill="none"
-                    stroke="#e7d7b1"
-                    strokeOpacity="0.13"
-                    strokeWidth="2.5"
-                    strokeDasharray="5 7"
-                  />
-                ) : renderType === 'canal' ? (
-                  <>
+                  {isHighlighted && highlight && (
                     <path
                       d={d}
                       fill="none"
-                      stroke="#12302e"
-                      strokeWidth="10"
+                      stroke={highlight.color}
+                      strokeOpacity="0.55"
+                      strokeWidth="12"
                       strokeLinecap="round"
+                      pointerEvents="none"
                     />
+                  )}
+                  {!activeThisEra && !built ? (
+                    // ghost — corridor exists but not in this era
                     <path
                       d={d}
                       fill="none"
-                      stroke="#4e9c96"
-                      strokeOpacity={built ? 1 : 0.75}
-                      strokeWidth="4.5"
-                      strokeLinecap="round"
+                      stroke="#e7d7b1"
+                      strokeOpacity="0.13"
+                      strokeWidth="2.5"
+                      strokeDasharray="5 7"
                     />
-                    <path
-                      d={d}
-                      fill="none"
-                      stroke="#9fd4cc"
-                      strokeOpacity="0.5"
-                      strokeWidth="1.2"
-                      strokeDasharray="10 14"
-                    />
-                  </>
-                ) : (
-                  <>
-                    <path
-                      d={d}
-                      fill="none"
-                      stroke="#331f12"
-                      strokeWidth="10"
-                      strokeLinecap="round"
-                    />
-                    <path
-                      d={d}
-                      fill="none"
-                      stroke="#c2632f"
-                      strokeOpacity={built ? 1 : 0.8}
-                      strokeWidth="4.5"
-                      strokeLinecap="round"
-                    />
-                    <path
-                      d={d}
-                      fill="none"
-                      stroke="#f2e6c8"
-                      strokeOpacity="0.65"
-                      strokeWidth="1.6"
-                      strokeDasharray="1.6 7"
-                    />
-                  </>
-                )}
+                  ) : renderType === 'canal' ? (
+                    <>
+                      <path
+                        d={d}
+                        fill="none"
+                        stroke="#12302e"
+                        strokeWidth="10"
+                        strokeLinecap="round"
+                      />
+                      <path
+                        d={d}
+                        fill="none"
+                        stroke="#4e9c96"
+                        strokeOpacity={built ? 1 : 0.75}
+                        strokeWidth="4.5"
+                        strokeLinecap="round"
+                      />
+                      <path
+                        d={d}
+                        fill="none"
+                        stroke="#9fd4cc"
+                        strokeOpacity="0.5"
+                        strokeWidth="1.2"
+                        strokeDasharray="10 14"
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <path
+                        d={d}
+                        fill="none"
+                        stroke="#331f12"
+                        strokeWidth="10"
+                        strokeLinecap="round"
+                      />
+                      <path
+                        d={d}
+                        fill="none"
+                        stroke="#c2632f"
+                        strokeOpacity={built ? 1 : 0.8}
+                        strokeWidth="4.5"
+                        strokeLinecap="round"
+                      />
+                      <path
+                        d={d}
+                        fill="none"
+                        stroke="#f2e6c8"
+                        strokeOpacity="0.65"
+                        strokeWidth="1.6"
+                        strokeDasharray="1.6 7"
+                      />
+                    </>
+                  )}
 
-                {/* legal-target pulse */}
-                {(isLegal || isSelected) && (
-                  <path
-                    d={d}
-                    fill="none"
-                    stroke={isSelected ? '#e6bd63' : '#e6bd63'}
-                    strokeWidth={isSelected ? 4 : 2}
-                    className={isSelected ? undefined : 'bb2-target'}
-                    strokeOpacity={isSelected ? 1 : 0.9}
-                    pointerEvents="none"
-                  />
-                )}
+                  {/* legal-target pulse */}
+                  {(isLegal || isSelected) && (
+                    <path
+                      d={d}
+                      fill="none"
+                      stroke={isSelected ? '#e6bd63' : '#e6bd63'}
+                      strokeWidth={isSelected ? 4 : 2}
+                      className={isSelected ? undefined : 'bb2-target'}
+                      strokeOpacity={isSelected ? 1 : 0.9}
+                      pointerEvents="none"
+                    />
+                  )}
 
-                {/* fat invisible hit area */}
-                {(pickingLink || onLinkClick) && (
-                  <path
-                    d={d}
-                    data-conn={key}
-                    data-legal={isLegal || undefined}
-                    fill="none"
-                    stroke="transparent"
-                    strokeWidth="22"
-                    role={pickingLink ? 'button' : undefined}
-                    aria-label={
-                      pickingLink
-                        ? `Route ${cities[conn.from]?.name ?? conn.from} — ${cities[conn.to]?.name ?? conn.to}${isLegal ? ' — legal route' : ' — not a legal route'}`
-                        : undefined
-                    }
-                    tabIndex={pickingLink && isLegal ? 0 : undefined}
-                    onKeyDown={(e) => {
-                      if (pickingLink && (e.key === 'Enter' || e.key === ' ')) {
-                        e.preventDefault()
-                        onLinkClick?.(conn.from, conn.to)
+                  {/* fat invisible hit area */}
+                  {(pickingLink || onLinkClick) && (
+                    <path
+                      d={d}
+                      data-conn={key}
+                      data-legal={isLegal || undefined}
+                      fill="none"
+                      stroke="transparent"
+                      strokeWidth="22"
+                      role={pickingLink ? 'button' : undefined}
+                      aria-label={
+                        pickingLink
+                          ? `Route ${cities[conn.from]?.name ?? conn.from} — ${cities[conn.to]?.name ?? conn.to}${isLegal ? ' — legal route' : ' — not a legal route'}`
+                          : undefined
                       }
-                    }}
-                    style={{
-                      cursor: isLegal
-                        ? 'pointer'
-                        : pickingLink
-                          ? 'not-allowed'
-                          : 'default',
-                    }}
-                    onClick={() => {
-                      if (!wasDrag() && pickingLink) {
-                        onLinkClick?.(conn.from, conn.to)
-                      }
-                    }}
-                  />
-                )}
-              </g>
-            )
-          })}
-        </g>
+                      tabIndex={pickingLink && isLegal ? 0 : undefined}
+                      onKeyDown={(e) => {
+                        if (
+                          pickingLink &&
+                          (e.key === 'Enter' || e.key === ' ')
+                        ) {
+                          e.preventDefault()
+                          onLinkClick?.(conn.from, conn.to)
+                        }
+                      }}
+                      style={{
+                        cursor: isLegal
+                          ? 'pointer'
+                          : pickingLink
+                            ? 'not-allowed'
+                            : 'default',
+                      }}
+                      onClick={() => {
+                        if (!wasDrag() && pickingLink) {
+                          onLinkClick?.(conn.from, conn.to)
+                        }
+                      }}
+                    />
+                  )}
+                </g>
+              )
+            })}
+          </g>
 
-        {/* the southern Farm Brewery's implicit connection: a spur off the
+          {/* the southern Farm Brewery's implicit connection: a spur off the
             kidderminster—worcester corridor (rules p.5 — one tile connects
             all three; no second tile may be placed, so no hit area) */}
-        {(() => {
-          const mid = pointAt('kidderminster', 'worcester', 0.5)
-          const fb = cityPos.farmBrewery2
-          // Mirror the corridor's built type so a rail link reads rail (orange),
-          // a canal link canal (teal), and an unbuilt corridor the neutral
-          // potential hint — never a canal default in the rail era.
-          const kwBuilt = builtLinks.get(linkKey('kidderminster', 'worcester'))
-          const spur = farmBrewerySpurStyle(kwBuilt?.type ?? null)
-          return (
-            <path
-              d={`M ${mid.x} ${mid.y} L ${fb.x} ${fb.y}`}
-              fill="none"
-              stroke={spur.stroke}
-              strokeOpacity={spur.strokeOpacity}
-              strokeWidth={spur.strokeWidth}
-              strokeDasharray={spur.strokeDasharray}
-              pointerEvents="none"
-            />
-          )
-        })()}
-
-        {/* ------------ merchant plates ------------ */}
-        {(Object.keys(cities) as CityId[])
-          .filter((id) => cities[id].type === 'merchant')
-          .map((id) => (
-            <MerchantPlate
-              key={id}
-              cityId={id}
-              entries={merchantsByCity.get(id) ?? []}
-              dimmed={
-                pickingCity ||
-                (vpAnnotations !== null && !vpAnnotations.cities.has(id)) ||
-                highlight !== null
-              }
-              inNetwork={networkCities?.has(id) ?? false}
-              networkColor={networkColor}
-              located={locatedCities?.has(id) ?? false}
-              vp={vpAnnotations?.cities.get(id)}
-              vpColor={vpColor}
-            />
-          ))}
-
-        {/* ------------ city plates ------------ */}
-        {(Object.keys(cities) as CityId[])
-          .filter((id) => cities[id].type === 'city')
-          .map((id) => {
-            const occupants = assignSlots(id, builtByCity.get(id) ?? [])
-            const isLegal = legalCities?.has(id) ?? false
+          {(() => {
+            const mid = pointAt('kidderminster', 'worcester', 0.5)
+            const fb = cityPos.farmBrewery2
+            // Mirror the corridor's built type so a rail link reads rail (orange),
+            // a canal link canal (teal), and an unbuilt corridor the neutral
+            // potential hint — never a canal default in the rail era.
+            const kwBuilt = builtLinks.get(
+              linkKey('kidderminster', 'worcester'),
+            )
+            const spur = farmBrewerySpurStyle(kwBuilt?.type ?? null)
             return (
-              <CityPlate
+              <path
+                d={`M ${mid.x} ${mid.y} L ${fb.x} ${fb.y}`}
+                fill="none"
+                stroke={spur.stroke}
+                strokeOpacity={spur.strokeOpacity}
+                strokeWidth={spur.strokeWidth}
+                strokeDasharray={spur.strokeDasharray}
+                pointerEvents="none"
+              />
+            )
+          })()}
+
+          {/* ------------ merchant plates ------------ */}
+          {(Object.keys(cities) as CityId[])
+            .filter((id) => cities[id].type === 'merchant')
+            .map((id) => (
+              <MerchantPlate
                 key={id}
                 cityId={id}
-                occupants={occupants}
-                isLegal={isLegal}
-                isSelected={selectedCity === id}
+                entries={merchantsByCity.get(id) ?? []}
                 dimmed={
-                  (pickingCity && !isLegal && selectedCity !== id) ||
+                  pickingCity ||
                   (vpAnnotations !== null && !vpAnnotations.cities.has(id)) ||
-                  (highlight !== null && !highlight.cities.has(id))
+                  highlight !== null
                 }
                 inNetwork={networkCities?.has(id) ?? false}
                 networkColor={networkColor}
-                highlighted={highlight?.cities.has(id) ?? false}
-                highlightColor={highlight?.color ?? null}
-                hoverHint={hoverCities?.has(id) ?? false}
                 located={locatedCities?.has(id) ?? false}
                 vp={vpAnnotations?.cities.get(id)}
                 vpColor={vpColor}
-                onClick={() => {
-                  if (!wasDrag() && pickingCity) onCityClick?.(id)
-                }}
-                clickable={pickingCity}
               />
-            )
-          })}
+            ))}
 
-        {/* ------------ built-link markers ------------
+          {/* ------------ city plates ------------ */}
+          {(Object.keys(cities) as CityId[])
+            .filter((id) => cities[id].type === 'city')
+            .map((id) => {
+              const occupants = assignSlots(id, builtByCity.get(id) ?? [])
+              const isLegal = legalCities?.has(id) ?? false
+              return (
+                <CityPlate
+                  key={id}
+                  cityId={id}
+                  occupants={occupants}
+                  isLegal={isLegal}
+                  isSelected={selectedCity === id}
+                  dimmed={
+                    (pickingCity && !isLegal && selectedCity !== id) ||
+                    (vpAnnotations !== null && !vpAnnotations.cities.has(id)) ||
+                    (highlight !== null && !highlight.cities.has(id))
+                  }
+                  inNetwork={networkCities?.has(id) ?? false}
+                  networkColor={networkColor}
+                  highlighted={highlight?.cities.has(id) ?? false}
+                  highlightColor={highlight?.color ?? null}
+                  hoverHint={hoverCities?.has(id) ?? false}
+                  located={locatedCities?.has(id) ?? false}
+                  vp={vpAnnotations?.cities.get(id)}
+                  vpColor={vpColor}
+                  onClick={() => {
+                    if (!wasDrag() && pickingCity) onCityClick?.(id)
+                  }}
+                  clickable={pickingCity}
+                />
+              )
+            })}
+
+          {/* ------------ built-link markers ------------
             Painted last on purpose: a route's marker can sit close enough to
             a plate that the plate would swallow it (SVG z-order is document
             order). `linkMarkerAnchor` already slides it into the gap between
             plates where one exists; this pass keeps it visible where none
             does — Stoke-on-Trent—Stone being the tightest hop on the board. */}
-        {linkStates.map(({ key, built, linkVp, anchor, dimmed }) =>
-          built || linkVp !== undefined ? (
-            <g key={key} opacity={dimmed ? 0.3 : 1}>
-              {built && (
-                <g
-                  transform={`translate(${anchor.x}, ${anchor.y})`}
-                  pointerEvents="none"
-                >
-                  <rect
-                    x="-16"
-                    y="-10"
-                    width="32"
-                    height="20"
-                    rx="3.5"
-                    fill={PLAYER_FILL[built.player.color]}
-                    stroke="#16130f"
-                    strokeWidth="1.4"
-                    filter="url(#bb2-plate-shadow)"
-                  />
-                  <g fill="#f2e6c8" stroke="none">
-                    {built.type === 'canal' ? (
-                      // bespoke narrowboat silhouette (no such icon exists
-                      // in any library — see bb-icon-research-f12)
-                      <path d="M-10.6 -5.2 h2.4 v3 h6.6 v-3.4 h1.8 v3.4 h1.4 v2 h-12.2 z M-13 1 h26 c-0.7 2.9 -3.2 4.6 -6.4 4.6 h-13.2 c-3.2 0 -5.7 -1.7 -6.4 -4.6 z" />
-                    ) : (
-                      // delapouite/steam-locomotive (game-icons.net CC BY 3.0)
-                      <g transform="translate(-12.5, -12.5) scale(0.04883)">
-                        <path d={GAME_ICONS.steamLocomotive.d} />
-                      </g>
-                    )}
+          {linkStates.map(({ key, built, linkVp, anchor, dimmed }) =>
+            built || linkVp !== undefined ? (
+              <g key={key} opacity={dimmed ? 0.3 : 1}>
+                {built && (
+                  <g
+                    transform={`translate(${anchor.x}, ${anchor.y})`}
+                    pointerEvents="none"
+                  >
+                    <rect
+                      x="-16"
+                      y="-10"
+                      width="32"
+                      height="20"
+                      rx="3.5"
+                      fill={PLAYER_FILL[built.player.color]}
+                      stroke="#16130f"
+                      strokeWidth="1.4"
+                      filter="url(#bb2-plate-shadow)"
+                    />
+                    <g fill="#f2e6c8" stroke="none">
+                      {built.type === 'canal' ? (
+                        // bespoke narrowboat silhouette (no such icon exists
+                        // in any library — see bb-icon-research-f12)
+                        <path d="M-10.6 -5.2 h2.4 v3 h6.6 v-3.4 h1.8 v3.4 h1.4 v2 h-12.2 z M-13 1 h26 c-0.7 2.9 -3.2 4.6 -6.4 4.6 h-13.2 c-3.2 0 -5.7 -1.7 -6.4 -4.6 z" />
+                      ) : (
+                        // delapouite/steam-locomotive (game-icons.net CC BY 3.0)
+                        <g transform="translate(-12.5, -12.5) scale(0.04883)">
+                          <path d={GAME_ICONS.steamLocomotive.d} />
+                        </g>
+                      )}
+                    </g>
                   </g>
-                </g>
-              )}
+                )}
 
-              {/* game-end: what this route scored for the shown player */}
-              {linkVp !== undefined && (
-                <g
-                  transform={`translate(${anchor.x}, ${anchor.y})`}
-                  data-vp-link={key}
-                >
-                  <VpRoundel vp={linkVp} color={vpColor ?? '#e6bd63'} />
-                </g>
-              )}
-            </g>
-          ) : null,
-        )}
-      </svg>
+                {/* game-end: what this route scored for the shown player */}
+                {linkVp !== undefined && (
+                  <g
+                    transform={`translate(${anchor.x}, ${anchor.y})`}
+                    data-vp-link={key}
+                  >
+                    <VpRoundel vp={linkVp} color={vpColor ?? '#e6bd63'} />
+                  </g>
+                )}
+              </g>
+            ) : null,
+          )}
+        </svg>
 
-      {/* prompt banner — the board's own instruction, high contrast */}
-      {prompt && (
-        <div className="pointer-events-none absolute left-1/2 top-3 z-10 -translate-x-1/2">
-          <div
-            className="bb2-rise flex items-center gap-2 rounded border px-4 py-2 text-[13px] font-semibold tracking-wide"
-            style={{
-              background: 'rgba(20, 16, 11, 0.92)',
-              borderColor: 'var(--bb-brass)',
-              color: 'var(--bb-parchment-bright)',
-              boxShadow:
-                '0 6px 18px rgba(0,0,0,.5), 0 0 0 1px rgba(230,189,99,.15)',
-            }}
+        {/* zoom controls */}
+        <div className="absolute bottom-3 right-3 z-10 flex flex-col gap-1.5">
+          <button
+            type="button"
+            className="bb2-board-ctrl"
+            onClick={() => zoomBy(1 / 1.3)}
+            aria-label="Zoom in"
           >
-            <span
-              className="inline-block h-2 w-2 rounded-full"
-              style={{ background: 'var(--bb-brass-bright)' }}
-            />
-            {prompt}
-          </div>
+            +
+          </button>
+          <button
+            type="button"
+            className="bb2-board-ctrl"
+            onClick={() => zoomBy(1.3)}
+            aria-label="Zoom out"
+          >
+            −
+          </button>
+          <button
+            type="button"
+            className="bb2-board-ctrl is-home"
+            onClick={resetView}
+            aria-label="Reset view"
+          >
+            ⌂
+          </button>
         </div>
-      )}
 
-      {/* zoom controls */}
-      <div className="absolute bottom-3 right-3 z-10 flex flex-col gap-1.5">
-        <button
-          type="button"
-          className="bb2-board-ctrl"
-          onClick={() => zoomBy(1 / 1.3)}
-          aria-label="Zoom in"
-        >
-          +
-        </button>
-        <button
-          type="button"
-          className="bb2-board-ctrl"
-          onClick={() => zoomBy(1.3)}
-          aria-label="Zoom out"
-        >
-          −
-        </button>
-        <button
-          type="button"
-          className="bb2-board-ctrl is-home"
-          onClick={resetView}
-          aria-label="Reset view"
-        >
-          ⌂
-        </button>
-      </div>
-
-      {/* legend — hidden on phones: it is decorative, and at 390px it runs
+        {/* legend — hidden on phones: it is decorative, and at 390px it runs
           under the zoom controls and swallows the reset button, which is the
-          one control a pinched-in player needs to find their way back. */}
-      <div
-        className="absolute bottom-3 left-3 z-10 hidden items-center gap-4 rounded border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] sm:flex"
-        style={{
-          background: 'rgba(20,16,11,.85)',
-          borderColor: 'var(--bb-brass-hairline-soft)',
-          color: 'rgba(231,215,177,.75)',
-        }}
-      >
-        <span className="flex items-center gap-1.5">
-          <svg width="26" height="8">
-            <line
-              x1="1"
-              y1="4"
-              x2="25"
-              y2="4"
-              stroke="#12302e"
-              strokeWidth="7"
-              strokeLinecap="round"
-            />
-            <line
-              x1="1"
-              y1="4"
-              x2="25"
-              y2="4"
-              stroke="#4e9c96"
-              strokeWidth="3"
-              strokeLinecap="round"
-            />
-          </svg>
-          Canal
-        </span>
-        <span className="flex items-center gap-1.5">
-          <svg width="26" height="8">
-            <line
-              x1="1"
-              y1="4"
-              x2="25"
-              y2="4"
-              stroke="#331f12"
-              strokeWidth="7"
-              strokeLinecap="round"
-            />
-            <line
-              x1="1"
-              y1="4"
-              x2="25"
-              y2="4"
-              stroke="#c2632f"
-              strokeWidth="3"
-              strokeLinecap="round"
-            />
-            <line
-              x1="1"
-              y1="4"
-              x2="25"
-              y2="4"
-              stroke="#f2e6c8"
-              strokeWidth="1.2"
-              strokeDasharray="1.4 5"
-            />
-          </svg>
-          Rail
-        </span>
-        <span className="flex items-center gap-1.5">
-          <svg width="26" height="8">
-            <line
-              x1="1"
-              y1="4"
-              x2="25"
-              y2="4"
-              stroke="#e7d7b1"
-              strokeOpacity="0.3"
-              strokeWidth="2"
-              strokeDasharray="4 5"
-            />
-          </svg>
-          Other era
-        </span>
-        {networkColor && networkCities && networkCities.size > 0 && (
+          one control a pinched-in player needs to find their way back.
+          Top-right, clear of the frame's bottom apron: the bottom-left corner
+          belongs to the hand tray's step label (.bb2-tray-label), and the
+          top-left to the map's own cartouche. */}
+        <div
+          className="absolute right-3 top-3 z-10 hidden items-center gap-4 rounded border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] sm:flex"
+          style={{
+            background: 'rgba(20,16,11,.85)',
+            borderColor: 'var(--bb-brass-hairline-soft)',
+            color: 'rgba(231,215,177,.75)',
+          }}
+        >
           <span className="flex items-center gap-1.5">
-            <span
-              className="inline-block h-3 w-4 rounded-[3px]"
-              style={{
-                background: `${networkColor}30`,
-                border: `1.5px solid ${networkColor}`,
-              }}
-            />
-            Your network
+            <svg width="26" height="8">
+              <line
+                x1="1"
+                y1="4"
+                x2="25"
+                y2="4"
+                stroke="#12302e"
+                strokeWidth="7"
+                strokeLinecap="round"
+              />
+              <line
+                x1="1"
+                y1="4"
+                x2="25"
+                y2="4"
+                stroke="#4e9c96"
+                strokeWidth="3"
+                strokeLinecap="round"
+              />
+            </svg>
+            Canal
           </span>
-        )}
+          <span className="flex items-center gap-1.5">
+            <svg width="26" height="8">
+              <line
+                x1="1"
+                y1="4"
+                x2="25"
+                y2="4"
+                stroke="#331f12"
+                strokeWidth="7"
+                strokeLinecap="round"
+              />
+              <line
+                x1="1"
+                y1="4"
+                x2="25"
+                y2="4"
+                stroke="#c2632f"
+                strokeWidth="3"
+                strokeLinecap="round"
+              />
+              <line
+                x1="1"
+                y1="4"
+                x2="25"
+                y2="4"
+                stroke="#f2e6c8"
+                strokeWidth="1.2"
+                strokeDasharray="1.4 5"
+              />
+            </svg>
+            Rail
+          </span>
+          <span className="flex items-center gap-1.5">
+            <svg width="26" height="8">
+              <line
+                x1="1"
+                y1="4"
+                x2="25"
+                y2="4"
+                stroke="#e7d7b1"
+                strokeOpacity="0.3"
+                strokeWidth="2"
+                strokeDasharray="4 5"
+              />
+            </svg>
+            Other era
+          </span>
+          {networkColor && networkCities && networkCities.size > 0 && (
+            <span className="flex items-center gap-1.5">
+              <span
+                className="inline-block h-3 w-4 rounded-[3px]"
+                style={{
+                  background: `${networkColor}30`,
+                  border: `1.5px solid ${networkColor}`,
+                }}
+              />
+              Your network
+            </span>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -35,6 +35,7 @@ import {
   SELLABLE,
   getHandSelection,
 } from './action-dock'
+import { boardCaption } from './board-caption'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from './board/board-map'
 import { CommandPalette } from './command-palette'
 import { demoSnapshot } from './demo/demo-snapshot'
@@ -60,6 +61,7 @@ import { PlayerRail } from './player-rail'
 import { SetupScreen } from './setup-screen'
 import { MarketsPanel, SidePanelRail, usePanelCollapsed } from './side-panels'
 import { sourceCandidateCities } from './source-spotlight'
+import { useStepScroll } from './use-step-scroll'
 
 const SAVE_KEY = 'bb2-save-v1'
 
@@ -734,26 +736,22 @@ function GameInner({
   // engine's; the shared seam keeps this identical to the online surface.
   const sourceCities = useMemo(() => sourceCandidateCities(state), [state])
 
-  const boardPrompt = useMemo(() => {
-    if (pickingSite) {
-      const t = ctx.selectedIndustryTile?.type
-      const n = legalCities?.size ?? 0
-      return `Choose a site for your ${t === 'manufacturer' ? 'goods works' : (t ?? 'industry')} — ${n} legal ${n === 1 ? 'city' : 'cities'}`
-    }
-    if (pickingLink || pickingSecondLink) {
-      const n = (legalLinks?.size ?? 0) / 2
-      return `Choose ${pickingSecondLink ? 'a second' : 'a'} ${ctx.era} route — ${n} available`
-    }
-    return null
-  }, [
-    pickingSite,
-    pickingLink,
-    pickingSecondLink,
-    legalCities,
-    legalLinks,
-    ctx.selectedIndustryTile?.type,
-    ctx.era,
-  ])
+  const boardPrompt = useMemo(
+    () =>
+      boardCaption(state, {
+        legalCities,
+        legalLinks,
+        sourceCities,
+      }),
+    [state, legalCities, legalLinks, sourceCities],
+  )
+
+  // Phone: a step change brings the surface that owns the next tap into
+  // view (board for site/route/source picks, dock for confirm/sale) —
+  // unless the player just scrolled somewhere themselves.
+  const boardFrameRef = useRef<HTMLDivElement | null>(null)
+  const dockPanelRef = useRef<HTMLDivElement | null>(null)
+  useStepScroll(state, boardFrameRef, dockPanelRef)
 
   // Every rejected click is answered by the engine's own explainer, so the
   // player is told what is missing instead of "not legal".
@@ -910,7 +908,10 @@ function GameInner({
 
         {/* ---------- main: board + dock ---------- */}
         <div className="flex min-h-0 flex-col gap-3 px-3 pb-3 lg:flex-1 lg:flex-row">
-          <div className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1">
+          <div
+            ref={boardFrameRef}
+            className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1"
+          >
             <div className="bb2-board-inner pb-9 lg:pb-[84px]">
               <BoardMap
                 players={ctx.players}
@@ -952,7 +953,10 @@ function GameInner({
             {/* Inner keeps its full width so a collapse clips the column to
                 the edge instead of squashing its contents mid-animation. */}
             <div className="flex w-full flex-col gap-3 lg:w-[416px]">
-              <div className="bb2-panel bb2-panel-active flex flex-col gap-3 p-5">
+              <div
+                ref={dockPanelRef}
+                className="bb2-panel bb2-panel-active flex flex-col gap-3 p-5"
+              >
                 {!needsReveal && (
                   <ActionDock
                     snapshot={state as GameStoreSnapshot}

--- a/src/components/hand-tray-layout.test.ts
+++ b/src/components/hand-tray-layout.test.ts
@@ -10,7 +10,6 @@ import {
   cardIndexAtX,
   dockShift,
   fanLayout,
-  hintClearance,
   lensReach,
   lensShiftX,
   moveHandleLayout,
@@ -162,26 +161,6 @@ describe('cardIndexAtX (drag-to-browse)', () => {
   it('a single card owns the whole tray', () => {
     expect(cardIndexAtX(0, 1, spacing, width)).toBe(0)
     expect(cardIndexAtX(width, 1, spacing, width)).toBe(0)
-  })
-})
-
-describe('hintClearance', () => {
-  // The bug this pins: the hint pill used to sit right on top of the fan, so
-  // a selected card's persistent lens rendered straight through the
-  // instruction telling the player what to do with it.
-  it('clears the persistent selected lens on a fine pointer', () => {
-    expect(hintClearance(LENS_FINE)).toBeGreaterThan(lensReach(LENS_SELECTED))
-  })
-
-  it('clears the pointer lens on both fine and coarse', () => {
-    expect(hintClearance(LENS_FINE)).toBeGreaterThan(lensReach(LENS_FINE))
-    expect(hintClearance(LENS_COARSE)).toBeGreaterThan(lensReach(LENS_COARSE))
-  })
-
-  it('reserves for the tallest lens the device can raise, not the current one', () => {
-    // Static per device: a touch tray must hold room for its own big peek
-    // even while nothing is raised, or the pill would jump on every tap.
-    expect(hintClearance(LENS_COARSE)).toBeGreaterThan(hintClearance(LENS_FINE))
   })
 })
 

--- a/src/components/hand-tray-layout.ts
+++ b/src/components/hand-tray-layout.ts
@@ -177,37 +177,6 @@ export function lensReach(lens: LensPreset): number {
   return lens.rise + CARD_H * (lens.scale - 1)
 }
 
-/** Layout height of the tray box — must match .bb2-handbox in theme.css. */
-export const HANDBOX_H = 150
-
-/**
- * Gap the hint pill must hold above the tray box so no lens can ever reach
- * it, in layout px (the caller scales it by the tray's own scale).
- *
- * Deliberately a STATIC per-device value — the worst case of the two lenses
- * that device can show (`lens` = the pointer's hover/peek preset, or the
- * persistent selected one) rather than whatever is raised right now. A pill
- * that re-measured per raise would jump ~70px on every hover, and the reserve
- * must hold in the resting state too: a selected card keeps its lens for the
- * whole flow, which is exactly the state that used to bury the instruction.
- *
- * A card is CARD_H tall in a HANDBOX_H box aligned to its bottom, so it
- * already pokes out the top before any lens applies. HINT_PAD covers what
- * this box model doesn't: the seat's own rotation about the 50% 120% pivot
- * lifts a card's top corner, and lensReach measures the lens rather than its
- * rotated bounding box (measured ~6px on the demo fan — the pad is rounded up
- * so the reserve stays honest rather than exact-and-brittle).
- */
-const HINT_PAD = 10
-
-export function hintClearance(lens: LensPreset): number {
-  return (
-    Math.max(lensReach(lens), lensReach(LENS_SELECTED)) +
-    (CARD_H - HANDBOX_H) +
-    HINT_PAD
-  )
-}
-
 /**
  * Which card of the fan sits under layout-x position `x` — the drag-to-browse
  * mapping. Uses the resting seat centres (width/2 + (i − (n−1)/2)·spacing),

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -33,7 +33,6 @@ import {
   fanAngle,
   fanLayout,
   fanLift,
-  hintClearance,
   lensReach,
   lensShiftX,
   moveHandleLayout,
@@ -283,30 +282,18 @@ export function HandTray({
       className={`bb2-handtray pointer-events-none fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center transition-[right] duration-300 ease-in-out ${
         panelCollapsed ? 'lg:right-[44px]' : 'lg:right-[428px]'
       }`}
-      style={
-        { '--bb-hint-clear': `${hintClearance(lens)}px` } as React.CSSProperties
-      }
     >
       {hint && (
-        // The pill stacks above the fan, clearing the tallest lens this
-        // device can raise (--bb-hint-clear, scaled with the tray) so no
-        // card — resting, selected or magnified — ever reaches it. It stays
-        // fully opaque and put: the reserve is static, so hovering never
-        // moves or dims the instruction. It is click-transparent: on phones
-        // the dock scrolls behind it, and the pill must never eat a tap
-        // aimed at an action button.
-        <div className="bb2-hand-hint bb2-rise relative z-[1]">
-          <div
-            className="rounded border px-4 py-1.5 text-[12px] font-semibold uppercase tracking-[0.18em]"
-            style={{
-              background: 'rgba(20,16,11,.92)',
-              borderColor: 'var(--bb-brass)',
-              color: 'var(--bb-brass-bright)',
-              boxShadow: '0 6px 18px rgba(0,0,0,.5)',
-            }}
-          >
-            {hint}
-          </div>
+        // The tray's own label, anchored to the band's left edge — never a
+        // floating pill over the middle of the board. Absolutely positioned,
+        // so it reserves no height and can never move the hand: the fan
+        // keeps a constant layout whether or not a hint is showing. On
+        // phones it rides the band's top edge (over the scrolling panel,
+        // not the board); on desktop it sits in the board frame's bottom
+        // apron, which the map never paints into (see .bb2-tray-label).
+        // Click-transparent like the rest of the tray.
+        <div className="bb2-tray-label" data-testid="hand-hint">
+          {hint}
         </div>
       )}
       <div

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -22,6 +22,7 @@ import {
 import { explainRefusal } from '~/store/refusal'
 import { refreshEmbeddedTileStats } from '~/store/saveMigration'
 import { ActionDock, SELLABLE, getHandSelection } from '../action-dock'
+import { boardCaption } from '../board-caption'
 import { BoardMap, PLAYER_FILL, playerNetworkCities } from '../board/board-map'
 import { CommandPalette } from '../command-palette'
 import { developMatView } from '../develop-mat'
@@ -41,6 +42,7 @@ import {
   usePanelCollapsed,
 } from '../side-panels'
 import { sourceCandidateCities } from '../source-spotlight'
+import { useStepScroll } from '../use-step-scroll'
 import { consumeRecoveryLink, credsKey } from './recovery-link'
 import { UNREACHABLE, refusalToShow } from './refusal'
 import { SeatKeyButton, SeatKeyModal, SeatKeyNotice } from './seat-key'
@@ -1426,26 +1428,20 @@ function MpTable({
     [state],
   )
 
-  const boardPrompt = useMemo(() => {
-    if (!ctx) return null
-    if (pickingSite) {
-      const t = ctx.selectedIndustryTile?.type
-      const n = legalCities?.size ?? 0
-      return `Choose a site for your ${t === 'manufacturer' ? 'goods works' : (t ?? 'industry')} — ${n} legal ${n === 1 ? 'city' : 'cities'}`
-    }
-    if (pickingLink || pickingSecondLink) {
-      const n = (legalLinks?.size ?? 0) / 2
-      return `Choose ${pickingSecondLink ? 'a second' : 'a'} ${ctx.era} route — ${n} available`
-    }
-    return null
-  }, [
-    ctx,
-    pickingSite,
-    pickingLink,
-    pickingSecondLink,
-    legalCities,
-    legalLinks,
-  ])
+  const boardPrompt = useMemo(
+    () =>
+      state
+        ? boardCaption(state, { legalCities, legalLinks, sourceCities })
+        : null,
+    [state, legalCities, legalLinks, sourceCities],
+  )
+
+  // Phone: a step change brings the surface that owns the next tap into
+  // view (board for site/route/source picks, dock for confirm/sale) —
+  // only on my own turn, and never against a scroll the player just made.
+  const boardFrameRef = useRef<HTMLDivElement | null>(null)
+  const dockPanelRef = useRef<HTMLDivElement | null>(null)
+  useStepScroll(myTurn ? state : null, boardFrameRef, dockPanelRef)
 
   // Exact sale probe on my own filtered snapshot (my hand is real in it).
   const canSellAnything = useMemo(() => {
@@ -1664,7 +1660,10 @@ function MpTable({
         />
 
         <div className="flex min-h-0 flex-col gap-3 px-3 pb-3 lg:flex-1 lg:flex-row">
-          <div className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1">
+          <div
+            ref={boardFrameRef}
+            className="bb2-board-frame h-[52vh] min-h-[320px] lg:h-auto lg:min-h-0 lg:flex-1"
+          >
             <div className="bb2-board-inner pb-9 lg:pb-[84px]">
               <BoardMap
                 players={ctx.players}
@@ -1704,6 +1703,7 @@ function MpTable({
                 the edge instead of squashing its contents mid-animation. */}
             <div className="flex w-full flex-col gap-3 lg:w-[416px]">
               <div
+                ref={dockPanelRef}
                 className={`bb2-panel bb2-panel-active flex flex-col gap-3 p-5 ${myTurn && inFlight ? 'bb2-busy' : ''}`}
                 aria-busy={myTurn && inFlight}
               >

--- a/src/components/source-spotlight.ts
+++ b/src/components/source-spotlight.ts
@@ -18,17 +18,17 @@ export interface SourceStepState {
   context: GameState
 }
 
-const BEER_STEPS = [
+export const BEER_STEPS = [
   'playing.action.selling.choosingBeerSource',
   'playing.action.networking.choosingDoubleLinkBeer',
 ]
 
-const IRON_STEPS = [
+export const IRON_STEPS = [
   'playing.action.building.choosingIronSource',
   'playing.action.developing.choosingIronSource',
 ]
 
-const COAL_STEPS = [
+export const COAL_STEPS = [
   'playing.action.building.choosingCoalSource',
   'playing.action.networking.choosingLinkCoal',
   'playing.action.networking.choosingDoubleLinkCoal',

--- a/src/components/step-scroll.test.ts
+++ b/src/components/step-scroll.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SCROLL_SUPPRESS_MS,
+  shouldStepScroll,
+  stepKey,
+  stepScrollTarget,
+} from './step-scroll'
+
+const matchesOnly = (step: string) => (path: never) => (path as string) === step
+
+describe('stepScrollTarget', () => {
+  it.each([
+    'playing.action.building.selectingLocation',
+    'playing.action.networking.selectingLink',
+    'playing.action.networking.selectingSecondLink',
+    'playing.action.selling.choosingBeerSource',
+    'playing.action.building.choosingIronSource',
+    'playing.action.building.choosingCoalSource',
+  ])('%s is a board tap', (step) => {
+    expect(stepScrollTarget(matchesOnly(step))).toBe('board')
+  })
+
+  it.each([
+    'playing.action.building.confirmingBuild',
+    'playing.action.networking.confirmingLink',
+    'playing.action.networking.confirmingDoubleLink',
+    'playing.action.takingLoan.confirmingLoan',
+    'playing.action.selling.selectingSale',
+  ])('%s is a dock step', (step) => {
+    expect(stepScrollTarget(matchesOnly(step))).toBe('dock')
+  })
+
+  it('card-pick and develop steps move nothing (tray is fixed, modal covers)', () => {
+    for (const step of [
+      'playing.action.selectingAction',
+      'playing.action.building.selectingCard',
+      'playing.action.developing.selectingTiles',
+      'playing.action.developing.confirmingDevelop',
+      'playing.action.scouting.selectingCards',
+    ]) {
+      expect(stepScrollTarget(matchesOnly(step))).toBeNull()
+    }
+  })
+})
+
+describe('stepKey', () => {
+  it('names the parked step and returns null off the wizard', () => {
+    expect(
+      stepKey(matchesOnly('playing.action.building.selectingLocation')),
+    ).toBe('playing.action.building.selectingLocation')
+    expect(stepKey(matchesOnly('playing.idle'))).toBeNull()
+  })
+})
+
+describe('shouldStepScroll', () => {
+  const base = {
+    prevStep: null,
+    step: 'playing.action.building.selectingLocation',
+    isPhone: true,
+    now: 10_000,
+    lastUserScrollAt: null,
+  }
+
+  it('scrolls on a fresh step change on phone', () => {
+    expect(shouldStepScroll(base)).toBe(true)
+  })
+
+  it('never scrolls on desktop', () => {
+    expect(shouldStepScroll({ ...base, isPhone: false })).toBe(false)
+  })
+
+  it('does not re-scroll while parked in the same step', () => {
+    expect(shouldStepScroll({ ...base, prevStep: base.step })).toBe(false)
+  })
+
+  it('does nothing when the step owns no surface', () => {
+    expect(shouldStepScroll({ ...base, step: null })).toBe(false)
+  })
+
+  it('yields to a player scroll inside the suppression window', () => {
+    expect(
+      shouldStepScroll({
+        ...base,
+        lastUserScrollAt: base.now - SCROLL_SUPPRESS_MS + 1,
+      }),
+    ).toBe(false)
+    expect(
+      shouldStepScroll({
+        ...base,
+        lastUserScrollAt: base.now - SCROLL_SUPPRESS_MS,
+      }),
+    ).toBe(true)
+  })
+})

--- a/src/components/step-scroll.test.ts
+++ b/src/components/step-scroll.test.ts
@@ -13,9 +13,6 @@ describe('stepScrollTarget', () => {
     'playing.action.building.selectingLocation',
     'playing.action.networking.selectingLink',
     'playing.action.networking.selectingSecondLink',
-    'playing.action.selling.choosingBeerSource',
-    'playing.action.building.choosingIronSource',
-    'playing.action.building.choosingCoalSource',
   ])('%s is a board tap', (step) => {
     expect(stepScrollTarget(matchesOnly(step))).toBe('board')
   })
@@ -26,6 +23,12 @@ describe('stepScrollTarget', () => {
     'playing.action.networking.confirmingDoubleLink',
     'playing.action.takingLoan.confirmingLoan',
     'playing.action.selling.selectingSale',
+    'playing.action.selling.choosingBeerSource',
+    'playing.action.networking.choosingDoubleLinkBeer',
+    'playing.action.building.choosingIronSource',
+    'playing.action.building.choosingCoalSource',
+    'playing.action.networking.choosingLinkCoal',
+    'playing.action.networking.choosingDoubleLinkCoal',
   ])('%s is a dock step', (step) => {
     expect(stepScrollTarget(matchesOnly(step))).toBe('dock')
   })
@@ -35,6 +38,7 @@ describe('stepScrollTarget', () => {
       'playing.action.selectingAction',
       'playing.action.building.selectingCard',
       'playing.action.developing.selectingTiles',
+      'playing.action.developing.choosingIronSource',
       'playing.action.developing.confirmingDevelop',
       'playing.action.scouting.selectingCards',
     ]) {

--- a/src/components/step-scroll.ts
+++ b/src/components/step-scroll.ts
@@ -1,0 +1,77 @@
+// Phone-only step-change scrolling: when a wizard step changes, the surface
+// that owns the NEXT tap may sit off-viewport (the board while you were
+// reading the dock, the dock's confirm while you were panning the map). The
+// fix is not to pin any text over the game — it is to bring the tap target
+// itself on screen. This module is the pure decision half; the shells apply
+// it with scrollIntoView.
+//
+// One rule guards it: never fight the player. A scroll or board pan inside
+// SCROLL_SUPPRESS_MS means they went somewhere on purpose — the step change
+// yields, the same hysteresis idea pan-into-view.ts encodes for hover-pan.
+
+/** Which surface owns the step's next tap. */
+export type StepSurface = 'board' | 'dock'
+
+/** Recent user scroll/pan wins over the auto-scroll for this long. */
+export const SCROLL_SUPPRESS_MS = 2000
+
+const BOARD_STEPS = [
+  'playing.action.building.selectingLocation',
+  'playing.action.networking.selectingLink',
+  'playing.action.networking.selectingSecondLink',
+  // Source picks are board taps too — the map spotlights the candidates.
+  'playing.action.selling.choosingBeerSource',
+  'playing.action.networking.choosingDoubleLinkBeer',
+  'playing.action.building.choosingIronSource',
+  'playing.action.developing.choosingIronSource',
+  'playing.action.building.choosingCoalSource',
+  'playing.action.networking.choosingLinkCoal',
+  'playing.action.networking.choosingDoubleLinkCoal',
+]
+
+// Confirm and sale steps live in the dock. Card-pick steps deliberately map
+// to nothing: the hand tray is bottom-fixed and always on screen, and the
+// develop steps open a full-screen modal that needs no scrolling.
+const DOCK_STEPS = [
+  'playing.action.building.confirmingBuild',
+  'playing.action.networking.confirmingLink',
+  'playing.action.networking.confirmingDoubleLink',
+  'playing.action.takingLoan.confirmingLoan',
+  'playing.action.selling.selectingSale',
+]
+
+/** Serialize the step the state is parked in, for change detection. */
+export function stepKey(matches: (path: never) => boolean): string | null {
+  for (const path of [...BOARD_STEPS, ...DOCK_STEPS]) {
+    if (matches(path as never)) return path
+  }
+  return null
+}
+
+/** The surface a step's next tap lives on, or null when nothing should move. */
+export function stepScrollTarget(
+  matches: (path: never) => boolean,
+): StepSurface | null {
+  if (BOARD_STEPS.some((p) => matches(p as never))) return 'board'
+  if (DOCK_STEPS.some((p) => matches(p as never))) return 'dock'
+  return null
+}
+
+/**
+ * Should this step change scroll? Only when the step actually changed, only
+ * on a scrolling layout (phone — desktop is viewport-locked), and only when
+ * the player hasn't just scrolled or panned somewhere themselves.
+ */
+export function shouldStepScroll(args: {
+  prevStep: string | null
+  step: string | null
+  isPhone: boolean
+  now: number
+  lastUserScrollAt: number | null
+}): boolean {
+  const { prevStep, step, isPhone, now, lastUserScrollAt } = args
+  if (!isPhone || step === null || step === prevStep) return false
+  if (lastUserScrollAt !== null && now - lastUserScrollAt < SCROLL_SUPPRESS_MS)
+    return false
+  return true
+}

--- a/src/components/step-scroll.ts
+++ b/src/components/step-scroll.ts
@@ -19,25 +19,28 @@ const BOARD_STEPS = [
   'playing.action.building.selectingLocation',
   'playing.action.networking.selectingLink',
   'playing.action.networking.selectingSecondLink',
-  // Source picks are board taps too — the map spotlights the candidates.
-  'playing.action.selling.choosingBeerSource',
-  'playing.action.networking.choosingDoubleLinkBeer',
-  'playing.action.building.choosingIronSource',
-  'playing.action.developing.choosingIronSource',
-  'playing.action.building.choosingCoalSource',
-  'playing.action.networking.choosingLinkCoal',
-  'playing.action.networking.choosingDoubleLinkCoal',
 ]
 
-// Confirm and sale steps live in the dock. Card-pick steps deliberately map
-// to nothing: the hand tray is bottom-fixed and always on screen, and the
-// develop steps open a full-screen modal that needs no scrolling.
+// Confirm and sale steps live in the dock — as do the beer/iron/coal source
+// picks: the map only spotlights those candidates, the actual pick control is
+// the dock picker, so a phone auto-scroll to the board would strand the
+// player away from the only tappable control. Card-pick steps deliberately
+// map to nothing: the hand tray is bottom-fixed and always on screen, and
+// `developing.choosingIronSource` maps to nothing too — it auto-opens the
+// develop mat modal, which owns that pick, same as its `selectingTiles`/
+// `confirmingDevelop` siblings.
 const DOCK_STEPS = [
   'playing.action.building.confirmingBuild',
   'playing.action.networking.confirmingLink',
   'playing.action.networking.confirmingDoubleLink',
   'playing.action.takingLoan.confirmingLoan',
   'playing.action.selling.selectingSale',
+  'playing.action.selling.choosingBeerSource',
+  'playing.action.networking.choosingDoubleLinkBeer',
+  'playing.action.building.choosingIronSource',
+  'playing.action.building.choosingCoalSource',
+  'playing.action.networking.choosingLinkCoal',
+  'playing.action.networking.choosingDoubleLinkCoal',
 ]
 
 /** Serialize the step the state is parked in, for change detection. */

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -576,10 +576,36 @@ button.bb2-card {
   transform: scale(var(--bb-hand-scale));
   width: calc(100% / var(--bb-hand-scale));
 }
-/* Lens reach is layout px inside the fan; the pill sits outside it, so the
- * reserve has to be scaled by hand. The 8px is the visual gap on top. */
-.bb2-hand-hint {
-  margin-bottom: calc(8px + var(--bb-hint-clear, 71px) * var(--bb-hand-scale));
+/* The tray's own step label. Absolutely positioned so it reserves no height
+ * — the fan never moves when it appears or disappears (a hint that resized
+ * the tray would reintroduce the jumping-hand regression PR #81 fixed).
+ * On phones it rides the top edge of the (scaled) card band, which overlays
+ * the scrolling panel there, never the board. On desktop the band sits in
+ * the board frame's bottom apron (the pb-[84px] strip the map never paints
+ * into), so the label drops to the tray's bottom-left corner beside the
+ * fan. Cards paint above it — a raised edge card may briefly cover it. */
+.bb2-tray-label {
+  position: absolute;
+  left: 12px;
+  bottom: calc(150px * var(--bb-hand-scale) - 16px);
+  max-width: 60%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 3px 8px;
+  border-radius: 3px;
+  border: 1px solid var(--bb-brass-hairline);
+  background: rgba(20, 16, 11, 0.88);
+  color: var(--bb-brass-bright);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+@media (min-width: 1024px) {
+  .bb2-tray-label {
+    bottom: 10px;
+  }
 }
 @media (min-width: 640px) {
   .bb2-handtray {

--- a/src/components/use-step-scroll.ts
+++ b/src/components/use-step-scroll.ts
@@ -1,0 +1,81 @@
+'use client'
+
+// The applied half of step-scroll.ts, shared by both shells: on a wizard
+// step change, scroll the surface that owns the next tap into view — phone
+// only (desktop is viewport-locked, the scroll is a no-op there and skipped).
+// The decision logic (which surface, the don't-fight-the-player window) is
+// pure and unit-tested in step-scroll.ts.
+import { useEffect, useRef } from 'react'
+import { shouldStepScroll, stepKey, stepScrollTarget } from './step-scroll'
+
+interface StepState {
+  matches: (path: never) => boolean
+}
+
+/** How long our own smooth scroll may emit scroll events without counting
+ * as the player scrolling (the suppression window must not eat itself). */
+const OWN_SCROLL_MS = 1000
+
+export function useStepScroll(
+  state: StepState | null,
+  boardRef: React.RefObject<HTMLElement | null>,
+  dockRef: React.RefObject<HTMLElement | null>,
+): void {
+  const lastUserScrollAt = useRef<number | null>(null)
+  const ownScrollAt = useRef<number | null>(null)
+  const prevStepRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const mark = () => {
+      const now = Date.now()
+      if (
+        ownScrollAt.current !== null &&
+        now - ownScrollAt.current < OWN_SCROLL_MS
+      )
+        return
+      lastUserScrollAt.current = now
+    }
+    // Capture catches the aside's inner scroller as well as the page; the
+    // board's pan gesture is pointer-driven, so touchmove covers it too.
+    window.addEventListener('scroll', mark, { passive: true, capture: true })
+    window.addEventListener('touchmove', mark, { passive: true })
+    window.addEventListener('wheel', mark, { passive: true })
+    return () => {
+      window.removeEventListener('scroll', mark, { capture: true })
+      window.removeEventListener('touchmove', mark)
+      window.removeEventListener('wheel', mark)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!state) return
+    const matches = (p: never) => state.matches(p)
+    const step = stepKey(matches)
+    const prevStep = prevStepRef.current
+    prevStepRef.current = step
+
+    const isPhone = !window.matchMedia('(min-width: 1024px)').matches
+    if (
+      !shouldStepScroll({
+        prevStep,
+        step,
+        isPhone,
+        now: Date.now(),
+        lastUserScrollAt: lastUserScrollAt.current,
+      })
+    )
+      return
+
+    const surface = stepScrollTarget(matches)
+    const el = surface === 'board' ? boardRef.current : dockRef.current
+    if (!el) return
+    ownScrollAt.current = Date.now()
+    const reduced = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches
+    el.scrollIntoView({
+      behavior: reduced ? 'auto' : 'smooth',
+      block: 'start',
+    })
+  }, [state, boardRef, dockRef])
+}


### PR DESCRIPTION
## Why

During a build the game narrates the same state **three times at once**: a banner floating over the board, a pill floating over the middle of the map, and the side panel saying the same thing more fully and better. The panel's version is the best-written **and** the only one obstructing nothing — the two floating ones are abbreviations of it. The hint was never badly placed; it was **duplicated**, and the copies that obstruct were the redundant ones. Two overlay designs have been rejected in a row (anchored-to-board scrolls away on phone; pinned-to-viewport is always in the face). This PR removes the category: nothing floats over the play area, ever. Each surface narrates itself, in layout flow.

## What changed

- **Board**: the overlay banner becomes a thin **caption bar built into the board frame** — one line, in normal flow between the frame's top edge and the svg, same brass-on-dark styling. It pushes the map down (~31px) and can never cover it. It renders only when the next tap is on the board: site picks, route picks, and — new, free coverage — the beer/iron/coal source steps whose candidates the map already spotlights. Text and counts come from `components/board-caption.ts`, shared by both shells like `legal-targets.ts`, so hotseat and multiplayer can't drift. No rule is re-derived: counts are the same engine-produced sets the spotlight uses.
- **Hand tray**: the floating pill becomes a **label inside the tray's own band** (`.bb2-tray-label`). On phones it rides the band's top edge (over the scrolling panel, never the board); on desktop it sits in the board frame's bottom apron — the `pb-[84px]` strip the map never paints into. The board legend moves to the frame's top-right to keep that corner free.
- **Dock and mat modal**: unchanged. They already narrate correctly.
- **Phone**: on a wizard step change, the surface that owns the next tap **scrolls into view** — the board for site/route/source picks, the dock for confirm/sale steps. This is the actual fix for "the instruction scrolled away when I needed it": don't keep the *text* on screen, bring the *target* on screen. One rule guards it: if the player scrolled or panned themselves within the last ~2s, the auto-scroll yields (the same hysteresis idea `pan-into-view.ts` encodes for hover-pan). `prefers-reduced-motion` drops the smooth animation. Decision logic is pure and unit-tested (`step-scroll.ts`); the applied half is `use-step-scroll.ts`, shared by both shells. Desktop is viewport-locked, so it's an explicit no-op there.

No minimum piece of the "spotlight harder" direction (Option B) turned out to be required: at 390px the board frame is part of the page flow, so `scrollIntoView` on the frame is sufficient on its own. Nothing from B is included.

## The tray reserve — decided deliberately

The old pill statically reserved ~71px of layout (~103px desktop / ~178px touch after lens math) above the fan via `hintClearance()`, sized so no raised card could ever collide with it — which is exactly why it sat visually inside the board. That reserve is **removed entirely**, not shrunk: the new label is absolutely positioned inside the tray band, so it occupies **zero layout height** and the fan keeps a constant layout whether a hint is showing or not. The hand can never jump when the hint appears, changes, or disappears — the same invariant PR #81 established for the mat readout, preserved by construction rather than by reservation. The trade accepted: a raised edge card may briefly pass over the label; that transient occlusion beats permanently reserving lens clearance over the map. `hintClearance` and its layout tests are deleted with the pill.

## Test changes (all honest relocations)

- `e2e/card-first.spec.ts`: three locators change from `.bb2-hand-hint` (the deleted pill's class) to `getByTestId('hand-hint')` — the same "Holding …" text assertions, pointed at the label that now legitimately carries it. No expectation was weakened.
- `hand-tray-layout.test.ts`: the `hintClearance` describe block is deleted along with the function it pinned (the pill it protected no longer exists).
- All other pinned hint strings ("Choose a site for your brewery…", "Choose a canal route…") are unchanged — the caption bar keeps the exact wording, so `coverage`/`atlas`/`bugfixes`/`board-touch-zoom` specs pass untouched.
- New: `board-caption.test.ts` (13 tests) and `step-scroll.test.ts` (18 tests).

Full unit suite: 92 files, 838 passed. Full Playwright suite: **63 passed**, `--workers=2`.

## Before / after

### 1280px — mid-build site pick
Before (three narrations at once; banner over the masthead, pill over the map):
![before 1280 site pick](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-before-1280-site-pick.png)
After (caption bar in the frame, label in the tray band, dock unchanged — nothing over the map):
![after 1280 site pick](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-after-1280-site-pick.png)

### 1280px — idle
Before (pill floats dead-centre over Wolverhampton/Cannock):
![before 1280 idle](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-before-1280-idle.png)
After:
![after 1280 idle](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-after-1280-idle.png)

### 390px — site pick
Before (pinned banner covers the wordmark and era plate; pill over the map):
![before 390 site pick](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-before-390-site-pick.png)
After (step change auto-scrolled the board into view; caption is part of the frame):
![after 390 site pick](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-after-390-site-pick.png)

### More flows (after)
Route pick at 1280 — "Choose a canal route — 21 available" in the frame:
![after 1280 route pick](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-after-1280-route-pick.png)
Develop keeps the mat modal's own narration; the iron-source caption sits in the frame behind it:
![after develop mat](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-after-1280-develop-mat.png)
Beer-source step at 390 — source picks now get a board caption for free:
![after 390 beer source](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr103-after-390-beer-source.png)

## Surfaced by this change, not fixed here: error toasts intercept board taps on phones

Chasing a CI-only e2e failure turned up a real input problem this change makes more likely to bite. Sonner error toasts render top-right with `pointer-events: auto` — verified by hit-testing a live toast at 390px: it wins `elementFromPoint` over its entire 358×73px rect (y 16–89, nearly full width). The auto-scroll now deliberately places the board's top edge at the viewport top at the exact moment the player is asked to tap it — so for the ~4s a toast lives (e.g. a rejected-tap `explainRefusal`, or the stale `lastError` the `?demo` fixture toasts on boot), a real finger aimed at a plate in that top band lands on the toast and the tap is silently eaten. This is pre-existing toast behavior (toasts always overlapped the board top on phones), but the step-change scroll makes the collision systematic rather than incidental. Deliberately **not** fixed in this PR — flagging for a separate decision. The e2e spec `board-touch-zoom.spec.ts` documents the interception concretely: its CDP pinch on Derby silently no-ops while the boot toast is up, and it now waits the toast out before dispatching touches.

Supersedes #101 (pinned-overlay approach, closed).

## Rebase + review update

Rebased onto latest main (no conflicts). Ran an independent review of the diff via Claude Code (Opus 5) — the opencode-go/kimi-k3 reviewer was out of limit and did not respond within a minute, so this used the authorized fallback instead of a metered provider.

Two P1 findings, both fixed:
- Beer/iron/coal source-pick steps (`step-scroll.ts`) were mapped to scroll to the board on phones, but the board is not tappable during those steps — the map only spotlights candidates, the actual pick control lives in the dock. Fixed to scroll to the dock instead.
- `developing.choosingIronSource` was also mapped to the board, but that step opens the develop mat modal, which owns the pick, same as its `selectingTiles`/`confirmingDevelop` siblings. Fixed to scroll nowhere, matching those siblings.

Lint, typecheck, and the full unit suite are green after the fixes.

The toast-interception item below remains exactly as flagged — a known, deliberately deferred issue awaiting a product decision, not touched by this update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual, in-frame board captions for board selections and resource/route steps.
  * On phones, the owning board/dock area now auto-scrolls into view when steps change, with reduced-motion support and scroll-suppression after manual panning.
* **UI Improvements**
  * Replaced the floating hand hint with a compact tray label that doesn’t reserve extra layout space.
  * Updated the map layout to use a top caption bar and repositioned the legend for better visibility.
* **Documentation**
  * Documented that “next-step narration” renders on the active surface only.
* **Tests**
  * Added caption and step-scroll test coverage; updated e2e selectors and stabilized the touch-after-zoom flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
