### PR TITLE
docs: replace create-t3-app boilerplate with real stack description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,20 @@
-# Create T3 App
+# Brass Birmingham
 
-This is a [T3 Stack](https://create.t3.gg/) project bootstrapped with `create-t3-app`.
+Digital implementation of the Brass Birmingham board game, built on Next.js 16
+and React 19, deployed on Vercel.
 
-## What's next? How do I make an app with this?
+The game engine is an [XState 5](https://stately.ai/docs/xstate-v5) state
+machine — every rule (build legality, resource sourcing, turn order, scoring)
+lives there, not scattered across the UI. Online games are persisted with
+[Drizzle ORM](https://orm.drizzle.team) on Neon Postgres; env config and AI
+responses are validated with [Zod](https://zod.dev); errors are tracked with
+[Sentry](https://sentry.io).
 
-We try to keep this project as simple as possible, so you can start with just the scaffolding we set up for you, and add additional things later when they become necessary.
-
-If you are not familiar with the different technologies used in this project, please refer to the respective docs. If you still are in the wind, please join our [Discord](https://t3.gg/discord) and ask for help.
-
-- [Next.js](https://nextjs.org)
-- [NextAuth.js](https://next-auth.js.org)
-- [Prisma](https://prisma.io)
-- [Drizzle](https://orm.drizzle.team)
-- [Tailwind CSS](https://tailwindcss.com)
-- [tRPC](https://trpc.io)
-
-## Learn More
-
-To learn more about the [T3 Stack](https://create.t3.gg/), take a look at the following resources:
-
-- [Documentation](https://create.t3.gg/)
-- [Learn the T3 Stack](https://create.t3.gg/en/faq#what-learning-resources-are-currently-available) — Check out these awesome tutorials
-
-You can check out the [create-t3-app GitHub repository](https://github.com/t3-oss/create-t3-app) — your feedback and contributions are welcome!
-
-## How do I deploy this?
-
-Follow our deployment guides for [Vercel](https://create.t3.gg/en/deployment/vercel), [Netlify](https://create.t3.gg/en/deployment/netlify) and [Docker](https://create.t3.gg/en/deployment/docker) for more information.
+There are no user accounts and no auth. A hotseat game runs entirely in the
+browser and saves to `localStorage`. Online games are identified by a token in
+the URL, with a per-seat secret in each player's `localStorage`; the server
+owns the state and streams updates to every player over Server-Sent Events
+(SSE).
 
 ## Local test database (Docker)
 


### PR DESCRIPTION
## Summary
- README opened with untouched create-t3-app boilerplate (title, T3 Stack blurb, tech list advertising NextAuth.js/tRPC/Prisma) even though none of those are used
- Replaced the top ~30 lines with a short, accurate description of the real stack: Next.js 16/React 19 on Vercel, XState 5 as the game engine, Drizzle ORM on Neon Postgres, Zod, Sentry, and no-auth token-URL multiplayer with per-seat localStorage secrets over SSE
- Hand-written sections below (Local test database, Debugging the game state machine, Icon credits, etc.) are untouched

Reviewed with Claude Opus 5 (kimi-k3 was out of subscription limit and hung past 1 minute); applied its two substantive findings — scoped the Zod claim to env/AI validation instead of implying it's DB validation, and clarified that only online games persist to Drizzle/Neon while hotseat games are fully client-side/localStorage.

## Test plan
- [x] `grep -niE 'create-t3|t3 stack|next-?auth|tRPC|prisma' README.md` returns nothing