### PR TITLE
chore: remove dead .claude/.mcp.json

### DIFF
--- a/.claude/.mcp.json
+++ b/.claude/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mpc-servers": {
-    "chrome-mcp-server": {
-      "type": "streamableHttp",
-      "url": "http://127.0.0.1:12306/mcp"
-    }
-  }
-}


### PR DESCRIPTION
## Summary
- `.claude/.mcp.json` has never worked: an MCP config must live at the repo root as `.mcp.json`, not under `.claude/`, and its top-level key was `mpc-servers` (typo for `mcpServers`).
- It declared a local Chrome MCP bridge on `http://127.0.0.1:12306/mcp`.

## Evidence
- Grepped the repo for `12306`, `mpc-servers`, `chrome-mcp-server`, and `.mcp.json`: the only hits are inside the dead file itself. Nothing depends on it.
- Julius already has a working Chrome DevTools MCP server plus the `chrome-devtools-axi` CLI wired in, so this stray local-bridge config is dead cruft rather than something to fix in place.

## Decision
Deleted the file rather than relocating it, since nothing references or needs it.

## Review
Pre-push review run via `claude --model claude-opus-5 -p` (kimi-k3 hung >1min, used the authorized fallback). No concerns raised.

## Test plan
- [x] Confirmed no repo references to the removed config/port/typo remain
- [x] Config/docs-only change — no app code, schema, dependency, or migration touched