### PR TITLE
fix(ui): stop error toasts from swallowing board taps on a phone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -557,6 +557,17 @@ What this means in practice:
   game itself never touches the DB.
 - All styles are scoped under `.bb2` (`theme.css`) with Fraunces + Barlow
   Semi Condensed via `next/font` in `src/app/page.tsx`.
+- THE TOAST LAYER IS POINTER-TRANSPARENT (`components/ui/sonner.tsx`): toasts
+  render top-right over the board, and on a 390px phone one covers a
+  board-width strip of it, so a hit-testable layer swallows the tap under it
+  with no feedback at all. The container and each toast take
+  `pointer-events: none`; `[&_button]` opts interactive controls (action,
+  cancel, close) back in — the app ships no such control today, so anything
+  adding one inherits it for free. The cost is sonner's own pointer
+  affordances (swipe-to-dismiss, hover-to-pause): toasts are notifications
+  here and expire on their own. Pinned by `e2e/toast-hit-test.spec.ts`, a
+  real-CDP-touch hit test — any new fixed overlay over the board owes the
+  same check.
 - INDUSTRY ICON COLOURS (2026-07-22): six industries each have a base + bright
   stop (`--bb-ind-*` / `--bb-ind-*-bright` in `theme.css`); glyphs render inside
   a `.bb2-indchip` wash coin via `IndustryChip` (`icons.tsx`) — the coin carries
@@ -951,7 +962,12 @@ When updating this file, preserve this bar for all agents and keep entries conci
   specs widen their per-expect timeout to 15s (`expect.configure`) and set
   long test timeouts — every assertion is a POST + SSE round trip against a
   network database; do NOT read a slow run as a product bug before checking
