### PR TITLE
fix(mat): one ring per tile while developing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -606,6 +606,22 @@ What this means in practice:
   `gameStore.developmat.test.ts` + `develop-mat.test.ts` +
   `e2e/develop-mat.spec.ts`; `iron-source.spec` / `locate-city.spec` /
   `mp-playthrough.spec` now drive develop THROUGH the modal.
+- ONE RING PER MAT TILE (2026-07-24): a mat tile shows exactly ONE ring, ever.
+  The selected tile's ring (`.bb2-mat-ring`, `theme.css`) is that ring, and on
+  an ARMED tile it does the arming itself (`.bb2-mat-ring-armed`: brass, 2px,
+  opacity-only breath) while the tile's own `.bb2-develop-armed` box-shadow
+  pulse stands down — two brass rings 3px apart on one tile edge was the bug.
+  Keying the stand-down on SELECTION (not CSS `:hover`) is deliberate: a tap
+  selects, so a hover-scoped rule would leave the clash on every phone. Hue
+  carries the rest: while developing, brass means "a pick scraps this one", so a
+  look at any other tile rings in `--bb-locate` teal (`.bb2-mat-ring-inspect`,
+  the map's own surveyor's mark) one line-weight lighter — armed vs read apart
+  by hue, weight AND breath, none of them alone, so reduced motion still tells
+  them apart. Develop mode also drops `MatTileArt`'s `next` halo: a soft brass
+  bloom over the stacked cardboard edges is exactly what makes pile depth
+  uncountable, and "next out to BUILD" says nothing on a scrapping surface.
+  NEVER answer a ring clash by growing or blurring one ring — depth reading is
+  the stack (see the mat-quantity note above). Pinned by `e2e/develop-mat.spec.ts`.
 - The board is a custom SVG (`board/board-map.tsx`, geometry hand-tuned in
   `board-data.ts`) — NOT React Flow. Legal targets come from `state.can(...)`
   sets computed in `game.tsx`; the map dims illegal plates/routes and

--- a/e2e/develop-mat.spec.ts
+++ b/e2e/develop-mat.spec.ts
@@ -38,6 +38,35 @@ test('the mat opens on the tile step and an armed tap stages the scrap', async (
   await expect(page.getByTestId('develop-lowest')).toBeVisible()
 })
 
