### PR TITLE
fix(board): stand merchant beer in its own socket below the tile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -568,13 +568,40 @@ What this means in practice:
   here and expire on their own. Pinned by `e2e/toast-hit-test.spec.ts`, a
   real-CDP-touch hit test — any new fixed overlay over the board owes the
   same check.
+- MERCHANT BEER SITS IN ITS OWN SOCKET (2026-07-26): the beer a merchant
+  supplies is an upright cask standing in a recessed round well BELOW its tile,
+  in a dedicated row the merchant plate reserves for it — the physical board's
+  own arrangement. Geometry is pure in `board/merchant-beer.ts` (which also owns
+  the merchant slot's industry-glyph cells, so tile-vs-socket clearance is
+  asserted in one place); the plate metrics it divides up (`MERCHANT_BEER_ROW_H`,
+  `MERCHANT_PLATE_H`, `MERCHANT_PLATE_TOP`) live with the other plate sizing in
+  `board/marker-anchor.ts` so `plateRect`'s obstacle box cannot drift from what
+  is drawn. Four rules, and any new on-board marker inherits them:
+  (1) THE BOARD IS 1600 UNITS WIDE AND A 390px PHONE RENDERS IT AT 0.221 (1280px
+  gives 0.489 — both measured off `getScreenCTM`, both pinned in
+  `merchant-beer.test.ts`), so a marker crammed into an occupied area can only
+  reach legible size by being reshaped, and a reshaped barrel stops reading as a
+  barrel. Give it its own space instead: BARREL ART IS AUTHORED ONCE AT CASK
+  PROPORTIONS AND PLACED WITH A SINGLE UNIFORM `scale()` — never stretch one
+  axis. (2) A merchant plate grows UPWARD from a bottom edge half a tile-row
+  below its city point (`MERCHANT_PLATE_TOP`), because growing downward pushes
+  Gloucester's ribbon off the viewBox and squeezes the Warrington–Stoke link
+  marker; `marker-anchor.test.ts` catches both. (3) Contrast comes from the dark
+  well under the amber, not from the fill — every plate, glyph and link icon on a
+  merchant is the same brass hue family. Corollary: the cask carries no light
+  keyline and no second fill; it must stay ONE amber mass or it breaks into two
+  blobs at phone size. (4) The socket is what makes state readable: a tile that
+  buys goods owns one for the whole era, so spent beer leaves a dashed empty
+  well, while a blank tile gets no socket at all — three distinct reads. Carries
+  `data-beer="ready"|"spent"`; pinned by `merchant-beer.test.ts` (geometry,
+  uniform scale, phone-scale mass) and `e2e/merchant-beer.spec.ts` (which slots
+  get one).
 - INDUSTRY ICON COLOURS (2026-07-22): six industries each have a base + bright
   stop (`--bb-ind-*` / `--bb-ind-*-bright` in `theme.css`); glyphs render inside
   a `.bb2-indchip` wash coin via `IndustryChip` (`icons.tsx`) — the coin carries
   the tint, the glyph keeps surface ink. Board tile faces use the SAME base
   hexes (`INDUSTRY_FILL`/`INDUSTRY_INK`, `board-map.tsx`). On-tile resource
-  markers share one 1px parchment keyline `#f2e6c8` (cubes + merchant beer
-  barrel). Cube LAYOUT: BOTH surfaces now draw EVERY cube in a two-wide grid —
+  markers share one 1px parchment keyline `#f2e6c8`. Cube LAYOUT: BOTH surfaces now draw EVERY cube in a two-wide grid —
   the player MAT (`player-ledger.tsx` `MatTileArt`) and, since 2026-07-23, the
   board (`BuiltTile`), whose geometry lives in the pure `board/tile-cubes.ts`
   (`cubeCells`). The board's old single column TOUCHED the roman level numeral
@@ -986,8 +1013,13 @@ What this means in practice:
   still builds and runs) and the BUILD-ONLY `SENTRY_AUTH_TOKEN`/`SENTRY_ORG`/
   `SENTRY_PROJECT` for source maps. All optional in `src/env.js`, documented in
   `.env.example`.
-- GOTCHA: `pnpm test`'s glob now includes `src/lib/*.test.ts` — it did not
-  before, so a test placed there used to be silently skipped by CI.
+- GOTCHA: `pnpm test`'s glob is an EXPLICIT per-directory list, not a recursive
+  sweep, and CI runs exactly it — a test in a directory that is not listed is
+  silently skipped on every PR (this hid `src/lib` and all of
+  `src/components/board` for a while). Add the directory to BOTH `test` and
+  `test:watch` in the same commit as the first test you put there, and check
+  with `pnpm test 2>&1 | grep <your-file>` rather than trusting a local
+  `pnpm vitest run <path>`.
 
 ## Analytics (added 2026-07-17)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -570,16 +570,19 @@ What this means in practice:
   same check.
 - MERCHANT BEER SITS IN ITS OWN SOCKET (2026-07-26): the beer a merchant
   supplies is an upright cask standing in a recessed round well BELOW its tile,
-  in a dedicated row the merchant plate reserves for it — the physical board's
-  own arrangement. Geometry is pure in `board/merchant-beer.ts` (which also owns
+  in a dedicated row the merchant plate reserves for it — alongside the tile
+  rather than inside its icon area, as the printed board does. Geometry is pure
+  in `board/merchant-beer.ts` (which also owns
   the merchant slot's industry-glyph cells, so tile-vs-socket clearance is
   asserted in one place); the plate metrics it divides up (`MERCHANT_BEER_ROW_H`,
   `MERCHANT_PLATE_H`, `MERCHANT_PLATE_TOP`) live with the other plate sizing in
   `board/marker-anchor.ts` so `plateRect`'s obstacle box cannot drift from what
   is drawn. Four rules, and any new on-board marker inherits them:
   (1) THE BOARD IS 1600 UNITS WIDE AND A 390px PHONE RENDERS IT AT 0.221 (1280px
-  gives 0.489 — both measured off `getScreenCTM`, both pinned in
-  `merchant-beer.test.ts`), so a marker crammed into an occupied area can only
+  gives 0.489 — the unit tests size markers against those numbers and
+  `e2e/merchant-beer.spec.ts` reads the live `getScreenCTM` at both widths, so a
+  frame change that shrinks the board fails), so a marker crammed into an
+  occupied area can only
   reach legible size by being reshaped, and a reshaped barrel stops reading as a
   barrel. Give it its own space instead: BARREL ART IS AUTHORED ONCE AT CASK
   PROPORTIONS AND PLACED WITH A SINGLE UNIFORM `scale()` — never stretch one
@@ -595,7 +598,9 @@ What this means in practice:
   well, while a blank tile gets no socket at all — three distinct reads. Carries
   `data-beer="ready"|"spent"`; pinned by `merchant-beer.test.ts` (geometry,
   uniform scale, phone-scale mass) and `e2e/merchant-beer.spec.ts` (which slots
-  get one).
+  get one, plus the render scale). Cosmetic cost, deliberate: a closed or blank
+  merchant still reserves the socket row, so its plate shows an empty bottom
+  band.
 - INDUSTRY ICON COLOURS (2026-07-22): six industries each have a base + bright
   stop (`--bb-ind-*` / `--bb-ind-*-bright` in `theme.css`); glyphs render inside
   a `.bb2-indchip` wash coin via `IndustryChip` (`icons.tsx`) — the coin carries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -569,9 +569,13 @@ What this means in practice:
   real-CDP-touch hit test — any new fixed overlay over the board owes the
   same check.
 - MERCHANT BEER SITS IN ITS OWN SOCKET (2026-07-26): the beer a merchant
-  supplies is an upright cask standing in a recessed round well BELOW its tile,
-  in a dedicated row the merchant plate reserves for it — alongside the tile
-  rather than inside its icon area, as the printed board does. Geometry is pure
+  supplies is the vendored `brewery` barrel glyph standing in a recessed round
+  well BELOW its tile, in a dedicated row the merchant plate reserves for it —
+  alongside the tile rather than inside its icon area, as the printed board does.
+  It is DELIBERATELY the same glyph the brewery industry wears: a merchant never
+  buys beer, so a barrel in the socket has one possible meaning, and beer and the
+  industry that makes it are one thing on this board — a second beer symbol would
+  be a new shape for a concept that already has one. Geometry is pure
   in `board/merchant-beer.ts` (which also owns
   the merchant slot's industry-glyph cells, so tile-vs-socket clearance is
   asserted in one place); the plate metrics it divides up (`MERCHANT_BEER_ROW_H`,
@@ -584,12 +588,21 @@ What this means in practice:
   frame change that shrinks the board fails), so a marker crammed into an
   occupied area can only
   reach legible size by being reshaped, and a reshaped barrel stops reading as a
-  barrel. Give it its own space instead: BARREL ART IS AUTHORED ONCE AT CASK
-  PROPORTIONS AND PLACED WITH A SINGLE UNIFORM `scale()` — never stretch one
-  axis. (2) A merchant plate grows UPWARD from a bottom edge half a tile-row
+  barrel. Give it its own space instead: THE GLYPH IS PLACED WITH A SINGLE
+  UNIFORM `scale()` — never stretch one axis (the e2e spec walks the rendered
+  matrix and fails on skew or unequal axes). Its ink bounds are hard-coded
+  (`BARREL_INK`) because the board renders server-side where there is no
+  `getBBox`; the same spec measures the live path so vendored icon data cannot
+  drift away from them. (1b) ANY SEPARATION MUST BE WORTH A SCREEN PIXEL: the
+  air above the socket row is 7 board units = 1.55 CSS px on a phone. Two units
+  — the intuitive "small gap" — is 0.44 px and reads as nothing at all.
+  (2) A merchant plate grows UPWARD from a bottom edge half a tile-row
   below its city point (`MERCHANT_PLATE_TOP`), because growing downward pushes
   Gloucester's ribbon off the viewBox and squeezes the Warrington–Stoke link
-  marker; `marker-anchor.test.ts` catches both. (3) Contrast comes from the dark
+  marker; `marker-anchor.test.ts` catches both. What CAPS the row height is the
+  link-icon pair straddling the plate's top edge (`LINK_ICON_DY`/`LINK_ICON_R`):
+  Warrington sits nearest the board's top edge, so the plate cannot exceed 100
+  units without pushing those icons outside the viewBox. (3) Contrast comes from the dark
   well under the amber, not from the fill — every plate, glyph and link icon on a
   merchant is the same brass hue family. Corollary: the cask carries no light
   keyline and no second fill; it must stay ONE amber mass or it breaks into two

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -593,7 +593,14 @@ What this means in practice:
   matrix and fails on skew or unequal axes). Its ink bounds are hard-coded
   (`BARREL_INK`) because the board renders server-side where there is no
   `getBBox`; the same spec measures the live path so vendored icon data cannot
-  drift away from them. (1b) ANY SEPARATION MUST BE WORTH A SCREEN PIXEL: the
+  drift away from them. (1a) A ROUND WELL IS FITTED BY RADIUS, NOT BY AXES. The
+  cask's silhouette nearly fills its own box, so its corners reach ~20% further
+  from centre than its half-width or half-height — an "is the height inside the
+  rim" check passes while the art overruns the ring at four points and the well
+  stops reading as one. `BARREL_INK_R` is that silhouette radius, sampled with
+  `isPointInFill` off the live path (the e2e spec re-samples it), and
+  `BARREL_RIM_CLEARANCE` is what is left over inside the rim's inner face.
+  (1b) ANY SEPARATION MUST BE WORTH A SCREEN PIXEL: the
   air above the socket row is 7 board units = 1.55 CSS px on a phone. Two units
   — the intuitive "small gap" — is 0.44 px and reads as nothing at all.
   (2) A merchant plate grows UPWARD from a bottom edge half a tile-row

--- a/e2e/merchant-beer.spec.ts
+++ b/e2e/merchant-beer.spec.ts
@@ -8,6 +8,7 @@
  * all, and a barrel spent on a sale.
  */
 import { type Page, expect, test } from '@playwright/test'