-  DB contention.
+  DB contention. GOTCHA for parallel checkouts: :3199 is shared and
+  `reuseExistingServer` is on locally, so a second run in another worktree
+  attaches to the FIRST run's dev server and every test after that run's
+  teardown dies on `ERR_CONNECTION_REFUSED` (dozens of ~150ms failures, all
+  `page.goto`). That is the port, not the product — run one suite at a time
+  per machine, or point `baseURL`/`webServer` at a free port for the run.
 - `mp-playthrough.spec.ts` (2026-07-17) is the capstone: two real browsers
   play a scripted-but-adaptive canal opening through the UI — network, loan,
   scout, wild-card builds, a SELL that stops at the beer-source picker (own

--- a/e2e/toast-hit-test.spec.ts
+++ b/e2e/toast-hit-test.spec.ts
@@ -1,0 +1,181 @@
+import { type Page, expect, test } from '@playwright/test'
+
+/**
+ * Error toasts float over the top of the board. On a phone they cover a
+ * board-width strip of it, so a toast layer that takes the hit-test swallows
+ * the tap under it — the worst kind of failure on a touch surface, because the
+ * player gets no feedback that the tap was lost.
+ *
+ * Taps here are raw CDP touch events: a synthetic `dispatchEvent` click would
+ * bypass the browser's own hit-test, which is the only thing under test.
+ */
+
+const PHONE = { width: 390, height: 844 }
+
+interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+const FRONT_TOAST =
+  '[data-sonner-toast][data-front="true"][data-visible="true"][data-removed="false"]'
+const BOARD = 'svg[aria-label="Game board map"]'
+
+function centre(r: Rect) {
+  return { x: r.x + r.width / 2, y: r.y + r.height / 2 }
+}
+
+function contains(r: Rect, p: { x: number; y: number }) {
+  return p.x > r.x && p.x < r.x + r.width && p.y > r.y && p.y < r.y + r.height
+}
+
+async function tap(page: Page, at: { x: number; y: number }) {
+  const cdp = await page.context().newCDPSession(page)
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x: at.x, y: at.y, id: 1 }],
+  })
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchEnd',
+    touchPoints: [],
+  })
+}
+
+async function box(page: Page, selector: string): Promise<Rect> {
+  const b = await page.locator(selector).first().boundingBox()
+  if (!b) throw new Error(`no box for ${selector}`)
+  return b
+}
+
+/**
+ * Hold every toast open. Sonner auto-closes on a 4s timer, which is plenty for
+ * a player and far too tight for a spec that has to settle the slide-in, scroll
+ * the board and then tap: an expiry mid-measurement would fail this test for a
+ * reason it is not about. Nothing else in the game schedules a timer this long.
+ */
+async function freezeToastExpiry(page: Page) {
+  await page.addInitScript(() => {
+    const native = window.setTimeout
+    window.setTimeout = ((fn: TimerHandler, ms?: number, ...rest: unknown[]) =>
+      (ms ?? 0) >= 3000
+        ? 0
+        : native(fn, ms, ...rest)) as typeof window.setTimeout
+  })
+}
+
+/** A toast slides in over ~400ms, so read its box once it has come to rest. */
+async function settledBox(page: Page, selector: string): Promise<Rect> {
+  let last = await box(page, selector)
+  for (let i = 0; i < 20; i++) {
+    await page.waitForTimeout(100)
+    const next = await box(page, selector)
+    if (next.y === last.y && next.height === last.height) return next
+    last = next
+  }
+  throw new Error(`${selector} never settled`)
+}
+
+/** What the browser itself says is on top at a viewport point. */
+async function hitTest(page: Page, at: { x: number; y: number }) {
+  return page.evaluate(({ x, y }) => {
+    const el = document.elementFromPoint(x, y)
+    return {
+      city: el?.closest('g[data-city]')?.getAttribute('data-city') ?? null,
+      inToastLayer: !!el?.closest('[data-sonner-toaster]'),
+    }
+  }, at)
+}
+
+/** A build stopped on the site step, with an error toast raised over the board. */
+async function toastOverBuildStep(page: Page) {
+  await freezeToastExpiry(page)
+  await page.goto('/?demo')
+  await page.getByTestId('action-build').click()
+  await page.getByTestId('card-brewery_2').click()
+  await expect(page.getByText(/Choose a site for your brewery/)).toBeVisible()
+
+  // An illegal site raises the engine's own refusal as an error toast.
+  await page
+    .locator('g[data-city="birmingham"]:not([data-legal])')
+    .click({ force: true })
+  await expect(
+    page.getByText(/Birmingham is not in your network/),
+  ).toBeVisible()
+  await page.locator(BOARD).scrollIntoViewIfNeeded()
+}
+
+test.use({ viewport: PHONE, hasTouch: true, isMobile: true })
+
+test('phone: an error toast does not swallow the board tap under it', async ({
+  page,
+}) => {
+  await toastOverBuildStep(page)
+
+  const toast = await settledBox(page, FRONT_TOAST)
+  const board = await box(page, BOARD)
+  // The premise: the toast is painted across the top of the board.
+  expect(toast.y).toBeLessThan(board.y + board.height)
+  expect(toast.y + toast.height).toBeGreaterThan(board.y)
+  expect(toast.width).toBeGreaterThan(300)
+
+  // Bring a legal plate under the toast by scrolling the page — the toast is
+  // fixed to the viewport, the board scrolls with the document.
+  const plate = page.locator(`${BOARD} g[data-city][data-legal="true"]`).first()
+  const city = await plate.getAttribute('data-city')
+  const cityName = (await plate.getAttribute('aria-label'))!.split(' — ')[0]
+  const start = await plate.boundingBox()
+  await page.evaluate(
+    (dy) => window.scrollBy(0, dy),
+    centre(start!).y - centre(toast).y,
+  )
+  const at = centre((await plate.boundingBox())!)
+
+  // The toast is still up, and still covers the point about to be tapped.
+  const stillThere = await box(page, FRONT_TOAST)
+  await expect(page.locator(FRONT_TOAST)).toBeVisible()
+  expect(contains(stillThere, at)).toBe(true)
+
+  // The browser hands that point to the plate, not to the toast layer.
+  const hit = await hitTest(page, at)
+  expect(hit.inToastLayer).toBe(false)
+  expect(hit.city).toBe(city)
+
+  // And a real finger there selects that site.
+  await tap(page, at)
+  const confirm = page.getByTestId('confirm-action')
+  await expect(confirm).toBeEnabled()
+  await confirm.click()
+  await expect(
+    page.getByText(new RegExp(`built Brewery \\(I\\) at ${cityName}`)),
+  ).toBeVisible()
+})
+
+test('phone: a control inside a toast is still clickable', async ({ page }) => {
+  await toastOverBuildStep(page)
+  await settledBox(page, FRONT_TOAST)
+
+  // No toast in the app carries an action, cancel or close control today, so
+  // the exception that keeps such a control clickable is exercised against the
+  // live cascade instead: a real button, inside a real toast, tapped for real.
+  await page.locator(FRONT_TOAST).evaluate((li) => {
+    const button = document.createElement('button')
+    button.dataset.button = 'true'
+    button.id = 'probe-action'
+    button.textContent = 'Undo'
+    button.addEventListener('click', () => {
+      button.dataset.tapped = 'true'
+    })
+    li.appendChild(button)
+  })
+
+  const button = page.locator('#probe-action')
+  await expect(button).toBeVisible()
+  const at = centre((await button.boundingBox())!)
+
+  // The browser hands the point to the button, not past it to the board.
+  expect((await hitTest(page, at)).inToastLayer).toBe(true)
+  await tap(page, at)
+  await expect(button).toHaveAttribute('data-tapped', 'true')
+})

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -11,11 +11,14 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps['theme']}
-      className="toaster group"
+      // Toasts float over the game board, so the layer must not take the
+      // hit-test: a swallowed tap tells the player nothing at all. Interactive
+      // toast controls (action, cancel, close) opt back in.
+      className="toaster group pointer-events-none"
       toastOptions={{
         classNames: {
           toast:
-            'group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
+            'group toast pointer-events-none [&_button]:pointer-events-auto group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg',
           description: 'group-[.toast]:text-muted-foreground',
           actionButton:
             'group-[.toast]:bg-primary group-[.toast]:text-primary-foreground',


### PR DESCRIPTION
## Why

Toasts render top-right, over the board. On a 390px phone viewport one covers a **358×53px board-width strip** at the top of the board, and because the toast layer takes the browser hit-test, a tap in that strip goes nowhere: no selection, no message, nothing to tell the player the tap was lost. Raising an error toast mid-action therefore blinded the top of the board until the toast expired — and an error toast is exactly the moment a player is about to try again.

This is not new behaviour: the toasts, their position and their pointer behaviour are unchanged. It only becomes easy to hit now that the board sits at the top of the viewport during a step change.

## What

`src/components/ui/sonner.tsx` — the toast container and each toast are pointer-transparent, with an exception (`[&_button]`) that keeps any interactive control inside a toast clickable.

**Precondition checked first:** no toast in this app carries an action, cancel or close control. Every call site is `toast.error(message)` or `toast(message)` — no `action:`/`cancel:` options anywhere, and `closeButton` is not enabled on any `<Toaster>`. So the simple whole-layer fix is the correct one here; the button exception is there so that adding an action later cannot silently produce an unclickable button, and it is pinned by a test rather than left as a hope.

**What this gives up:** sonner's own pointer affordances on a toast — swipe-to-dismiss and hover-to-pause. Nothing in the app relies on either: these toasts are notifications that expire on their own after 4s, and there is no dismiss-on-tap behaviour to break (sonner has none without `closeButton`). The board underneath is worth more than a swipe shortcut.

## Evidence (390px, iPhone-class viewport)

The same scripted tap on Derby — a legal build site — while an error toast covers it.

### Before: tap swallowed, still on the SITE step
![before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr106-before.png)

### After: Derby selected, flow advanced to CONFIRM
![after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr106-after.png)

## Tests

`e2e/toast-hit-test.spec.ts`, two hit-test-level assertions at 390px with real CDP touch events (a synthetic `dispatchEvent` click would bypass the browser hit-test, which is the only thing under test — same blind spot as the `setPointerCapture` bug documented in `board-map.tsx`):

1. **The regression.** Enter a build, tap an illegal city to raise the engine's refusal as an error toast, scroll a legal plate under the toast, then assert the browser hands that point to the plate rather than the toast layer — and drive a real touch there, which selects the site and confirms the build. Verified to **fail on `main`** (`inToastLayer: true`, the tap is swallowed and the dock never leaves the SITE step).
2. **The control guard.** A button inside a live toast is tapped for real and its handler must fire. Verified to fail if the `[&_button]` exception is dropped.

The spec holds toast timers open (sonner auto-closes after 4s — plenty for a player, too tight for a spec that has to settle the slide-in, scroll and then tap) and requires a live, unremoved front toast, so it cannot pass vacuously against a toast that has gone away.

Full suite green locally: `pnpm test` 839 passed, `pnpm exec playwright test` 66 passed / 1 skipped (the quarantined Develop journey), plus lint and typecheck.

## Note for the parallel 375px hand-tray investigation

Not the same problem. `hand-tray.spec.ts`'s 375px "Open the ledger" tap passes on this branch and on `main` when the suite is not contended — the mass failures I first saw were port :3199 being shared with a second concurrent Playwright run (every failure was `ERR_CONNECTION_REFUSED` on `page.goto` after the other run's teardown killed the dev server). That trap is now written down in `AGENTS.md`. The ledger button sits at the bottom of the layout, nowhere near the top-right toast strip, so the toast layer was never over it.

## Review

Reviewed pre-push by `codex review` (gpt-5.6-luna, reasoning effort xhigh) against `origin/main`. No P0/P1. Both P2 findings are fixed in this branch:

- the toast's 4s lifetime made the spec time-sensitive → timers held open, and the front-toast selector now requires `data-visible="true"`/`data-removed="false"`;
- the control probe only read computed `pointer-events` → it drives a real tap at a real handler, and was verified to fail with the exception removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toast notifications no longer block touch or pointer interactions with content beneath them.
  * Interactive controls within toast notifications remain clickable.

* **Tests**
  * Added end-to-end coverage for touch hit-testing between toast overlays and the underlying game board.
  * Added validation for interactive controls embedded in notifications.

* **Documentation**
  * Documented toast interaction behavior and guidance for running end-to-end tests with shared development servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->