+test('a tile never shows two rings: the selected one does its own arming', async ({
+  page,
+}) => {
+  await openDevelopMat(page)
+
+  // The mat opens with the lowest cotton tile both armed and selected.
+  const cotton = page.getByTestId('mat-slot-cotton_2')
+  await expect(cotton).toHaveAttribute('data-develop-armed', 'true')
+  await expect(cotton).toHaveAttribute('aria-pressed', 'true')
+  // Its own pulse stands down and its single ring carries the arming instead.
+  await expect(cotton).not.toHaveClass(/bb2-develop-armed/)
+  await expect(cotton.locator('.bb2-mat-ring-armed')).toHaveCount(1)
+
+  // Every other armed tile keeps pulsing, with no second ring of its own.
+  const coal = page.locator(
+    '[data-develop-armed][data-testid^="mat-slot-coal"]',
+  )
+  await expect(coal).toHaveClass(/bb2-develop-armed/)
+  await expect(coal.locator('.bb2-mat-ring')).toHaveCount(0)
+
+  // Reading a tile a pick would NOT scrap rings it in the inspect hue, and
+  // hands the brass pulse back to the armed one.
+  const higher = page.getByTestId('mat-slot-cotton_3')
+  await higher.hover()
+  await expect(higher.locator('.bb2-mat-ring-inspect')).toHaveCount(1)
+  await expect(cotton).toHaveClass(/bb2-develop-armed/)
+  await expect(cotton.locator('.bb2-mat-ring')).toHaveCount(0)
+})
+
 test('a lightbulb Pottery tap explains the rulebook block', async ({
   page,
 }) => {

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -300,7 +300,8 @@ function LinkIcons({ n }: { n: number }) {
 // One slot in an industry track: a tile, or an empty placeholder for a
 // depleted level. Tapping/hovering a tile drives the docked readout. In
 // develop mode the ARMED tile (the one a pick would scrap) smoulders brass
-// and a tap peels it off; tapping any other tile explains why not.
+// and a tap peels it off; tapping any other tile explains why not. Exactly one
+// ring shows per tile — see `ringHue` below.
 function TrackSlot({
   entry,
   selected,
@@ -330,29 +331,39 @@ function TrackSlot({
     )
   }
   const { tile, count, next, barred } = entry
+  const armed = develop?.armed ?? false
+  // One ring per tile: the armed pulse steps aside on the tile the pointer is
+  // on, so two brass rings never stack on the same tile edge. In develop mode
+  // brass is reserved for "a pick scraps this one", so a look at any other
+  // tile rings in the survey teal the map uses for locating a place.
+  const ringHue = !develop || armed ? 'var(--bb-brass-bright)' : '#8fd8cd'
+  const ringGlow =
+    !develop || armed ? 'rgba(230,189,99,.4)' : 'rgba(143,216,205,.4)'
   return (
     <button
       type="button"
       data-testid={`mat-slot-${tile.id}`}
       data-depth={count}
-      data-develop-armed={develop?.armed || undefined}
+      data-develop-armed={armed || undefined}
       aria-pressed={selected}
       aria-label={
-        develop?.armed
+        armed
           ? `Scrap ${LABEL[tile.type]} ${ROMAN[tile.level] ?? tile.level}`
           : undefined
       }
       onClick={(e) => {
         onSelect()
         if (develop) {
-          if (develop.armed) develop.onPick(e.currentTarget)
+          if (armed) develop.onPick(e.currentTarget)
           else develop.onBlocked()
         }
       }}
       onMouseEnter={onSelect}
       onFocus={onSelect}
       className={`relative shrink-0 rounded-md transition-transform hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus:outline-none ${
-        develop?.armed ? 'bb2-develop-armed hover:-translate-y-1' : ''
+        armed
+          ? `hover:-translate-y-1 ${selected ? '' : 'bb2-develop-armed'}`
+          : ''
       }`}
       style={{ opacity: barred ? 0.42 : 1 }}
     >
@@ -372,8 +383,8 @@ function TrackSlot({
           className="pointer-events-none absolute rounded-lg"
           style={{
             inset: -3,
-            border: '1.5px solid var(--bb-brass-bright)',
-            boxShadow: '0 0 8px rgba(230,189,99,.4)',
+            border: `1.5px solid ${ringHue}`,
+            boxShadow: `0 0 8px ${ringGlow}`,
           }}
         />
       )}

--- a/src/components/player-ledger.tsx
+++ b/src/components/player-ledger.tsx
@@ -332,13 +332,11 @@ function TrackSlot({
   }
   const { tile, count, next, barred } = entry
   const armed = develop?.armed ?? false
-  // One ring per tile: the armed pulse steps aside on the tile the pointer is
-  // on, so two brass rings never stack on the same tile edge. In develop mode
-  // brass is reserved for "a pick scraps this one", so a look at any other
-  // tile rings in the survey teal the map uses for locating a place.
-  const ringHue = !develop || armed ? 'var(--bb-brass-bright)' : '#8fd8cd'
-  const ringGlow =
-    !develop || armed ? 'rgba(230,189,99,.4)' : 'rgba(143,216,205,.4)'
+  // The selected tile's ring is the only ring it shows: on an armed tile that
+  // ring takes over the arming (brass, breathing) and the pulse below stands
+  // down, so the two never stack on one tile edge. Ring styling lives in
+  // `.bb2-mat-ring*` (theme.css) — the armed breath animates the border colour,
+  // which an inline style would fight.
   return (
     <button
       type="button"
@@ -374,18 +372,18 @@ function TrackSlot({
         tile={tile}
         depth={count}
         size={48}
-        next={next}
+        // "Next tile out to BUILD" is noise while developing, and its soft brass
+        // halo is a second glow over the stacked edges the pile depth is read
+        // from — the armed ring says what matters on this surface.
+        next={next && !develop}
         barred={barred}
       />
       {selected && (
         <span
           aria-hidden
-          className="pointer-events-none absolute rounded-lg"
-          style={{
-            inset: -3,
-            border: `1.5px solid ${ringHue}`,
-            boxShadow: `0 0 8px ${ringGlow}`,
-          }}
+          className={`pointer-events-none absolute rounded-lg bb2-mat-ring ${
+            armed ? 'bb2-mat-ring-armed' : develop ? 'bb2-mat-ring-inspect' : ''
+          }`}
         />
       )}
     </button>

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -30,6 +30,8 @@
 
   --bb-canal: #4e9c96;
   --bb-canal-deep: #2b5a58;
+  /* the surveyor's "here it is" teal — see the hover-to-locate mark below */
+  --bb-locate: #8fd8cd;
   --bb-rail: #c2632f;
   --bb-rail-deep: #7c3d1c;
   --bb-danger: #c14434;
@@ -1094,12 +1096,42 @@ button:focus-visible .bb2-locate-name {
     box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.95);
   }
 }
-/* Carried only by an armed tile that is NOT the selected one: the selection
-   ring is the single ring on the tile under the pointer (hover and focus both
-   select), so this never shares an edge with it. */
+/* Carried only by an armed tile that is NOT the selected one — on the selected
+   tile `.bb2-mat-ring-armed` is the armed ring instead, so brass never stacks
+   two rings on one tile edge. */
 .bb2-develop-armed {
   animation: bb2-develop-arm 1.5s ease-in-out infinite;
   border-radius: 8px;
+}
+
+/* The ring on the selected tile (a tap, a hover and a focus all select). It is
+   the ONLY ring that tile shows, so on an armed one it does the arming too:
+   same brass, same 2px line, same opacity-only breath as the pulse it stands in
+   for. Every tile a pick would scrap therefore breathes brass, selected or not. */
+.bb2-mat-ring {
+  inset: -3px;
+  border: 1.5px solid var(--bb-brass-bright);
+  box-shadow: 0 0 8px rgba(230, 189, 99, 0.4);
+}
+.bb2-mat-ring-armed {
+  border-width: 2px;
+  animation: bb2-mat-ring-arm 1.5s ease-in-out infinite;
+}
+@keyframes bb2-mat-ring-arm {
+  0%,
+  100% {
+    border-color: rgba(230, 189, 99, 0.62);
+  }
+  50% {
+    border-color: rgba(230, 189, 99, 1);
+  }
+}
+/* While developing, brass means "a pick scraps this one" — so reading any other
+   tile rings in the surveyor's teal, one line-weight lighter. Hue, weight and
+   breath all separate the two, none of them alone. */
+.bb2-mat-ring-inspect {
+  border-color: var(--bb-locate);
+  box-shadow: 0 0 8px rgba(143, 216, 205, 0.4);
 }
 
 /* A scrapped tile mid-flight from its pile to the scrap tray: one long arc
@@ -1140,6 +1172,10 @@ button:focus-visible .bb2-locate-name {
   .bb2-develop-armed {
     animation: none;
     box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.85);
+  }
+  .bb2-mat-ring-armed {
+    animation: none;
+    border-color: rgba(230, 189, 99, 0.95);
   }
   .bb2-dev-flyer {
     transition: none;

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -1094,13 +1094,12 @@ button:focus-visible .bb2-locate-name {
     box-shadow: 0 0 0 2px rgba(230, 189, 99, 0.95);
   }
 }
+/* Carried only by an armed tile that is NOT the selected one: the selection
+   ring is the single ring on the tile under the pointer (hover and focus both
+   select), so this never shares an edge with it. */
 .bb2-develop-armed {
   animation: bb2-develop-arm 1.5s ease-in-out infinite;
   border-radius: 8px;
-}
-.bb2-develop-armed:hover,
-.bb2-develop-armed:focus-visible {
-  animation-duration: 0.8s;
 }
 
 /* A scrapped tile mid-flight from its pile to the scrap tray: one long arc


### PR DESCRIPTION
## One ring per mat tile while developing

Opening Develop put two brass rings on the same tile edge, ~3px apart: the
pulsing **armed** ring (the tile a pick would scrap) and the **selection** ring
that follows the pointer. The mat opens with the lowest cotton tile both armed
and selected, so the clash was the first thing you saw — worst on cotton, whose
3-deep piles crowd their neighbours as well.

Neither ring changed size. They stopped sharing a tile.

- **The selected tile's ring is the only ring it shows**, and on an armed tile it
  does the arming itself — same brass, same 2px line, same opacity-only breath —
  while that tile's own box-shadow pulse stands down. Every tile a pick would
  scrap breathes brass, selected or not.
- **Brass now means one thing on this surface.** While developing it is reserved
  for "a pick scraps this one", so reading any *other* tile rings it in the
  surveyor's teal the map already uses to locate a place, one line-weight
  lighter. Armed and merely-being-read are separated by hue, weight *and* breath
  — none of them alone, so the reduced-motion path still tells them apart.
- **Develop mode drops `MatTileArt`'s "next out to build" halo.** It was a third
  brass signal on that same tile, and a soft bloom over the stacked cardboard
  edges is exactly what makes a pile's depth hard to count. It also says nothing
  on a scrapping surface.

The stand-down is keyed on **selection**, not a CSS `:hover` rule. That is
deliberate: a tap selects, so a hover-scoped rule would leave the clash intact on
every phone — the 390px case below.

Outside develop mode the mat is untouched.

### Cotton level track mid-Develop, 1280px

![1280px before and after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr110-compare-1280.png)

### Depth still reads

Remaining quantity is the stack, never a numeral, so the acceptance bar was that
a 3-deep cotton pile stays countable at 390px. It does — the ring sits 3px
*outside* the pile's box and its glow blooms away from the edges. The fixtures
never seat an armed tile on a 3-deep pile, so the last 390px frame puts the exact
armed ring on the 3-deep stack to show the worst case.

![390px before and after](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr110-compare-390.png)

### Reduced motion, barred tiles, and the untouched plain mat

![other states](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr110-compare-states.png)

### Verified

`pnpm test` 839 passed · `pnpm lint` · `pnpm typecheck` · full Playwright suite
65 passed. New e2e case in `e2e/develop-mat.spec.ts` pins the invariant: the
armed-and-selected tile carries no second ring, other armed tiles keep pulsing
with no ring of their own, and reading a neighbour hands the brass pulse back.

### Review notes

Reviewed by `codex` (gpt-5.6-luna, xhigh) and `pi` (claude-opus-5, high). Two P1s
were raised and fixed in the second commit: the first pass suppressed the pulse
outright, which — because selection is sticky and pre-seeded — left the armed
tile mute at rest; and the `next` build halo survived as a third brass signal.

Carried, not fixed:

- **P2** the locate teal is still hardcoded in `board-map.tsx` (×2) and
  `command-palette.tsx`; this PR adds the `--bb-locate` token and uses it, so
  converging those three sites is a small follow-up.
- **P3** leaving an armed tile restarts its box-shadow pulse from the dim
  keyframe, so armed tiles drift out of phase after you sweep the mat. Six
  independently smouldering embers is not objectionable, and the alternative is
  relocating the armed ring on every tile.
- **P3** an armed *and* barred tile inherits the track's `opacity: .42`, so its
  ring is the faintest of the three states. Pre-existing dimming; the pottery
  frame above shows it still reads apart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed develop-mode mat tiles displaying two arming rings.
  * Clarified and corrected ring behavior for selected, armed, and inspected tiles.
  * Preserved distinct visual states for armed tiles and hover-to-locate inspection.

* **Accessibility**
  * Improved reduced-motion behavior by disabling ring animations when requested.

* **Tests**
  * Added end-to-end coverage for mat ring visibility, selection, arming, and inspection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->