+import { BARREL_INK_R } from '../src/components/board/merchant-beer'
 
 function sockets(page: Page, city: string, state?: 'ready' | 'spent') {
   const sel = state ? `[data-beer="${state}"]` : '[data-beer]'
@@ -77,7 +78,8 @@ test('the barrel glyph sits centred in its socket, clear of the rim', async ({
     .evaluate((g) => {
       const socket = g.querySelector('circle')!
       const art = g.querySelector('g') as SVGGElement
-      const ink = (art.querySelector('path') as SVGPathElement).getBBox()
+      const path = art.querySelector('path') as SVGPathElement
+      const ink = path.getBBox()
       // getBBox is in the element's own space, so walk the art group's matrix
       // to land the ink bounds in the socket's coordinates.
       const m = art.transform.baseVal.consolidate()!.matrix
@@ -89,12 +91,30 @@ test('the barrel glyph sits centred in its socket, clear of the rim', async ({
           y: m.b * x + m.d * y + m.f,
         })),
       )
+      // The socket is round, so what has to fit is the silhouette's own radius,
+      // not its width and height. Sample the fill for the furthest inked point
+      // from the centre of the bounds the transform centres on the socket.
+      const cx = ink.x + ink.width / 2
+      const cy = ink.y + ink.height / 2
+      const probe = (g as SVGGElement).ownerSVGElement!.createSVGPoint()
+      const N = 160
+      let inkR = 0
+      for (let i = 0; i <= N; i++) {
+        for (let j = 0; j <= N; j++) {
+          probe.x = ink.x + (ink.width * i) / N
+          probe.y = ink.y + (ink.height * j) / N
+          if (!path.isPointInFill(probe)) continue
+          inkR = Math.max(inkR, Math.hypot(probe.x - cx, probe.y - cy))
+        }
+      }
       return {
         r: Number(socket.getAttribute('r')),
+        stroke: Number(socket.getAttribute('stroke-width')),
         a: m.a,
         b: m.b,
         c: m.c,
         d: m.d,
+        inkR,
         left: Math.min(...pts.map((p) => p.x)),
         right: Math.max(...pts.map((p) => p.x)),
         top: Math.min(...pts.map((p) => p.y)),
@@ -111,11 +131,20 @@ test('the barrel glyph sits centred in its socket, clear of the rim', async ({
   const w = fit.right - fit.left
   const h = fit.bottom - fit.top
   expect(w).toBeGreaterThan(0)
-  // Centred on the socket origin, and inside its rim on both axes.
+  // Centred on the socket origin.
   expect(Math.abs(fit.left + w / 2)).toBeLessThan(0.6)
   expect(Math.abs(fit.top + h / 2)).toBeLessThan(0.6)
-  expect(w / 2).toBeLessThan(fit.r - 1)
-  expect(h / 2).toBeLessThan(fit.r - 1)
+
+  // The hard-coded silhouette radius the geometry is sized from, measured off
+  // the live path so replacing the vendored icon cannot quietly let the barrel
+  // overrun the well again.
+  expect(fit.inkR).toBeGreaterThan(BARREL_INK_R - 3)
+  expect(fit.inkR).toBeLessThan(BARREL_INK_R + 1)
+
+  // Every inked point sits inside the rim's inner face, with a ring of well to
+  // spare, so the socket contains the barrel rather than being covered by it.
+  const placedR = fit.inkR * fit.a
+  expect(placedR).toBeLessThan(fit.r - fit.stroke / 2 - 1.8)
 })
 
 // merchant-beer.test.ts sizes the barrel in board units against these two

--- a/e2e/merchant-beer.spec.ts
+++ b/e2e/merchant-beer.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * The beer a merchant supplies, as the board actually renders it.
+ *
+ * The geometry is unit-pinned in `src/components/board/merchant-beer.test.ts`;
+ * what only a real render can show is WHICH slots get a socket and which state
+ * it is in, so this spec walks the four cases the fixtures produce: a merchant
+ * with beer, a blank tile that buys nothing, a closed merchant with no tiles at
+ * all, and a barrel spent on a sale.
+ */
+import { type Page, expect, test } from '@playwright/test'
+
+function sockets(page: Page, city: string, state?: 'ready' | 'spent') {
+  const sel = state ? `[data-beer="${state}"]` : '[data-beer]'
+  return page.locator(`g[data-city="${city}"] ${sel}`)
+}
+
+test('every merchant tile that buys goods shows its beer; blank and closed ones show none', async ({
+  page,
+}) => {
+  await page.goto('/?demo')
+  await expect(page.getByTestId('era-plate')).toBeVisible()
+
+  // Warrington prints two tiles in this fixture, both stocked.
+  await expect(sockets(page, 'warrington', 'ready')).toHaveCount(2)
+
+  await expect(sockets(page, 'shrewsbury', 'ready')).toHaveCount(1)
+
+  // Gloucester and Oxford each pair a buying tile with a blank one. The blank
+  // tile never holds beer, so it gets no socket at all — not an empty one.
+  for (const city of ['gloucester', 'oxford']) {
+    await expect(sockets(page, city, 'ready')).toHaveCount(1)
+    await expect(sockets(page, city)).toHaveCount(1)
+  }
+
+  // Nottingham is closed at this player count: no tiles, so no sockets.
+  await expect(sockets(page, 'nottingham')).toHaveCount(0)
+
+  // Nothing is stuck in the spent state before anyone has sold.
+  await expect(page.locator('[data-beer="spent"]')).toHaveCount(0)
+})
+
+test('spending a merchant barrel empties that socket and no other', async ({
+  page,
+}) => {
+  await page.goto('/?demo=beerchoice')
+  await expect(sockets(page, 'warrington', 'ready')).toHaveCount(1)
+  const readyBefore = await page.locator('[data-beer="ready"]').count()
+
+  await page.getByTestId('action-sell').click()
+  await page.locator('button.bb2-card:not([disabled])').first().click()
+  await page
+    .getByTestId('sale-option')
+    .filter({ hasText: 'cotton at Leek' })
+    .click()
+  await page
+    .getByTestId('beer-source')
+    .filter({ hasText: "Warrington merchant's barrel" })
+    .click()
+
+  await expect(sockets(page, 'warrington', 'spent')).toHaveCount(1)
+  await expect(sockets(page, 'warrington', 'ready')).toHaveCount(0)
+  await expect(page.locator('[data-beer="ready"]')).toHaveCount(readyBefore - 1)
+})

--- a/e2e/merchant-beer.spec.ts
+++ b/e2e/merchant-beer.spec.ts
@@ -61,3 +61,23 @@ test('spending a merchant barrel empties that socket and no other', async ({
   await expect(sockets(page, 'warrington', 'ready')).toHaveCount(0)
   await expect(page.locator('[data-beer="ready"]')).toHaveCount(readyBefore - 1)
 })
+
+// merchant-beer.test.ts sizes the barrel in board units against these two
+// scales. They are a property of the frame, not of the board data, so a layout
+// change could move them and shrink every on-board marker with nothing failing.
+for (const [width, height, scale] of [
+  [1280, 900, 0.489],
+  [390, 844, 0.221],
+] as const) {
+  test(`the board renders at ${scale} of its viewBox at ${width}px`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width, height })
+    await page.goto('/?demo')
+    await expect(page.getByTestId('era-plate')).toBeVisible()
+    const measured = await page
+      .locator('svg.touch-none')
+      .evaluate((svg) => (svg as SVGSVGElement).getScreenCTM()!.a)
+    expect(measured).toBeCloseTo(scale, 2)
+  })
+}

--- a/e2e/merchant-beer.spec.ts
+++ b/e2e/merchant-beer.spec.ts
@@ -62,6 +62,62 @@ test('spending a merchant barrel empties that socket and no other', async ({
   await expect(page.locator('[data-beer="ready"]')).toHaveCount(readyBefore - 1)
 })
 
+test('the barrel glyph sits centred in its socket, clear of the rim', async ({
+  page,
+}) => {
+  // `merchant-beer.ts` hard-codes the vendored glyph's ink bounds, because the
+  // board renders server-side where there is no `getBBox`. This measures the
+  // real path: if the icon data moves, the barrel drifts off-centre or out of
+  // its well and nothing else would notice.
+  await page.goto('/?demo')
+  await expect(page.getByTestId('era-plate')).toBeVisible()
+  const fit = await page
+    .locator('g[data-beer="ready"]')
+    .first()
+    .evaluate((g) => {
+      const socket = g.querySelector('circle')!
+      const art = g.querySelector('g') as SVGGElement
+      const ink = (art.querySelector('path') as SVGPathElement).getBBox()
+      // getBBox is in the element's own space, so walk the art group's matrix
+      // to land the ink bounds in the socket's coordinates.
+      const m = art.transform.baseVal.consolidate()!.matrix
+      const xs = [ink.x, ink.x + ink.width]
+      const ys = [ink.y, ink.y + ink.height]
+      const pts = xs.flatMap((x) =>
+        ys.map((y) => ({
+          x: m.a * x + m.c * y + m.e,
+          y: m.b * x + m.d * y + m.f,
+        })),
+      )
+      return {
+        r: Number(socket.getAttribute('r')),
+        a: m.a,
+        b: m.b,
+        c: m.c,
+        d: m.d,
+        left: Math.min(...pts.map((p) => p.x)),
+        right: Math.max(...pts.map((p) => p.x)),
+        top: Math.min(...pts.map((p) => p.y)),
+        bottom: Math.max(...pts.map((p) => p.y)),
+      }
+    })
+
+  // Both axes come out of the same factor, with no skew: the art can be sized,
+  // never stretched or sheared.
+  expect(fit.a).toBeCloseTo(fit.d, 9)
+  expect(fit.b).toBe(0)
+  expect(fit.c).toBe(0)
+
+  const w = fit.right - fit.left
+  const h = fit.bottom - fit.top
+  expect(w).toBeGreaterThan(0)
+  // Centred on the socket origin, and inside its rim on both axes.
+  expect(Math.abs(fit.left + w / 2)).toBeLessThan(0.6)
+  expect(Math.abs(fit.top + h / 2)).toBeLessThan(0.6)
+  expect(w / 2).toBeLessThan(fit.r - 1)
+  expect(h / 2).toBeLessThan(fit.r - 1)
+})
+
 // merchant-beer.test.ts sizes the barrel in board units against these two
 // scales. They are a property of the frame, not of the board data, so a layout
 // change could move them and shrink every on-board marker with nothing failing.

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "typecheck": "tsc --noEmit",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
-    "test": "vitest run src/store/gameStore.*.test.ts src/data/*.test.ts src/lib/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
-    "test:watch": "vitest src/store/gameStore.*.test.ts src/data/*.test.ts src/lib/*.test.ts src/components/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
+    "test": "vitest run src/store/gameStore.*.test.ts src/data/*.test.ts src/lib/*.test.ts src/components/*.test.ts src/components/board/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
+    "test:watch": "vitest src/store/gameStore.*.test.ts src/data/*.test.ts src/lib/*.test.ts src/components/*.test.ts src/components/board/*.test.ts src/components/mp/*.test.ts src/server/ai/*.test.ts src/server/db/*.test.ts src/server/mp/*.test.ts scripts/*.test.ts",
     "test:all": "vitest run",
     "test:coverage": "vitest run --coverage"
   },

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -35,6 +35,7 @@ import {
   BEER_SOCKET_CX,
   BEER_SOCKET_CY,
   BEER_SOCKET_R,
+  BEER_SOCKET_STROKE,
   barrelTransform,
   merchantIconCells,
 } from './merchant-beer'
@@ -1698,7 +1699,7 @@ function MerchantBeerSocket({ hasBeer }: { hasBeer: boolean }) {
         fillOpacity={hasBeer ? 0.95 : 0.7}
         stroke="#c39538"
         strokeOpacity={hasBeer ? 0.6 : 0.3}
-        strokeWidth="1.2"
+        strokeWidth={BEER_SOCKET_STROKE}
         strokeDasharray={hasBeer ? undefined : '3 3'}
       />
       {hasBeer && (

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -18,6 +18,8 @@ import { GAME_ICONS } from '../gameicons-data'
 import { IndustryFragment } from '../icons'
 import { VIEW_H, VIEW_W, cityPos, linkKey } from './board-data'
 import {
+  MERCHANT_PLATE_H,
+  MERCHANT_PLATE_TOP,
   PLATE_PAD,
   SLOT,
   SLOT_GAP,
@@ -26,6 +28,23 @@ import {
   pointAt,
   routeCurve,
 } from './marker-anchor'
+import {
+  BARREL_H,
+  BARREL_SCALE,
+  BARREL_W,
+  BEER_SOCKET_CX,
+  BEER_SOCKET_CY,
+  BEER_SOCKET_R,
+  HEAD_CX,
+  HEAD_CY,
+  HEAD_RX,
+  HEAD_RY,
+  HOOP_W,
+  MAX_ICONS,
+  barrelBodyPath,
+  barrelHoops,
+  merchantIconCells,
+} from './merchant-beer'
 import {
   FOCUS_PAN_ANIMATION_MS,
   FOCUS_PAN_DEBOUNCE_MS,
@@ -1518,9 +1537,9 @@ function BuiltTile({ occ }: { occ: BuiltIndustry }) {
   const ink = occ.flipped ? INDUSTRY_FILL[occ.type] : INDUSTRY_INK[occ.type]
   const statInk = occ.flipped ? '#4a3d29' : ink
   // On-tile resource markers: the fill carries the resource identity, a
-  // single 1px parchment keyline (shared with the merchant beer barrel)
-  // lifts every marker off its face and off the owner ribbon. Iron stays the
-  // shipped orange for now — its market/tile hue reconcile lands separately.
+  // single 1px parchment keyline lifts every marker off its face and off the
+  // owner ribbon. Iron stays the shipped orange for now — its market/tile hue
+  // reconcile lands separately.
   const cubes =
     occ.type === 'coal'
       ? { n: occ.coalCubesOnTile, c: '#1d1b18' }
@@ -1659,6 +1678,72 @@ function BuiltTile({ occ }: { occ: BuiltIndustry }) {
 
 /* ================= merchant plate ================= */
 
+/**
+ * The beer a merchant supplies, standing in its own socket below the tile.
+ *
+ * The socket is what makes the state readable: it is always drawn for a tile
+ * that buys goods, so a spent merchant leaves a dark well exactly where its
+ * siblings still show amber — absence is a mark, not a missing mark. And amber
+ * against the near-black well separates by luminance, where amber on the brass
+ * plate and brass glyphs shares their hue and washes out. Geometry, including
+ * the barrel's single uniform scale, lives in `merchant-beer.ts`.
+ */
+function MerchantBeerSocket({ hasBeer }: { hasBeer: boolean }) {
+  return (
+    <g
+      transform={`translate(${BEER_SOCKET_CX}, ${BEER_SOCKET_CY})`}
+      data-beer={hasBeer ? 'ready' : 'spent'}
+    >
+      <title>
+        {hasBeer
+          ? 'Beer barrel ready here — consumed when selling to this merchant'
+          : 'Beer already taken from this merchant — none left this era'}
+      </title>
+      <circle
+        r={BEER_SOCKET_R}
+        fill="#100e0c"
+        fillOpacity={hasBeer ? 0.95 : 0.7}
+        stroke="#c39538"
+        strokeOpacity={hasBeer ? 0.6 : 0.3}
+        strokeWidth="1.2"
+        strokeDasharray={hasBeer ? undefined : '3 3'}
+      />
+      {hasBeer && (
+        <g
+          transform={`translate(${-BARREL_W / 2}, ${-BARREL_H / 2}) scale(${BARREL_SCALE})`}
+        >
+          {/* No parchment keyline on the barrel: the socket already separates
+              the amber, and at phone scale a light stroke on a ~5px shape
+              washes the fill towards cream. */}
+          <path d={barrelBodyPath()} fill="#e8bc4f" />
+          {barrelHoops().map((h) => (
+            <line
+              key={h.y}
+              x1={h.x1}
+              y1={h.y}
+              x2={h.x2}
+              y2={h.y}
+              stroke="#8a6d34"
+              strokeWidth={HOOP_W}
+            />
+          ))}
+          {/* Rim only, no second fill: the cask has to stay ONE amber mass or
+              it breaks into two blobs once the board is phone-sized. */}
+          <ellipse
+            cx={HEAD_CX}
+            cy={HEAD_CY}
+            rx={HEAD_RX}
+            ry={HEAD_RY}
+            fill="none"
+            stroke="#8a6d34"
+            strokeWidth={HOOP_W}
+          />
+        </g>
+      )}
+    </g>
+  )
+}
+
 function MerchantPlate({
   cityId,
   entries,
@@ -1682,7 +1767,7 @@ function MerchantPlate({
   const pos = cityPos[cityId]
   const n = Math.max(entries.length, 2)
   const plateW = n * SLOT + (n - 1) * SLOT_GAP + PLATE_PAD * 2
-  const plateH = SLOT + PLATE_PAD * 2
+  const plateH = MERCHANT_PLATE_H
   const name = cities[cityId].name
   const closed = entries.length === 0
   const bonusLabel = (m: Merchant) =>
@@ -1696,7 +1781,7 @@ function MerchantPlate({
 
   return (
     <g
-      transform={`translate(${pos.x - plateW / 2}, ${pos.y - plateH / 2})`}
+      transform={`translate(${pos.x - plateW / 2}, ${pos.y + MERCHANT_PLATE_TOP})`}
       data-city={cityId}
       data-located={located || undefined}
       opacity={dimmed && !located ? 0.45 : closed && !located ? 0.3 : 1}
@@ -1760,25 +1845,21 @@ function MerchantPlate({
                 strokeDasharray={m ? undefined : '3 3'}
               />
               {m && m.industryIcons.length > 0 ? (
-                m.industryIcons.slice(0, 3).map((t, j) => {
-                  const count = Math.min(m.industryIcons.length, 3)
-                  const size = count === 1 ? 24 : 15
-                  const x =
-                    count === 1 ? (SLOT - size) / 2 : 4 + (j % 2) * (size + 4)
-                  const y =
-                    count === 1
-                      ? (SLOT - size) / 2
-                      : 3.5 + Math.floor(j / 2) * (size + 4)
-                  return (
+                m.industryIcons
+                  .slice(0, MAX_ICONS)
+                  .map((t, j) => ({
+                    t,
+                    cell: merchantIconCells(m.industryIcons.length)[j]!,
+                  }))
+                  .map(({ t, cell }, j) => (
                     <g
                       key={j}
-                      transform={`translate(${x}, ${y}) scale(${size / 24})`}
+                      transform={`translate(${cell.x}, ${cell.y}) scale(${cell.size / 24})`}
                       style={{ color: '#e6bd63' }}
                     >
                       <IndustryFragment type={t} />
                     </g>
-                  )
-                })
+                  ))
               ) : m ? (
                 // blank merchant tile — buys nothing
                 <text
@@ -1792,40 +1873,11 @@ function MerchantPlate({
                   ✕
                 </text>
               ) : null}
-              {/* beer barrel ready at this merchant — drawn as a barrel,
-                  not an anonymous dot (captain feedback 2026-07-14) */}
-              {m?.hasBeer && (
-                <g transform={`translate(${SLOT - 7}, 6.5)`}>
-                  <title>
-                    Beer barrel available — consumed when selling to this
-                    merchant
-                  </title>
-                  <ellipse
-                    cx="0"
-                    cy="0"
-                    rx="4.2"
-                    ry="5.2"
-                    fill="#e8bc4f"
-                    stroke="#f2e6c8"
-                    strokeWidth="1"
-                  />
-                  <line
-                    x1="-4.2"
-                    y1="-1.7"
-                    x2="4.2"
-                    y2="-1.7"
-                    stroke="#5c451a"
-                    strokeWidth="0.9"
-                  />
-                  <line
-                    x1="-4.2"
-                    y1="1.7"
-                    x2="4.2"
-                    y2="1.7"
-                    stroke="#5c451a"
-                    strokeWidth="0.9"
-                  />
-                </g>
+              {/* A merchant tile that buys anything owns a socket for the whole
+                  era; a blank tile never holds beer, so it gets no socket at
+                  all and can never be mistaken for a spent one. */}
+              {m && m.industryIcons.length > 0 && (
+                <MerchantBeerSocket hasBeer={m.hasBeer} />
               )}
             </g>
           )

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -18,6 +18,8 @@ import { GAME_ICONS } from '../gameicons-data'
 import { IndustryFragment } from '../icons'
 import { VIEW_H, VIEW_W, cityPos, linkKey } from './board-data'
 import {
+  LINK_ICON_DY,
+  LINK_ICON_R,
   MERCHANT_PLATE_H,
   MERCHANT_PLATE_TOP,
   PLATE_PAD,
@@ -29,16 +31,10 @@ import {
   routeCurve,
 } from './marker-anchor'
 import {
+  BARREL_ICON,
   BEER_SOCKET_CX,
   BEER_SOCKET_CY,
   BEER_SOCKET_R,
-  HEAD_CX,
-  HEAD_CY,
-  HEAD_RX,
-  HEAD_RY,
-  HOOP_W,
-  barrelBodyPath,
-  barrelHoops,
   barrelTransform,
   merchantIconCells,
 } from './merchant-beer'
@@ -1707,32 +1703,10 @@ function MerchantBeerSocket({ hasBeer }: { hasBeer: boolean }) {
       />
       {hasBeer && (
         <g transform={barrelTransform()}>
-          {/* No parchment keyline on the barrel: the socket already separates
-              the amber, and at phone scale a light stroke on a ~5px shape
-              washes the fill towards cream. */}
-          <path d={barrelBodyPath()} fill="#e8bc4f" />
-          {barrelHoops().map((h) => (
-            <line
-              key={h.y}
-              x1={h.x1}
-              y1={h.y}
-              x2={h.x2}
-              y2={h.y}
-              stroke="#8a6d34"
-              strokeWidth={HOOP_W}
-            />
-          ))}
-          {/* Rim only, no second fill: the cask has to stay ONE amber mass or
-              it breaks into two blobs once the board is phone-sized. */}
-          <ellipse
-            cx={HEAD_CX}
-            cy={HEAD_CY}
-            rx={HEAD_RX}
-            ry={HEAD_RY}
-            fill="none"
-            stroke="#8a6d34"
-            strokeWidth={HOOP_W}
-          />
+          {/* One flat amber fill, no keyline: the socket already separates the
+              amber, and a second tone on a ~5px shape breaks the cask into two
+              blobs instead of shading it. */}
+          <path d={BARREL_ICON.d} fill="#e8bc4f" />
         </g>
       )}
     </g>
@@ -1875,7 +1849,10 @@ function MerchantPlate({
 
       {/* the two •—• link-scoring icons printed at every merchant location
           (GAME_CONSTANTS.MERCHANT_LINK_ICONS — worth 2 to adjacent links) */}
-      <g transform={`translate(${plateW / 2 - 15}, -7)`} pointerEvents="none">
+      <g
+        transform={`translate(${plateW / 2 - 15}, ${-LINK_ICON_DY})`}
+        pointerEvents="none"
+      >
         <title>2 link-scoring icons at this merchant</title>
         {[0, 1].map((i) => (
           <g
@@ -1885,9 +1862,21 @@ function MerchantPlate({
             strokeWidth="1.5"
             strokeLinecap="round"
           >
-            <circle cx="0" cy="0" r="1.7" fill="#c39538" stroke="none" />
+            <circle
+              cx="0"
+              cy="0"
+              r={LINK_ICON_R}
+              fill="#c39538"
+              stroke="none"
+            />
             <path d="M1.7 0 H9.3" />
-            <circle cx="11" cy="0" r="1.7" fill="#c39538" stroke="none" />
+            <circle
+              cx="11"
+              cy="0"
+              r={LINK_ICON_R}
+              fill="#c39538"
+              stroke="none"
+            />
           </g>
         ))}
       </g>

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -29,9 +29,6 @@ import {
   routeCurve,
 } from './marker-anchor'
 import {
-  BARREL_H,
-  BARREL_SCALE,
-  BARREL_W,
   BEER_SOCKET_CX,
   BEER_SOCKET_CY,
   BEER_SOCKET_R,
@@ -40,9 +37,9 @@ import {
   HEAD_RX,
   HEAD_RY,
   HOOP_W,
-  MAX_ICONS,
   barrelBodyPath,
   barrelHoops,
+  barrelTransform,
   merchantIconCells,
 } from './merchant-beer'
 import {
@@ -1709,9 +1706,7 @@ function MerchantBeerSocket({ hasBeer }: { hasBeer: boolean }) {
         strokeDasharray={hasBeer ? undefined : '3 3'}
       />
       {hasBeer && (
-        <g
-          transform={`translate(${-BARREL_W / 2}, ${-BARREL_H / 2}) scale(${BARREL_SCALE})`}
-        >
+        <g transform={barrelTransform()}>
           {/* No parchment keyline on the barrel: the socket already separates
               the amber, and at phone scale a light stroke on a ~5px shape
               washes the fill towards cream. */}
@@ -1845,21 +1840,15 @@ function MerchantPlate({
                 strokeDasharray={m ? undefined : '3 3'}
               />
               {m && m.industryIcons.length > 0 ? (
-                m.industryIcons
-                  .slice(0, MAX_ICONS)
-                  .map((t, j) => ({
-                    t,
-                    cell: merchantIconCells(m.industryIcons.length)[j]!,
-                  }))
-                  .map(({ t, cell }, j) => (
-                    <g
-                      key={j}
-                      transform={`translate(${cell.x}, ${cell.y}) scale(${cell.size / 24})`}
-                      style={{ color: '#e6bd63' }}
-                    >
-                      <IndustryFragment type={t} />
-                    </g>
-                  ))
+                merchantIconCells(m.industryIcons.length).map((cell, j) => (
+                  <g
+                    key={j}
+                    transform={`translate(${cell.x}, ${cell.y}) scale(${cell.size / 24})`}
+                    style={{ color: '#e6bd63' }}
+                  >
+                    <IndustryFragment type={m.industryIcons[j]!} />
+                  </g>
+                ))
               ) : m ? (
                 // blank merchant tile — buys nothing
                 <text

--- a/src/components/board/marker-anchor.test.ts
+++ b/src/components/board/marker-anchor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { type CityId, connections } from '~/data/board'
-import { linkKey } from './board-data'
+import { type CityId, cities, connections } from '~/data/board'
+import { VIEW_H, VIEW_W, linkKey } from './board-data'
 import {
   type Rect,
   linkMarkerAnchor,
@@ -21,6 +21,32 @@ function occludedBy(from: CityId, to: CityId, at: { x: number; y: number }) {
   const box = markerBoxAt(at)
   return plateObstacles().filter((r) => overlaps(box, r)).length
 }
+
+describe('plate boxes', () => {
+  const ids = Object.keys(cities) as CityId[]
+
+  it('all sit inside the board viewBox', () => {
+    // Anything past the edges is simply not drawn, and merchant plates reach
+    // further from their city point than city plates do.
+    for (const id of ids) {
+      const r = plateRect(id)
+      expect(r.x, id).toBeGreaterThanOrEqual(0)
+      expect(r.y, id).toBeGreaterThanOrEqual(0)
+      expect(r.x + r.w, id).toBeLessThanOrEqual(VIEW_W)
+      expect(r.y + r.h, id).toBeLessThanOrEqual(VIEW_H)
+    }
+  })
+
+  it('never overlap each other', () => {
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const a = plateRect(ids[i]!)
+        const b = plateRect(ids[j]!)
+        expect(overlaps(a, b), `${ids[i]} / ${ids[j]}`).toBe(false)
+      }
+    }
+  })
+})
 
 // The bug the captain hit: the boat on the Stoke—Stone canal sat under the
 // Stoke plate and its name ribbon.

--- a/src/components/board/marker-anchor.test.ts
+++ b/src/components/board/marker-anchor.test.ts
@@ -53,8 +53,27 @@ describe('link marker anchors', () => {
     // the marker layer painting after the plates instead.
     expect(blocked.map((c) => linkKey(c.from, c.to))).toStrictEqual([
       'stoke|stone',
+      'worcester|gloucester',
       'birmingham|redditch',
     ])
+  })
+
+  it('leaves a blocked marker mostly in the open', () => {
+    // A route with no fully clear spot must still be a marker on the board
+    // rather than a marker on a plate, so bound the residual overlap.
+    for (const conn of connections) {
+      const box = markerBoxAt(linkMarkerAnchor(conn.from, conn.to))
+      let covered = 0
+      for (const r of plateObstacles()) {
+        const ox = Math.min(box.x + box.w, r.x + r.w) - Math.max(box.x, r.x)
+        const oy = Math.min(box.y + box.h, r.y + r.h) - Math.max(box.y, r.y)
+        if (ox > 0 && oy > 0) covered += ox * oy
+      }
+      expect(
+        covered / (box.w * box.h),
+        linkKey(conn.from, conn.to),
+      ).toBeLessThan(0.4)
+    }
   })
 
   it('keeps every anchor on its own route', () => {

--- a/src/components/board/marker-anchor.test.ts
+++ b/src/components/board/marker-anchor.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import { type CityId, cities, connections } from '~/data/board'
 import { VIEW_H, VIEW_W, linkKey } from './board-data'
 import {
+  LINK_ICON_DY,
+  LINK_ICON_R,
   type Rect,
   linkMarkerAnchor,
   markerBoxAt,
@@ -35,6 +37,16 @@ describe('plate boxes', () => {
       expect(r.y, at).toBeGreaterThanOrEqual(0)
       expect(r.x + r.w, at).toBeLessThanOrEqual(VIEW_W)
       expect(r.y + r.h, at).toBeLessThanOrEqual(VIEW_H)
+    }
+  })
+
+  it('leave room above for the link-icon pair', () => {
+    // The pair straddles the top edge, so a plate that reaches too far up puts
+    // it outside the viewBox. This is what caps a merchant plate's height.
+    for (const id of ids) {
+      expect(plateRect(id).y, id).toBeGreaterThanOrEqual(
+        LINK_ICON_DY + LINK_ICON_R,
+      )
     }
   })
 

--- a/src/components/board/marker-anchor.test.ts
+++ b/src/components/board/marker-anchor.test.ts
@@ -25,15 +25,16 @@ function occludedBy(from: CityId, to: CityId, at: { x: number; y: number }) {
 describe('plate boxes', () => {
   const ids = Object.keys(cities) as CityId[]
 
-  it('all sit inside the board viewBox', () => {
-    // Anything past the edges is simply not drawn, and merchant plates reach
-    // further from their city point than city plates do.
-    for (const id of ids) {
-      const r = plateRect(id)
-      expect(r.x, id).toBeGreaterThanOrEqual(0)
-      expect(r.y, id).toBeGreaterThanOrEqual(0)
-      expect(r.x + r.w, id).toBeLessThanOrEqual(VIEW_W)
-      expect(r.y + r.h, id).toBeLessThanOrEqual(VIEW_H)
+  it('every plate and name ribbon sits inside the board viewBox', () => {
+    // A zoomed-in player sees exactly the viewBox, so anything outside it is
+    // reachable only by the letterbox slack at fit zoom. Merchant plates reach
+    // further from their city point than city plates do, hence the check.
+    for (const r of plateObstacles()) {
+      const at = `${r.x},${r.y}`
+      expect(r.x, at).toBeGreaterThanOrEqual(0)
+      expect(r.y, at).toBeGreaterThanOrEqual(0)
+      expect(r.x + r.w, at).toBeLessThanOrEqual(VIEW_W)
+      expect(r.y + r.h, at).toBeLessThanOrEqual(VIEW_H)
     }
   })
 
@@ -95,10 +96,11 @@ describe('link marker anchors', () => {
         const oy = Math.min(box.y + box.h, r.y + r.h) - Math.max(box.y, r.y)
         if (ox > 0 && oy > 0) covered += ox * oy
       }
+      // Stoke—Stone is the worst case at 0.387; the rest are under 0.06.
       expect(
         covered / (box.w * box.h),
         linkKey(conn.from, conn.to),
-      ).toBeLessThan(0.4)
+      ).toBeLessThan(0.45)
     }
   })
 

--- a/src/components/board/marker-anchor.ts
+++ b/src/components/board/marker-anchor.ts
@@ -27,7 +27,7 @@ export const PLATE_PAD = 6
  * obstacle box and `merchant-beer.ts` divides it into the socket and its
  * clearance, so the two cannot drift.
  */
-export const MERCHANT_BEER_ROW_H = 34
+export const MERCHANT_BEER_ROW_H = 36
 
 /** Height of any merchant plate: tile row plus beer-socket row. */
 export const MERCHANT_PLATE_H = SLOT + MERCHANT_BEER_ROW_H + PLATE_PAD * 2
@@ -40,6 +40,14 @@ export const MERCHANT_PLATE_H = SLOT + MERCHANT_BEER_ROW_H + PLATE_PAD * 2
  * merchant plates are anchored this way; city plates centre on their point.
  */
 export const MERCHANT_PLATE_TOP = (SLOT + PLATE_PAD * 2) / 2 - MERCHANT_PLATE_H
+
+/**
+ * The link-scoring icon pair straddles a plate's top edge, making it the topmost
+ * thing a plate draws — which caps how far up a plate may reach. Warrington sits
+ * nearest the board's top edge, so this is what bounds `MERCHANT_BEER_ROW_H`.
+ */
+export const LINK_ICON_DY = 7
+export const LINK_ICON_R = 1.7
 
 /** Plates whose slots stack into a grid instead of one row. */
 export const PLATE_GRIDS: Partial<Record<CityId, Array<[number, number]>>> = {

--- a/src/components/board/marker-anchor.ts
+++ b/src/components/board/marker-anchor.ts
@@ -21,6 +21,26 @@ export const SLOT = 52
 export const SLOT_GAP = 4
 export const PLATE_PAD = 6
 
+/**
+ * Height of the beer-socket row a merchant plate carries under its tile row.
+ * Lives here with the other plate metrics — `plateRect` needs it to size the
+ * obstacle box and `merchant-beer.ts` divides it into the socket and its
+ * clearance, so the two cannot drift.
+ */
+export const MERCHANT_BEER_ROW_H = 34
+
+/** Height of any merchant plate: tile row plus beer-socket row. */
+export const MERCHANT_PLATE_H = SLOT + MERCHANT_BEER_ROW_H + PLATE_PAD * 2
+
+/**
+ * A merchant plate's top edge relative to its city point. The plate hangs its
+ * BOTTOM edge half a tile row below the point and reaches upward for the rest,
+ * so the extra height lands in empty board: the name ribbon keeps its baseline
+ * and the routes arriving from below keep the gap a link marker needs. Only
+ * merchant plates are anchored this way; city plates centre on their point.
+ */
+export const MERCHANT_PLATE_TOP = (SLOT + PLATE_PAD * 2) / 2 - MERCHANT_PLATE_H
+
 /** Plates whose slots stack into a grid instead of one row. */
 export const PLATE_GRIDS: Partial<Record<CityId, Array<[number, number]>>> = {
   birmingham: [
@@ -79,7 +99,7 @@ export function plateRect(cityId: CityId): Rect {
   let h: number
   if (cities[cityId].type === 'merchant') {
     w = 2 * SLOT + SLOT_GAP + PLATE_PAD * 2
-    h = SLOT + PLATE_PAD * 2
+    h = MERCHANT_PLATE_H
   } else {
     const grid = plateGrid(cityId, (cityIndustrySlots[cityId] ?? []).length)
     const cols = Math.max(...grid.map(([c]) => c)) + 1
@@ -87,7 +107,11 @@ export function plateRect(cityId: CityId): Rect {
     w = cols * SLOT + (cols - 1) * SLOT_GAP + PLATE_PAD * 2
     h = rows * SLOT + (rows - 1) * SLOT_GAP + PLATE_PAD * 2
   }
-  return { x: pos.x - w / 2, y: pos.y - h / 2, w, h }
+  const y =
+    cities[cityId].type === 'merchant'
+      ? pos.y + MERCHANT_PLATE_TOP
+      : pos.y - h / 2
+  return { x: pos.x - w / 2, y, w, h }
 }
 
 // The name ribbon hangs under every plate (baseline at plateH + 13) and is

--- a/src/components/board/merchant-beer.test.ts
+++ b/src/components/board/merchant-beer.test.ts
@@ -6,32 +6,21 @@ import {
   SLOT,
 } from './marker-anchor'
 import {
-  BARREL_ART_H,
-  BARREL_ART_W,
   BARREL_H,
+  BARREL_ICON,
+  BARREL_INK,
   BARREL_SCALE,
   BARREL_W,
-  BASE_CY,
-  BASE_RX,
-  BASE_RY,
   BEER_ROW_GAP,
   BEER_SOCKET_CX,
   BEER_SOCKET_CY,
   BEER_SOCKET_D,
   BEER_SOCKET_R,
-  HEAD_CX,
-  HEAD_CY,
-  HEAD_RX,
-  HEAD_RY,
-  HOOP_INSET,
   ICON_SIZE_GRID,
   ICON_SIZE_SINGLE,
   MAX_ICONS,
-  barrelBodyPath,
-  barrelHoops,
   barrelTransform,
   merchantIconCells,
-  silhouetteEdge,
 } from './merchant-beer'
 
 /**
@@ -65,70 +54,53 @@ describe('beer socket', () => {
   it('never crosses into the neighbouring slot', () => {
     expect(BEER_SOCKET_D).toBeLessThanOrEqual(SLOT)
   })
+
+  it('shows air above itself at both render scales', () => {
+    // A gap only reads once it is worth about a screen pixel and a half; on a
+    // phone a couple of board units is under half of one.
+    expect(BEER_ROW_GAP * PHONE_SCALE).toBeGreaterThan(1.4)
+    expect(BEER_ROW_GAP * DESKTOP_SCALE).toBeGreaterThan(3)
+  })
 })
 
 describe('barrel', () => {
+  it('is one of the vendored game-icons glyphs', () => {
+    expect(BARREL_ICON.name).toBe('barrel')
+    expect(BARREL_ICON.author).toBe('Delapouite')
+    expect(BARREL_ICON.d.length).toBeGreaterThan(100)
+  })
+
   it('is placed with a single scale factor, never one per axis', () => {
     // The transform string is the thing that could distort the art, so assert
     // its shape: one scale argument, no comma.
     const t = barrelTransform()
-    expect(t).toMatch(/^translate\([^)]*\) scale\([\d.]+\)$/)
+    expect(t).toMatch(/^translate\([^)]*\) scale\([\d.]+\) translate\([^)]*\)$/)
     expect(t).toContain(`scale(${BARREL_SCALE})`)
-    expect(BARREL_W / BARREL_H).toBeCloseTo(BARREL_ART_W / BARREL_ART_H, 10)
+    expect(BARREL_W / BARREL_H).toBeCloseTo(BARREL_INK.w / BARREL_INK.h, 10)
   })
 
-  it('is authored taller than it is wide, like a cask', () => {
-    expect(BARREL_ART_H).toBeGreaterThan(BARREL_ART_W)
-    expect(BARREL_ART_W / BARREL_ART_H).toBeGreaterThan(0.6)
+  it('reads as a cask: its ink is taller than it is wide', () => {
+    expect(BARREL_INK.h).toBeGreaterThan(BARREL_INK.w)
+    expect(BARREL_INK.w / BARREL_INK.h).toBeGreaterThan(0.6)
+  })
+
+  it('is centred on the socket', () => {
+    const t = barrelTransform()
+    expect(t.startsWith(`translate(${-BARREL_W / 2}, ${-BARREL_H / 2})`)).toBe(
+      true,
+    )
+    expect(t.endsWith(`translate(${-BARREL_INK.x}, ${-BARREL_INK.y})`)).toBe(
+      true,
+    )
   })
 
   it('keeps a legible bright mass at phone scale', () => {
     // A socket of its own puts the whole barrel on a clear patch of plate, so
     // both axes survive the reduction rather than just the longer one.
     expect(BARREL_W * PHONE_SCALE).toBeGreaterThan(4.5)
-    expect(BARREL_H * PHONE_SCALE).toBeGreaterThan(5.5)
+    expect(BARREL_H * PHONE_SCALE).toBeGreaterThan(5)
     // And at desk scale there is room for the cask shape to read.
-    expect(BARREL_H * DESKTOP_SCALE).toBeGreaterThan(12)
-  })
-
-  it('draws a closed silhouette springing from the head', () => {
-    const d = barrelBodyPath()
-    expect(d.startsWith(`M${HEAD_CX - HEAD_RX} ${HEAD_CY}`)).toBe(true)
-    expect(d.endsWith('Z')).toBe(true)
-  })
-
-  it('tapers: both heads are narrower than the bilge', () => {
-    expect(HEAD_RX).toBeLessThan(BARREL_ART_W / 2)
-    expect(BASE_RX).toBeLessThan(BARREL_ART_W / 2)
-    const bilge = silhouetteEdge((HEAD_CY + BASE_CY) / 2)
-    expect(bilge.right - bilge.left).toBeGreaterThan(HEAD_RX * 2 * 1.3)
-  })
-
-  it('keeps both heads inside the art box', () => {
-    expect(HEAD_CY - HEAD_RY).toBeGreaterThanOrEqual(0)
-    expect(BASE_CY + BASE_RY).toBeLessThanOrEqual(BARREL_ART_H)
-    expect(HEAD_CY + HEAD_RY).toBeLessThan(BASE_CY - BASE_RY)
-  })
-
-  it('keeps the silhouette inside the art box at every height', () => {
-    for (let y = HEAD_CY; y <= BASE_CY; y += 0.5) {
-      const { left, right } = silhouetteEdge(y)
-      expect(left).toBeGreaterThanOrEqual(0)
-      expect(right).toBeLessThanOrEqual(BARREL_ART_W)
-    }
-  })
-
-  it('keeps both hoops inside the silhouette at their own height', () => {
-    const hoops = barrelHoops()
-    expect(hoops).toHaveLength(2)
-    for (const h of hoops) {
-      const { left, right } = silhouetteEdge(h.y)
-      expect(h.x1).toBeCloseTo(left + HOOP_INSET, 6)
-      expect(h.x2).toBeCloseTo(right - HOOP_INSET, 6)
-      expect(h.y).toBeGreaterThan(HEAD_CY + HEAD_RY)
-      expect(h.y).toBeLessThan(BASE_CY - BASE_RY)
-    }
-    expect(hoops[0]!.y).toBeLessThan(hoops[1]!.y)
+    expect(BARREL_H * DESKTOP_SCALE).toBeGreaterThan(11)
   })
 })
 

--- a/src/components/board/merchant-beer.test.ts
+++ b/src/components/board/merchant-beer.test.ts
@@ -9,12 +9,15 @@ import {
   BARREL_H,
   BARREL_ICON,
   BARREL_INK,
+  BARREL_INK_R,
+  BARREL_RIM_CLEARANCE,
   BARREL_SCALE,
   BARREL_W,
   BEER_ROW_GAP,
   BEER_SOCKET_CX,
   BEER_SOCKET_CY,
   BEER_SOCKET_D,
+  BEER_SOCKET_INNER_R,
   BEER_SOCKET_R,
   ICON_SIZE_GRID,
   ICON_SIZE_SINGLE,
@@ -46,9 +49,16 @@ describe('beer socket', () => {
     )
   })
 
-  it('holds the barrel clear of its rim', () => {
-    expect(BARREL_W / 2).toBeLessThan(BEER_SOCKET_R)
-    expect(BARREL_H / 2).toBeLessThan(BEER_SOCKET_R)
+  it('holds the whole barrel silhouette clear of its rim', () => {
+    // The socket is ROUND, so fitting the cask's width and height inside the rim
+    // proves nothing: its corners reach a fifth further out than either axis and
+    // that is where it overran. Measure the silhouette's own radius.
+    expect(BARREL_INK_R * BARREL_SCALE).toBeLessThan(BEER_SOCKET_INNER_R)
+    // And leave enough dark well showing that the containment is obvious rather
+    // than tangent.
+    expect(BARREL_RIM_CLEARANCE).toBeGreaterThan(1.8)
+    expect(BARREL_W / 2).toBeLessThan(BEER_SOCKET_INNER_R)
+    expect(BARREL_H / 2).toBeLessThan(BEER_SOCKET_INNER_R)
   })
 
   it('never crosses into the neighbouring slot', () => {
@@ -95,12 +105,17 @@ describe('barrel', () => {
   })
 
   it('keeps a legible bright mass at phone scale', () => {
-    // A socket of its own puts the whole barrel on a clear patch of plate, so
-    // both axes survive the reduction rather than just the longer one.
-    expect(BARREL_W * PHONE_SCALE).toBeGreaterThan(4.5)
-    expect(BARREL_H * PHONE_SCALE).toBeGreaterThan(5)
-    // And at desk scale there is room for the cask shape to read.
-    expect(BARREL_H * DESKTOP_SCALE).toBeGreaterThan(11)
+    // At 390px the socket is barely 6px across, so nothing cask-shaped can read
+    // there at any size that fits inside it — what carries is the amber mass
+    // against the dark well. Hold that mass above the point where antialiasing
+    // dissolves it into the rim.
+    expect(BARREL_W * PHONE_SCALE).toBeGreaterThan(3.5)
+    expect(BARREL_H * PHONE_SCALE).toBeGreaterThan(4.5)
+    // At desk scale the cask shape itself has room to read.
+    expect(BARREL_H * DESKTOP_SCALE).toBeGreaterThan(10)
+    // Whatever the size, the barrel is the majority of the well it stands in —
+    // a token rattling around inside the rim reads as debris, not as stock.
+    expect(BARREL_H / BEER_SOCKET_D).toBeGreaterThan(0.65)
   })
 })
 

--- a/src/components/board/merchant-beer.test.ts
+++ b/src/components/board/merchant-beer.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MERCHANT_BEER_ROW_H,
+  MERCHANT_PLATE_H,
+  PLATE_PAD,
+  SLOT,
+} from './marker-anchor'
+import {
+  BARREL_ART_H,
+  BARREL_ART_W,
+  BARREL_H,
+  BARREL_SCALE,
+  BARREL_W,
+  BASE_CY,
+  BASE_RX,
+  BASE_RY,
+  BEER_ROW_GAP,
+  BEER_SOCKET_CX,
+  BEER_SOCKET_CY,
+  BEER_SOCKET_D,
+  BEER_SOCKET_R,
+  HEAD_CX,
+  HEAD_CY,
+  HEAD_RX,
+  HEAD_RY,
+  HOOP_W,
+  ICON_SIZE_GRID,
+  ICON_SIZE_SINGLE,
+  MAX_ICONS,
+  barrelBodyPath,
+  barrelHoops,
+  merchantIconCells,
+} from './merchant-beer'
+
+/**
+ * The board is a 1600×1150 viewBox letterboxed into its frame, which measures
+ * out at these scales — so a marker's board units convert straight to the CSS
+ * pixels a player actually looks at.
+ */
+const PHONE_SCALE = 0.221
+const DESKTOP_SCALE = 0.489
+
+describe('beer socket', () => {
+  it('sits in its own row under the tile, not inside it', () => {
+    expect(BEER_SOCKET_CY - BEER_SOCKET_R).toBeGreaterThanOrEqual(SLOT)
+    expect(BEER_SOCKET_CX).toBe(SLOT / 2)
+  })
+
+  it('fits the row the merchant plate reserves for it', () => {
+    expect(BEER_SOCKET_D + BEER_ROW_GAP).toBe(MERCHANT_BEER_ROW_H)
+    // Slot-local y, so both of the plate's pads count.
+    expect(PLATE_PAD + BEER_SOCKET_CY + BEER_SOCKET_R + PLATE_PAD).toBe(
+      MERCHANT_PLATE_H,
+    )
+  })
+
+  it('holds the barrel clear of its rim', () => {
+    expect(BARREL_W / 2).toBeLessThan(BEER_SOCKET_R)
+    expect(BARREL_H / 2).toBeLessThan(BEER_SOCKET_R)
+  })
+
+  it('never crosses into the neighbouring slot', () => {
+    expect(BEER_SOCKET_D).toBeLessThanOrEqual(SLOT)
+  })
+})
+
+describe('barrel', () => {
+  it('is only ever scaled uniformly', () => {
+    // One scalar drives both axes, so the art can never be stretched to fit.
+    expect(BARREL_W / BARREL_H).toBeCloseTo(BARREL_ART_W / BARREL_ART_H, 10)
+    expect(BARREL_SCALE).toBeCloseTo(BARREL_W / BARREL_ART_W, 10)
+    expect(BARREL_SCALE).toBeCloseTo(BARREL_H / BARREL_ART_H, 10)
+  })
+
+  it('is authored taller than it is wide, like a cask', () => {
+    expect(BARREL_ART_H).toBeGreaterThan(BARREL_ART_W)
+    expect(BARREL_ART_W / BARREL_ART_H).toBeGreaterThan(0.6)
+  })
+
+  it('keeps a legible bright mass at phone scale', () => {
+    // The socket puts the whole barrel on its own patch of plate, so both axes
+    // survive: a marker squeezed into the glyph grid gave ~2px each way.
+    expect(BARREL_W * PHONE_SCALE).toBeGreaterThan(4.5)
+    expect(BARREL_H * PHONE_SCALE).toBeGreaterThan(5.5)
+    // And at desk scale there is room for the cask detail to read.
+    expect(BARREL_H * DESKTOP_SCALE).toBeGreaterThan(12)
+  })
+
+  it('draws a closed silhouette springing from the head', () => {
+    const d = barrelBodyPath()
+    expect(d.startsWith(`M${HEAD_CX - HEAD_RX} ${HEAD_CY}`)).toBe(true)
+    expect(d.endsWith('Z')).toBe(true)
+  })
+
+  it('tapers: both heads are narrower than the bilge', () => {
+    expect(HEAD_RX).toBeLessThan(BARREL_ART_W / 2)
+    expect(BASE_RX).toBeLessThan(BARREL_ART_W / 2)
+    expect(HEAD_RX / (BARREL_ART_W / 2)).toBeLessThan(0.75)
+  })
+
+  it('keeps both heads inside the art box', () => {
+    expect(HEAD_CY - HEAD_RY).toBeGreaterThanOrEqual(0)
+    expect(BASE_CY + BASE_RY).toBeLessThanOrEqual(BARREL_ART_H)
+    expect(HEAD_CY + HEAD_RY).toBeLessThan(BASE_CY - BASE_RY)
+  })
+
+  it('keeps both hoops inside the silhouette', () => {
+    const hoops = barrelHoops()
+    expect(hoops).toHaveLength(2)
+    for (const h of hoops) {
+      expect(h.x1).toBeGreaterThan(0)
+      expect(h.x2).toBeLessThan(BARREL_ART_W)
+      expect(h.y).toBeGreaterThan(HEAD_CY + HEAD_RY)
+      expect(h.y).toBeLessThan(BASE_CY - BASE_RY)
+      expect(HOOP_W).toBeLessThan(BARREL_ART_H / 20)
+    }
+    expect(hoops[0]!.y).toBeLessThan(hoops[1]!.y)
+  })
+})
+
+describe('merchantIconCells', () => {
+  it('draws nothing for a blank merchant tile', () => {
+    expect(merchantIconCells(0)).toEqual([])
+  })
+
+  it('keeps the shipped glyph sizes', () => {
+    expect(merchantIconCells(1)[0]?.size).toBe(ICON_SIZE_SINGLE)
+    for (const n of [2, 3]) {
+      for (const cell of merchantIconCells(n)) {
+        expect(cell.size).toBe(ICON_SIZE_GRID)
+      }
+    }
+  })
+
+  it('uses the whole tile, which the socket no longer shares', () => {
+    for (const n of [1, 2, 3]) {
+      for (const cell of merchantIconCells(n)) {
+        expect(cell.x).toBeGreaterThanOrEqual(0)
+        expect(cell.y).toBeGreaterThanOrEqual(0)
+        expect(cell.x + cell.size).toBeLessThanOrEqual(SLOT)
+        expect(cell.y + cell.size).toBeLessThanOrEqual(SLOT)
+      }
+    }
+  })
+
+  it('centres the glyph block in the tile', () => {
+    for (const n of [1, 2, 3]) {
+      const cells = merchantIconCells(n)
+      const top = Math.min(...cells.map((c) => c.y))
+      const bottom = Math.max(...cells.map((c) => c.y + c.size))
+      expect(top).toBeCloseTo(SLOT - bottom, 6)
+    }
+  })
+
+  it('never overlaps two glyphs', () => {
+    for (const n of [2, 3]) {
+      const cells = merchantIconCells(n)
+      for (let i = 0; i < cells.length; i++) {
+        for (let j = i + 1; j < cells.length; j++) {
+          const a = cells[i]!
+          const b = cells[j]!
+          const apart =
+            a.x + a.size <= b.x ||
+            b.x + b.size <= a.x ||
+            a.y + a.size <= b.y ||
+            b.y + b.size <= a.y
+          expect(apart).toBe(true)
+        }
+      }
+    }
+  })
+
+  it('puts an odd third glyph under the first', () => {
+    const cells = merchantIconCells(3)
+    expect(cells[2]?.x).toBe(cells[0]?.x)
+    expect(cells[2]?.y).toBeGreaterThan(cells[0]!.y)
+  })
+
+  it('caps at the printed icon count', () => {
+    expect(merchantIconCells(9)).toHaveLength(MAX_ICONS)
+  })
+})

--- a/src/components/board/merchant-beer.test.ts
+++ b/src/components/board/merchant-beer.test.ts
@@ -23,19 +23,22 @@ import {
   HEAD_CY,
   HEAD_RX,
   HEAD_RY,
-  HOOP_W,
+  HOOP_INSET,
   ICON_SIZE_GRID,
   ICON_SIZE_SINGLE,
   MAX_ICONS,
   barrelBodyPath,
   barrelHoops,
+  barrelTransform,
   merchantIconCells,
+  silhouetteEdge,
 } from './merchant-beer'
 
 /**
  * The board is a 1600×1150 viewBox letterboxed into its frame, which measures
  * out at these scales — so a marker's board units convert straight to the CSS
- * pixels a player actually looks at.
+ * pixels a player looks at. `e2e/merchant-beer.spec.ts` reads the live
+ * `getScreenCTM` at both widths and fails if the frame drifts off them.
  */
 const PHONE_SCALE = 0.221
 const DESKTOP_SCALE = 0.489
@@ -65,11 +68,13 @@ describe('beer socket', () => {
 })
 
 describe('barrel', () => {
-  it('is only ever scaled uniformly', () => {
-    // One scalar drives both axes, so the art can never be stretched to fit.
+  it('is placed with a single scale factor, never one per axis', () => {
+    // The transform string is the thing that could distort the art, so assert
+    // its shape: one scale argument, no comma.
+    const t = barrelTransform()
+    expect(t).toMatch(/^translate\([^)]*\) scale\([\d.]+\)$/)
+    expect(t).toContain(`scale(${BARREL_SCALE})`)
     expect(BARREL_W / BARREL_H).toBeCloseTo(BARREL_ART_W / BARREL_ART_H, 10)
-    expect(BARREL_SCALE).toBeCloseTo(BARREL_W / BARREL_ART_W, 10)
-    expect(BARREL_SCALE).toBeCloseTo(BARREL_H / BARREL_ART_H, 10)
   })
 
   it('is authored taller than it is wide, like a cask', () => {
@@ -78,11 +83,11 @@ describe('barrel', () => {
   })
 
   it('keeps a legible bright mass at phone scale', () => {
-    // The socket puts the whole barrel on its own patch of plate, so both axes
-    // survive: a marker squeezed into the glyph grid gave ~2px each way.
+    // A socket of its own puts the whole barrel on a clear patch of plate, so
+    // both axes survive the reduction rather than just the longer one.
     expect(BARREL_W * PHONE_SCALE).toBeGreaterThan(4.5)
     expect(BARREL_H * PHONE_SCALE).toBeGreaterThan(5.5)
-    // And at desk scale there is room for the cask detail to read.
+    // And at desk scale there is room for the cask shape to read.
     expect(BARREL_H * DESKTOP_SCALE).toBeGreaterThan(12)
   })
 
@@ -95,7 +100,8 @@ describe('barrel', () => {
   it('tapers: both heads are narrower than the bilge', () => {
     expect(HEAD_RX).toBeLessThan(BARREL_ART_W / 2)
     expect(BASE_RX).toBeLessThan(BARREL_ART_W / 2)
-    expect(HEAD_RX / (BARREL_ART_W / 2)).toBeLessThan(0.75)
+    const bilge = silhouetteEdge((HEAD_CY + BASE_CY) / 2)
+    expect(bilge.right - bilge.left).toBeGreaterThan(HEAD_RX * 2 * 1.3)
   })
 
   it('keeps both heads inside the art box', () => {
@@ -104,15 +110,23 @@ describe('barrel', () => {
     expect(HEAD_CY + HEAD_RY).toBeLessThan(BASE_CY - BASE_RY)
   })
 
-  it('keeps both hoops inside the silhouette', () => {
+  it('keeps the silhouette inside the art box at every height', () => {
+    for (let y = HEAD_CY; y <= BASE_CY; y += 0.5) {
+      const { left, right } = silhouetteEdge(y)
+      expect(left).toBeGreaterThanOrEqual(0)
+      expect(right).toBeLessThanOrEqual(BARREL_ART_W)
+    }
+  })
+
+  it('keeps both hoops inside the silhouette at their own height', () => {
     const hoops = barrelHoops()
     expect(hoops).toHaveLength(2)
     for (const h of hoops) {
-      expect(h.x1).toBeGreaterThan(0)
-      expect(h.x2).toBeLessThan(BARREL_ART_W)
+      const { left, right } = silhouetteEdge(h.y)
+      expect(h.x1).toBeCloseTo(left + HOOP_INSET, 6)
+      expect(h.x2).toBeCloseTo(right - HOOP_INSET, 6)
       expect(h.y).toBeGreaterThan(HEAD_CY + HEAD_RY)
       expect(h.y).toBeLessThan(BASE_CY - BASE_RY)
-      expect(HOOP_W).toBeLessThan(BARREL_ART_H / 20)
     }
     expect(hoops[0]!.y).toBeLessThan(hoops[1]!.y)
   })
@@ -123,7 +137,7 @@ describe('merchantIconCells', () => {
     expect(merchantIconCells(0)).toEqual([])
   })
 
-  it('keeps the shipped glyph sizes', () => {
+  it('draws a lone glyph large and shares a grid from two up', () => {
     expect(merchantIconCells(1)[0]?.size).toBe(ICON_SIZE_SINGLE)
     for (const n of [2, 3]) {
       for (const cell of merchantIconCells(n)) {
@@ -132,7 +146,7 @@ describe('merchantIconCells', () => {
     }
   })
 
-  it('uses the whole tile, which the socket no longer shares', () => {
+  it('uses the whole tile, which is the socket-free area', () => {
     for (const n of [1, 2, 3]) {
       for (const cell of merchantIconCells(n)) {
         expect(cell.x).toBeGreaterThanOrEqual(0)

--- a/src/components/board/merchant-beer.ts
+++ b/src/components/board/merchant-beer.ts
@@ -24,6 +24,10 @@ export const BEER_ROW_GAP = 7
 /** Diameter of the recessed socket a merchant's barrel rests in. */
 export const BEER_SOCKET_D = MERCHANT_BEER_ROW_H - BEER_ROW_GAP
 export const BEER_SOCKET_R = BEER_SOCKET_D / 2
+/** Width of the socket's brass rim, centred on `BEER_SOCKET_R`. */
+export const BEER_SOCKET_STROKE = 1.2
+/** Inside face of that rim — the circle the barrel has to stay within. */
+export const BEER_SOCKET_INNER_R = BEER_SOCKET_R - BEER_SOCKET_STROKE / 2
 /** Socket centre in slot-local units — under the middle of its own tile. */
 export const BEER_SOCKET_CX = SLOT / 2
 export const BEER_SOCKET_CY = SLOT + BEER_ROW_GAP + BEER_SOCKET_R
@@ -88,11 +92,28 @@ export const BARREL_ICON = GAME_ICONS.brewery
  */
 export const BARREL_INK = { x: 73, y: 41, w: 366.02, h: 433.94 }
 
-/** Height of the placed barrel, in board units. */
-export const BARREL_H = 25
+/**
+ * Furthest the glyph's ink reaches from the centre of those bounds, in the same
+ * 512-unit space. This — not the ink's width or height — is what has to fit a
+ * ROUND socket: the cask's silhouette very nearly fills its box, so its corners
+ * sit a fifth further out than either axis and an axis-only fit lets them
+ * overrun the rim. Sampled off the live path, and re-measured by
+ * `e2e/merchant-beer.spec`.
+ */
+export const BARREL_INK_R = 245.06
+
+/**
+ * Height of the placed barrel, in board units: as large as the socket can hold
+ * with a ring of well still showing all the way round. Sized up from here the
+ * silhouette eats the rim and the well stops reading as one.
+ */
+export const BARREL_H = 21
 /** The ONLY scale factor applied to the art, and it drives both axes. */
 export const BARREL_SCALE = BARREL_H / BARREL_INK.h
 export const BARREL_W = BARREL_INK.w * BARREL_SCALE
+/** Board units of dark well left between the cask's silhouette and the rim. */
+export const BARREL_RIM_CLEARANCE =
+  BEER_SOCKET_INNER_R - BARREL_INK_R * BARREL_SCALE
 
 /**
  * Places the glyph's ink centred on the socket. One `scale` argument by

--- a/src/components/board/merchant-beer.ts
+++ b/src/components/board/merchant-beer.ts
@@ -1,3 +1,4 @@
+import { GAME_ICONS } from '../gameicons-data'
 import { MERCHANT_BEER_ROW_H, SLOT } from './marker-anchor'
 
 /**
@@ -9,13 +10,17 @@ import { MERCHANT_BEER_ROW_H, SLOT } from './marker-anchor'
  * inside its icon area — the arrangement the printed board uses. That is what
  * buys the barrel its size: sharing the tile it would compete with the glyph
  * grid for the same 52 units and could only be made legible by being reshaped,
- * and a barrel is only recognisable at its natural proportions. So the art is
- * authored once at cask proportions (`BARREL_ART_W`×`BARREL_ART_H`) and placed
- * by `barrelTransform`, which scales both axes by one scalar.
+ * and a barrel is only recognisable at its natural proportions. The art is the
+ * project's own vendored `brewery` glyph, placed by `barrelTransform` at one
+ * scale factor for both axes.
  */
 
-/** Air between the tile row and the beer socket below it. */
-export const BEER_ROW_GAP = 2
+/**
+ * Air between the tile row and the beer socket below it. Sized to read as a gap
+ * rather than a hairline at BOTH render scales — a couple of board units is
+ * under half a screen pixel on a phone, which is no gap at all.
+ */
+export const BEER_ROW_GAP = 7
 /** Diameter of the recessed socket a merchant's barrel rests in. */
 export const BEER_SOCKET_D = MERCHANT_BEER_ROW_H - BEER_ROW_GAP
 export const BEER_SOCKET_R = BEER_SOCKET_D / 2
@@ -66,117 +71,37 @@ export function merchantIconCells(count: number): IconCell[] {
 /* ---------------- the barrel ---------------- */
 
 /**
- * The barrel's own coordinate box, at cask proportions: taller than its bilge is
- * wide, with heads narrower than the bilge. That taper is the whole read — an
- * untapered amber pill is a pill — so it is authored here and never adjusted to
- * fit anything.
+ * The barrel is `GAME_ICONS.brewery` — Delapouite's `barrel`, the same glyph the
+ * brewery industry wears. Deliberate: a merchant never buys beer, so a barrel
+ * can only ever appear here as the commodity, and beer and the industry that
+ * makes it are one thing on this board. Measured against `beerStein` at both
+ * render scales it also holds together better — a single connected amber mass at
+ * every scale and pixel density tested, where a stein's handle and a hand-drawn
+ * cask's hoops break the shape into fragments.
  */
-export const BARREL_ART_W = 92
-export const BARREL_ART_H = 122
+export const BARREL_ICON = GAME_ICONS.brewery
+
+/**
+ * Ink bounds of that glyph inside its 512-unit box. Read off `getBBox` and
+ * hard-coded because the board renders server-side too; `e2e/merchant-beer.spec`
+ * measures the live path and fails if the vendored data moves.
+ */
+export const BARREL_INK = { x: 73, y: 41, w: 366.02, h: 433.94 }
+
 /** Height of the placed barrel, in board units. */
-export const BARREL_H = 28
+export const BARREL_H = 25
 /** The ONLY scale factor applied to the art, and it drives both axes. */
-export const BARREL_SCALE = BARREL_H / BARREL_ART_H
-export const BARREL_W = BARREL_ART_W * BARREL_SCALE
-
-/** The top head, seen slightly from above. */
-export const HEAD_CX = BARREL_ART_W / 2
-export const HEAD_CY = 12
-export const HEAD_RX = 29
-export const HEAD_RY = 9
-/** The base, hidden behind the staves except for its front rim. */
-export const BASE_CY = BARREL_ART_H - 10
-export const BASE_RX = 27
-export const BASE_RY = 8
-
-interface Pt {
-  x: number
-  y: number
-}
+export const BARREL_SCALE = BARREL_H / BARREL_INK.h
+export const BARREL_W = BARREL_INK.w * BARREL_SCALE
 
 /**
- * The right-hand stave, head to base. Its control points reach past the art box
- * because a cubic never touches them — that overshoot is what gives the cask a
- * bilge wide enough to read against the narrow heads. The left stave is this
- * one mirrored, and both the silhouette and the hoops are measured from it, so
- * a hoop can never disagree with the edge it has to stay inside.
- */
-const BILGE_OVERSHOOT = 4
-const STAVE: readonly [Pt, Pt, Pt, Pt] = [
-  { x: HEAD_CX + HEAD_RX, y: HEAD_CY },
-  { x: BARREL_ART_W + BILGE_OVERSHOOT, y: 40 },
-  { x: BARREL_ART_W + BILGE_OVERSHOOT, y: 84 },
-  { x: HEAD_CX + BASE_RX, y: BASE_CY },
-]
-
-function staveAt(t: number): Pt {
-  const u = 1 - t
-  const w = [u * u * u, 3 * u * u * t, 3 * u * t * t, t * t * t]
-  return {
-    x: STAVE.reduce((s, p, i) => s + p.x * w[i]!, 0),
-    y: STAVE.reduce((s, p, i) => s + p.y * w[i]!, 0),
-  }
-}
-
-/**
- * Left and right edge of the silhouette at a given height, in art units. y runs
- * monotonically down the stave, so a bisection finds its parameter.
- */
-export function silhouetteEdge(y: number): { left: number; right: number } {
-  let lo = 0
-  let hi = 1
-  for (let i = 0; i < 40; i++) {
-    const mid = (lo + hi) / 2
-    if (staveAt(mid).y < y) lo = mid
-    else hi = mid
-  }
-  const right = staveAt((lo + hi) / 2).x
-  return { left: BARREL_ART_W - right, right }
-}
-
-/**
- * Silhouette of the cask: over the top head, down the staves to the bilge, in
- * to the narrower base, across the front of the base rim and back up.
- */
-export function barrelBodyPath(): string {
-  const mirror = (p: Pt) => `${BARREL_ART_W - p.x} ${p.y}`
-  return [
-    `M${HEAD_CX - HEAD_RX} ${HEAD_CY}`,
-    `A${HEAD_RX} ${HEAD_RY} 0 0 1 ${STAVE[0].x} ${STAVE[0].y}`,
-    `C${STAVE[1].x} ${STAVE[1].y} ${STAVE[2].x} ${STAVE[2].y} ${STAVE[3].x} ${STAVE[3].y}`,
-    `A${BASE_RX} ${BASE_RY} 0 0 1 ${BARREL_ART_W - STAVE[3].x} ${STAVE[3].y}`,
-    `C${mirror(STAVE[2])} ${mirror(STAVE[1])} ${HEAD_CX - HEAD_RX} ${HEAD_CY}`,
-    'Z',
-  ].join(' ')
-}
-
-export interface Hoop {
-  y: number
-  x1: number
-  x2: number
-}
-
-/** Thickness of a hoop, and how far it is held back from the silhouette. */
-export const HOOP_W = 7
-export const HOOP_INSET = 2
-const HOOP_YS = [42, 86]
-
-/**
- * The two iron hoops, spanning the silhouette's own width at their height so
- * neither can poke out of the bilge. They read as banding at desk size and as a
- * faint darkening at phone size, where they are sub-pixel.
- */
-export function barrelHoops(): Hoop[] {
-  return HOOP_YS.map((y) => {
-    const { left, right } = silhouetteEdge(y)
-    return { y, x1: left + HOOP_INSET, x2: right - HOOP_INSET }
-  })
-}
-
-/**
- * Places the art centred on the socket. One `scale` argument by construction:
- * the barrel may be sized, never reshaped.
+ * Places the glyph's ink centred on the socket. One `scale` argument by
+ * construction: the barrel may be sized, never reshaped.
  */
 export function barrelTransform(): string {
-  return `translate(${-BARREL_W / 2}, ${-BARREL_H / 2}) scale(${BARREL_SCALE})`
+  return (
+    `translate(${-BARREL_W / 2}, ${-BARREL_H / 2}) ` +
+    `scale(${BARREL_SCALE}) ` +
+    `translate(${-BARREL_INK.x}, ${-BARREL_INK.y})`
+  )
 }

--- a/src/components/board/merchant-beer.ts
+++ b/src/components/board/merchant-beer.ts
@@ -1,0 +1,133 @@
+import { MERCHANT_BEER_ROW_H, SLOT } from './marker-anchor'
+
+/**
+ * Geometry for a merchant slot's contents: the industry glyphs printed on the
+ * tile, and the beer socket that sits under it (`MerchantPlate` in
+ * `board-map.tsx`).
+ *
+ * The socket is board furniture in its OWN row below the tile, which is where
+ * the physical board puts it. That is what buys the barrel its size: inside the
+ * slot it would compete with the glyph grid for the same 52 units and could
+ * only be legible by being reshaped, and a barrel is only recognisable at its
+ * natural proportions. So the barrel art is authored once at cask proportions
+ * (`BARREL_ART_W`×`BARREL_ART_H`) and placed with a single uniform
+ * `scale(BARREL_SCALE)` — no axis is ever scaled on its own.
+ */
+
+/** Air between the tile row and the beer socket below it. */
+export const BEER_ROW_GAP = 2
+/** Diameter of the recessed socket a merchant's barrel rests in. */
+export const BEER_SOCKET_D = MERCHANT_BEER_ROW_H - BEER_ROW_GAP
+export const BEER_SOCKET_R = BEER_SOCKET_D / 2
+/** Socket centre in slot-local units — under the middle of its own tile. */
+export const BEER_SOCKET_CX = SLOT / 2
+export const BEER_SOCKET_CY = SLOT + BEER_ROW_GAP + BEER_SOCKET_R
+
+/** A single glyph is drawn large; two or three share a 2-column grid. */
+export const ICON_SIZE_SINGLE = 24
+export const ICON_SIZE_GRID = 15
+export const ICON_GRID_GAP = 4
+export const ICON_GRID_COLS = 2
+/** A merchant tile prints at most this many industry icons. */
+export const MAX_ICONS = 3
+
+export interface IconCell {
+  x: number
+  y: number
+  size: number
+}
+
+/**
+ * Top-left corner and size of each industry glyph in a merchant slot, in
+ * slot-local units. The block is centred in the tile; an odd third glyph sits
+ * in the left column, so it lines up under the first.
+ */
+export function merchantIconCells(count: number): IconCell[] {
+  const n = Math.min(Math.max(count, 0), MAX_ICONS)
+  if (n === 0) return []
+  if (n === 1) {
+    const off = (SLOT - ICON_SIZE_SINGLE) / 2
+    return [{ x: off, y: off, size: ICON_SIZE_SINGLE }]
+  }
+  const step = ICON_SIZE_GRID + ICON_GRID_GAP
+  const rows = Math.ceil(n / ICON_GRID_COLS)
+  const blockW =
+    ICON_GRID_COLS * ICON_SIZE_GRID + (ICON_GRID_COLS - 1) * ICON_GRID_GAP
+  const blockH = rows * ICON_SIZE_GRID + (rows - 1) * ICON_GRID_GAP
+  const x0 = (SLOT - blockW) / 2
+  const y0 = (SLOT - blockH) / 2
+  return Array.from({ length: n }, (_, i) => ({
+    x: x0 + (i % ICON_GRID_COLS) * step,
+    y: y0 + Math.floor(i / ICON_GRID_COLS) * step,
+    size: ICON_SIZE_GRID,
+  }))
+}
+
+/* ---------------- the barrel ---------------- */
+
+/**
+ * The barrel's own coordinate box, at cask proportions: taller than its bilge is
+ * wide, with heads narrower than the bilge. That taper is the whole read — an
+ * untapered amber pill is a pill — so it is authored here and never adjusted to
+ * fit anything.
+ */
+export const BARREL_ART_W = 92
+export const BARREL_ART_H = 122
+/** Height of the placed barrel, in board units. */
+export const BARREL_H = 28
+/** The ONLY transform applied to the art, and it drives both axes. */
+export const BARREL_SCALE = BARREL_H / BARREL_ART_H
+export const BARREL_W = BARREL_ART_W * BARREL_SCALE
+
+/** The top head, seen slightly from above. */
+export const HEAD_CX = BARREL_ART_W / 2
+export const HEAD_CY = 12
+export const HEAD_RX = 29
+export const HEAD_RY = 9
+/** The base, hidden behind the staves except for its front rim. */
+export const BASE_CY = BARREL_ART_H - 10
+export const BASE_RX = 27
+export const BASE_RY = 8
+/**
+ * How far the stave control points reach past the art box. The bilge is a
+ * cubic, which never touches its control points, so overshooting is what gives
+ * the cask a bulge wide enough to read against the narrow heads.
+ */
+export const BILGE_OVERSHOOT = 4
+
+/**
+ * Silhouette of the cask: over the top head, down the staves to the bilge, in
+ * to the narrower base, across the front of the base rim and back up.
+ */
+export function barrelBodyPath(): string {
+  const right = BARREL_ART_W + BILGE_OVERSHOOT
+  const left = -BILGE_OVERSHOOT
+  return [
+    `M${HEAD_CX - HEAD_RX} ${HEAD_CY}`,
+    `A${HEAD_RX} ${HEAD_RY} 0 0 1 ${HEAD_CX + HEAD_RX} ${HEAD_CY}`,
+    `C${right} 40 ${right} 84 ${HEAD_CX + BASE_RX} ${BASE_CY}`,
+    `A${BASE_RX} ${BASE_RY} 0 0 1 ${HEAD_CX - BASE_RX} ${BASE_CY}`,
+    `C${left} 84 ${left} 40 ${HEAD_CX - HEAD_RX} ${HEAD_CY}`,
+    'Z',
+  ].join(' ')
+}
+
+export interface Hoop {
+  y: number
+  x1: number
+  x2: number
+}
+
+/**
+ * The two iron hoops, in art units. Inset from the silhouette so a hoop can
+ * never poke out of the bilge, and thin: they carry identity at desk scale
+ * only, being sub-pixel once the board is on a phone.
+ */
+export const HOOP_W = 4
+
+export function barrelHoops(): Hoop[] {
+  return [
+    { y: 42, x1: 6, x2: BARREL_ART_W - 6 },
+    { y: 86, x1: 7, x2: BARREL_ART_W - 7 },
+  ]
+}

--- a/src/components/board/merchant-beer.ts
+++ b/src/components/board/merchant-beer.ts
@@ -5,13 +5,13 @@ import { MERCHANT_BEER_ROW_H, SLOT } from './marker-anchor'
  * tile, and the beer socket that sits under it (`MerchantPlate` in
  * `board-map.tsx`).
  *
- * The socket is board furniture in its OWN row below the tile, which is where
- * the physical board puts it. That is what buys the barrel its size: inside the
- * slot it would compete with the glyph grid for the same 52 units and could
- * only be legible by being reshaped, and a barrel is only recognisable at its
- * natural proportions. So the barrel art is authored once at cask proportions
- * (`BARREL_ART_W`×`BARREL_ART_H`) and placed with a single uniform
- * `scale(BARREL_SCALE)` — no axis is ever scaled on its own.
+ * The socket is board furniture in its OWN row, alongside the tile rather than
+ * inside its icon area — the arrangement the printed board uses. That is what
+ * buys the barrel its size: sharing the tile it would compete with the glyph
+ * grid for the same 52 units and could only be made legible by being reshaped,
+ * and a barrel is only recognisable at its natural proportions. So the art is
+ * authored once at cask proportions (`BARREL_ART_W`×`BARREL_ART_H`) and placed
+ * by `barrelTransform`, which scales both axes by one scalar.
  */
 
 /** Air between the tile row and the beer socket below it. */
@@ -75,7 +75,7 @@ export const BARREL_ART_W = 92
 export const BARREL_ART_H = 122
 /** Height of the placed barrel, in board units. */
 export const BARREL_H = 28
-/** The ONLY transform applied to the art, and it drives both axes. */
+/** The ONLY scale factor applied to the art, and it drives both axes. */
 export const BARREL_SCALE = BARREL_H / BARREL_ART_H
 export const BARREL_W = BARREL_ART_W * BARREL_SCALE
 
@@ -88,26 +88,64 @@ export const HEAD_RY = 9
 export const BASE_CY = BARREL_ART_H - 10
 export const BASE_RX = 27
 export const BASE_RY = 8
+
+interface Pt {
+  x: number
+  y: number
+}
+
 /**
- * How far the stave control points reach past the art box. The bilge is a
- * cubic, which never touches its control points, so overshooting is what gives
- * the cask a bulge wide enough to read against the narrow heads.
+ * The right-hand stave, head to base. Its control points reach past the art box
+ * because a cubic never touches them — that overshoot is what gives the cask a
+ * bilge wide enough to read against the narrow heads. The left stave is this
+ * one mirrored, and both the silhouette and the hoops are measured from it, so
+ * a hoop can never disagree with the edge it has to stay inside.
  */
-export const BILGE_OVERSHOOT = 4
+const BILGE_OVERSHOOT = 4
+const STAVE: readonly [Pt, Pt, Pt, Pt] = [
+  { x: HEAD_CX + HEAD_RX, y: HEAD_CY },
+  { x: BARREL_ART_W + BILGE_OVERSHOOT, y: 40 },
+  { x: BARREL_ART_W + BILGE_OVERSHOOT, y: 84 },
+  { x: HEAD_CX + BASE_RX, y: BASE_CY },
+]
+
+function staveAt(t: number): Pt {
+  const u = 1 - t
+  const w = [u * u * u, 3 * u * u * t, 3 * u * t * t, t * t * t]
+  return {
+    x: STAVE.reduce((s, p, i) => s + p.x * w[i]!, 0),
+    y: STAVE.reduce((s, p, i) => s + p.y * w[i]!, 0),
+  }
+}
+
+/**
+ * Left and right edge of the silhouette at a given height, in art units. y runs
+ * monotonically down the stave, so a bisection finds its parameter.
+ */
+export function silhouetteEdge(y: number): { left: number; right: number } {
+  let lo = 0
+  let hi = 1
+  for (let i = 0; i < 40; i++) {
+    const mid = (lo + hi) / 2
+    if (staveAt(mid).y < y) lo = mid
+    else hi = mid
+  }
+  const right = staveAt((lo + hi) / 2).x
+  return { left: BARREL_ART_W - right, right }
+}
 
 /**
  * Silhouette of the cask: over the top head, down the staves to the bilge, in
  * to the narrower base, across the front of the base rim and back up.
  */
 export function barrelBodyPath(): string {
-  const right = BARREL_ART_W + BILGE_OVERSHOOT
-  const left = -BILGE_OVERSHOOT
+  const mirror = (p: Pt) => `${BARREL_ART_W - p.x} ${p.y}`
   return [
     `M${HEAD_CX - HEAD_RX} ${HEAD_CY}`,
-    `A${HEAD_RX} ${HEAD_RY} 0 0 1 ${HEAD_CX + HEAD_RX} ${HEAD_CY}`,
-    `C${right} 40 ${right} 84 ${HEAD_CX + BASE_RX} ${BASE_CY}`,
-    `A${BASE_RX} ${BASE_RY} 0 0 1 ${HEAD_CX - BASE_RX} ${BASE_CY}`,
-    `C${left} 84 ${left} 40 ${HEAD_CX - HEAD_RX} ${HEAD_CY}`,
+    `A${HEAD_RX} ${HEAD_RY} 0 0 1 ${STAVE[0].x} ${STAVE[0].y}`,
+    `C${STAVE[1].x} ${STAVE[1].y} ${STAVE[2].x} ${STAVE[2].y} ${STAVE[3].x} ${STAVE[3].y}`,
+    `A${BASE_RX} ${BASE_RY} 0 0 1 ${BARREL_ART_W - STAVE[3].x} ${STAVE[3].y}`,
+    `C${mirror(STAVE[2])} ${mirror(STAVE[1])} ${HEAD_CX - HEAD_RX} ${HEAD_CY}`,
     'Z',
   ].join(' ')
 }
@@ -118,16 +156,27 @@ export interface Hoop {
   x2: number
 }
 
-/**
- * The two iron hoops, in art units. Inset from the silhouette so a hoop can
- * never poke out of the bilge, and thin: they carry identity at desk scale
- * only, being sub-pixel once the board is on a phone.
- */
-export const HOOP_W = 4
+/** Thickness of a hoop, and how far it is held back from the silhouette. */
+export const HOOP_W = 7
+export const HOOP_INSET = 2
+const HOOP_YS = [42, 86]
 
+/**
+ * The two iron hoops, spanning the silhouette's own width at their height so
+ * neither can poke out of the bilge. They read as banding at desk size and as a
+ * faint darkening at phone size, where they are sub-pixel.
+ */
 export function barrelHoops(): Hoop[] {
-  return [
-    { y: 42, x1: 6, x2: BARREL_ART_W - 6 },
-    { y: 86, x1: 7, x2: BARREL_ART_W - 7 },
-  ]
+  return HOOP_YS.map((y) => {
+    const { left, right } = silhouetteEdge(y)
+    return { y, x1: left + HOOP_INSET, x2: right - HOOP_INSET }
+  })
+}
+
+/**
+ * Places the art centred on the socket. One `scale` argument by construction:
+ * the barrel may be sized, never reshaped.
+ */
+export function barrelTransform(): string {
+  return `translate(${-BARREL_W / 2}, ${-BARREL_H / 2}) scale(${BARREL_SCALE})`
 }


### PR DESCRIPTION
**Preview:** [https://brass-birmingham-74alhe9zl-julius-retzers-projects.vercel.app/?demo](https://brass-birmingham-74alhe9zl-julius-retzers-projects.vercel.app/?demo) — the merchant plates to look at are Warrington (top centre), Shrewsbury, Gloucester and Oxford. For the spent state, `/?demo=beerchoice` then Sell → cotton at Leek → Warrington merchant's barrel.

## The complaint

From a playtest: you cannot tell at a glance which merchants have beer available.

## What the board drew, and why it failed

The beer sat **inside** the merchant slot, as an 8.4 × 10.4-unit amber ellipse
(`rx 4.2, ry 5.2`) tucked into the top-right corner of the tile's icon grid.

Three things made it unreadable, and they compounded:

1. **It was too small to survive the board's own scale.** The board is a
   1600 × 1150 viewBox letterboxed into its frame. At 1280px that is 0.489
   (measured off `getScreenCTM`), and at 390px it is **0.221** — so the barrel
   landed at **1.9 × 2.3 CSS px** on a phone. That is a smudge, not an icon.
2. **It shared its corner and its hue with the industry glyphs.** The plate
   stroke is `#c39538`, the glyphs are `#e6bd63`, the barrel is `#e8bc4f` —
   one brass family, and the barrel sat 6 units from the nearest glyph.
3. **Absence was invisible.** Spending a merchant's barrel simply removed the
   mark. A merchant whose beer was gone looked identical to one that never had
   any (a blank tile buys nothing and holds no beer), so there was no
   presence/absence read at all — only "was something there a moment ago?".

The size is the root cause, and it cannot be fixed inside the slot: the glyph
grid already owns that space, so the only way to make the barrel bigger there is
to reshape it — and a reshaped barrel stops reading as a barrel.

## The fix: give it the place the printed board gives it

A recessed round well in a **dedicated row under the tile**, one per merchant
space, alongside the tile rather than competing with its icon area.

- **The icon is the project's own vendored glyph** — `GAME_ICONS.brewery`,
  Delapouite's `barrel` from game-icons.net (already in
  `src/components/gameicons-data.ts`, already credited in the app and README).
- **It is never distorted.** `barrelTransform()` emits one `scale()` argument
  driving both axes; the e2e spec walks the *rendered* matrix and fails if
  `a ≠ d` or either skew term is non-zero.
- **Visible air above it.** The gap between the tile row and the socket row is
  **7 board units = 1.55 CSS px at 390 and 3.42 px at 1280** (measured live).
- **The socket carries the state.** A tile that buys goods owns its well for the
  whole era, so a spent barrel leaves a dashed empty well exactly where its
  neighbours still show amber. A blank tile gets no well at all.
- **Contrast comes from the well, not the fill.** Amber on `--bb-coal-950`
  `#100e0c` separates by luminance where amber on brass does not. The cask is one
  flat amber fill — no keyline, no second tone — because at phone size a two-tone
  barrel breaks into two blobs instead of shading.
- **Colours are all existing tokens:** `#e8bc4f` (the board's own beer amber, as
  on brewery tiles), `#c39538` = `--bb-brass` for the rim, `#100e0c` =
  `--bb-coal-950` for the well.

### Sizing the barrel to its well

A round well is fitted by **radius**, not by axes, and that distinction is the
whole of the last correction. The cask's silhouette very nearly fills its own
bounding box, so its corners reach ~20% further from centre than either
half-extent: at the earlier 25-unit height the width (10.5) and height (12.5)
half-extents both sat inside the 14.5-unit rim, yet the silhouette reached
**14.12** units out — into the rim's 1.2-wide stroke band. The amber cut the ring
at four points and the well stopped reading as a container at all.

`BARREL_INK_R` is that silhouette radius, sampled with `isPointInFill` off the
live path rather than inferred from the bounding box, and the barrel is sized
from it:

| | board units | @1280 (0.489) | @390 (0.221) |
|---|---|---|---|
| socket diameter | 29 | 14.2 px | 6.41 px |
| barrel (W × H) | 17.71 × **21** | 8.66 × 10.27 px | 3.91 × 4.64 px |
| silhouette radius | 11.86 | 5.80 px | 2.62 px |
| clear well inside the rim | 2.04 | 1.00 px | 0.45 px |

The transform is unchanged in shape — `translate(…) scale(0.0484) translate(…)`,
one factor for both axes — so this is a uniform reduction of 16% in linear size
and nothing else moved. The unit test measures against the rim's inner face
rather than the axes, so it reproduces the defect: put the height back to 25 and
it fails with `expected 14.11831128727474 to be less than 13.9`.

**The trade at phone scale, stated plainly.** Shrinking works against the
original complaint, so it is worth being precise about the cost. At 390px the
whole socket is 6.4 px across, so no cask *shape* can read there at any size that
fits inside it — what carries presence is the amber mass against the dark well,
and that mass goes from ~20 px² to ~14 px². Both are a solid amber dot; the two
full-board phone shots below are effectively indistinguishable. At 1280px, where
the shape does read, the containment is what was broken and is now fixed. I did
not enlarge the socket instead: its row height is capped by the link-scoring
`•—•` pair on Warrington's plate top (below), and a bigger well would buy the
margin by making the beer's own row taller on every merchant.

### Which glyph, and why the brewery barrel

The set carries two beer candidates. I rendered both — plus the hand-drawn cask
this PR started with — into the real socket at both render scales and at DPR 1
and 3, then measured them:

| | ink bbox aspect | lit px @390 DPR3 | light energy | connected parts @1280 DPR1 |
|---|---|---|---|---|
| `brewery` (Delapouite *barrel*) | **0.84** | **707** | 41.4k | **3** (97% in one) |
| `beerStein` (Lorc *beer-stein*) | 0.95 | 671 | 41.6k | 4 (95% in one) |
| hand-drawn cask | 0.75 | 668 | 41.9k | 5 (93% in one) |

All three put the same light into the socket, so presence is a tie. The barrel
wins on the two things that decide a small shape: it stays **one connected amber
mass** at every scale and pixel density tested, where the stein's handle and the
hand-drawn cask's hoops fragment it; and its ink is the most clearly
taller-than-wide, which is what keeps a cask silhouette rather than a blob. No
new glyph needed to be vendored.

**On reusing the brewery industry icon** — I concluded this reads as
*consistent*, not confusing:

- A merchant never buys beer, so a barrel can never appear as an industry icon
  inside a merchant tile. In the socket it has exactly one possible meaning.
- The socket is separate furniture below the tile, outside the icon grid, and a
  merchant cannot hold an industry tile — so "this merchant has a brewery" is
  not a reading available to the player.
- Beer and the industry that makes it are one thing on this board. Using the
  stein instead would introduce a *second* symbol for a commodity that already
  has one, which is the more confusing option.

### Where the extra height goes

A merchant plate is 100 units tall instead of 64, and it grows **upward**: its
bottom edge stays half a tile-row below its city point (`MERCHANT_PLATE_TOP`), so
the name ribbon does not move and the routes arriving from below keep the gap a
link marker needs. Growing downward instead pushes Gloucester's ribbon off the
viewBox and squeezes the Warrington–Stoke marker between its neighbours.

What *caps* the row height is the link-scoring `•—•` pair that straddles a
plate's top edge: Warrington sits nearest the board's top edge, so the plate
cannot grow past 100 units without pushing those icons outside the viewBox.
`LINK_ICON_DY`/`LINK_ICON_R` name that bound and `marker-anchor.test.ts` asserts
every plate leaves room for it, alongside "no plate or ribbon leaves the viewBox"
and "no plate overlaps another".

## Screenshots

All shots are real renders of `/?demo` (and `/?demo=beerchoice` for the spent
state) at the stated viewport width. **Before** is the barrel at its previous
25-unit height, which is the only thing this change touches.

### Merchant row — 1280px

Before — the amber overruns the rim, and the ring is cut at four points:

![merchant row 1280 before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-merchant-1280-before.png)

After — an unbroken brass rim with dark well showing all the way round:

![merchant row 1280 after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-merchant-1280-after.png)

### Merchant row — 390px

Before:

![merchant row 390 before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-merchant-390-before.png)

After:

![merchant row 390 after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-merchant-390-after.png)

### Three states, one plate: ready / spent / blank

Warrington in `?demo=beerchoice` prints one buying tile and one blank tile.
Before the sale — barrel in the well on the right, no well at all on the blank
left-hand tile:

![states 1280 ready](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-states-1280-ready.png)

After selling to that merchant — the same well, now a dashed empty socket, which
is still plainly different from the blank tile beside it:

![states 1280 spent](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-states-1280-spent.png)

The same pair at 390px:

![states 390 ready](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-states-390-ready.png)

![states 390 spent](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-states-390-spent.png)

### Full board — nothing adjacent changed

1280px, before and after:

![full board 1280 before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-board-1280-before.png)

![full board 1280 after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-board-1280-after.png)

390px, before and after — at true phone scale the merchant beer is an amber dot
either way, which is the cost of the shrink measured rather than asserted:

![full board 390 before](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-board-390-before.png)

![full board 390 after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr107-v2-board-390-after.png)

## Tests

- `src/components/board/merchant-beer.test.ts` — silhouette-radius containment
  inside the rim's inner face plus a floor on the leftover well, the
  single-scale transform, the glyph's identity and credit, cask aspect, the
  resulting bright mass at both render scales, the barrel's share of its own
  well, and that the air above the socket is worth more than a screen pixel.
- `src/components/board/marker-anchor.test.ts` — plate/ribbon boxes inside the
  viewBox, headroom for the link-icon pair, no plate overlaps another, link
  markers never worse than the plain midpoint, and a bound on how much of a
  blocked marker a plate may cover.
- `e2e/merchant-beer.spec.ts` — which slots get a socket (stocked, blank,
  closed); a barrel spent on a sale emptying that socket and no other; the
  rendered glyph centred in its well with an unskewed, equal-axis matrix; the
  live silhouette radius re-sampled with `isPointInFill` and checked against the
  rim (this is what guards the hard-coded ink figures, since the board renders
  server-side where there is no `getBBox`); and the two render scales read live
  from `getScreenCTM`.
- `package.json` — `pnpm test` lists its directories explicitly and CI runs
  exactly that list, so `src/components/board` was never executed on a PR. Added
  to both the run and watch globs; that also un-skips `viewport`, `tile-cubes`,
  `pan-into-view`, `route-style` and `marker-anchor`, all passing.

Full suite green (964 tests), lint + typecheck clean, and the full Playwright
suite passes (83 specs).

## Review notes

Reviewed against `origin/main` by `codex review` (gpt-5.6-luna, xhigh) — no
findings on this pass. An earlier intent-aware pass with `claude-opus-5` at high
effort produced no P0/P1 either; fixed from it: the viewBox containment test
covers name ribbons, the render scales are pinned live in e2e,
`merchantIconCells` is called once per slot rather than once per glyph, and a
dead export plus three version-relative test comments are gone.

Carried, deliberately:

- **P3** — Worcester–Gloucester joins the two routes whose link marker has no
  fully clear spot. Measured coverage of the marker box: 5.0%, against
  Birmingham–Redditch's 5.7% and Stoke–Stone's 38.7%. It clips only the
  *estimated* name-ribbon box, no plate, and the marker layer already paints
  after the plates. The bound is 0.45 with the 0.387 baseline named.
- **P3** — Warrington's plate top is at board `y = 10`, so the decorative
  hover-locate ping ring (drawn at `y = -14` and animating out to 1.12× while
  fading to zero opacity) reaches a few units above the viewBox when a player is
  zoomed all the way in on the board's topmost city. Cosmetic, on a ring that is
  already transparent at that point.
- **P3** — a closed or blank merchant still reserves the socket row, so its plate
  shows an empty bottom band. That is what keeps the three states distinct;
  Nottingham is dimmed to 0.3 when closed anyway.
