### PR TITLE
fix(ui): drop the idle tray label above the hand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -693,7 +693,13 @@ What this means in practice:
   (absolutely positioned, ZERO height reserve — `hintClearance` and the old
   pill are gone, so the fan never moves when the hint changes; don't
   reintroduce a hint that resizes the tray, that's the PR #81 jumping-hand
-  regression); dock and mat modal narrate themselves. On phones a wizard
+  regression); dock and mat modal narrate themselves. The tray label exists
+  ONLY while an action is in flight: the fixed tray floats over the scrolling
+  panel column, so an idle label sits on some panel's heading for the whole
+  turn — idle narration is the dock's own "Choose an action" panel, card-first
+  entry included. It paints ABOVE the fan (`z-index`), because a selected card
+  keeps its lens for the whole flow and would otherwise bury it; the tray is
+  click-transparent, so that costs no tap. On phones a wizard
   step change scrolls the surface that owns the next tap into view
   (`step-scroll.ts` pure decision + `use-step-scroll.ts` applied half; 2s
   don't-fight-the-player window, `prefers-reduced-motion` honoured, no-op on
@@ -730,7 +736,9 @@ What this means in practice:
   `role="img"` back, that flattens them out of the a11y tree.
 - The hand tray (`hand-tray.tsx`) doubles as the card selector for every
   discard step. `getHandSelection()` (`action-dock.tsx`) returns
-  `{hint, selectedIds}` for EVERY `playing.action.*` state: the card-picking
+  `{hint, selectedIds}` for EVERY `playing.action.*` state (`hint` is null
+  while idling — the hand stays live, the tray just says nothing): the
+  card-picking
   steps name the action; once a card is committed a catch-all keeps the held
   `context.selectedCard` in `selectedIds` with a `Holding <name>` hint — so the
   fan keeps the card lifted (persistent `LENS_SELECTED`) and the pill keeps

--- a/e2e/card-first.spec.ts
+++ b/e2e/card-first.spec.ts
@@ -33,10 +33,15 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   await page.goto('/?demo')
   await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
 
-  // The hand is live while idling — play a card first.
+  // The hand is live while idling, and the tray carries no label until an
+  // action is actually in flight — play a card first.
+  await expect(page.getByTestId('hand-hint')).toHaveCount(0)
   await page.getByTestId('card-brewery_2').click()
   await expect(page.getByText('Play this card')).toBeVisible()
-  await expect(page.getByText('Holding')).toBeVisible()
+  await expect(page.getByTestId('held-card')).toContainText('Holding')
+  await expect(
+    page.getByTestId('hand-hint').getByText(/^Holding /),
+  ).toBeVisible()
 
   // The held card's actions are offered; Network goes STRAIGHT to the
   // route step — no second card ask.

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -237,7 +237,8 @@ interface ActionDockProps {
 /* ----- hand-selection contract for the shell / HandTray ----- */
 
 export interface HandSelection {
-  hint: string
+  /** null = the tray says nothing; the hand is still live. */
+  hint: string | null
   selectedIds: string[]
 }
 
@@ -245,10 +246,13 @@ export function getHandSelection(
   snapshot: GameStoreSnapshot,
 ): HandSelection | null {
   const is = (path: string) => snapshot.matches(path as never)
-  // Card-first: the hand is live while idling — playing a card opens the
-  // actions it can start (the machine's cardSelected state). Wording gotcha:
-  // neither hint may contain "choose an action" (the idle dock title, pinned
-  // by e2e getByText, which substring-matches case-insensitively).
+  // A hint exists only while something is actually in flight. Idling, the
+  // hand is live (card-first: playing a card opens the actions it can start,
+  // the machine's cardSelected state) but the tray says nothing — the dock's
+  // own "Choose an action" panel is the narration for that state, and a tray
+  // label repeating it just covers whatever panel it happens to float over.
+  // Wording gotcha: no hint may contain "choose an action" (that dock title,
+  // pinned by e2e getByText, which substring-matches case-insensitively).
   //
   // Which cards are actually clickable at each step is NOT decided here — the
   // shell asks the machine (`state.can({SELECT_CARD, cardId})`) per card. That
@@ -256,11 +260,14 @@ export function getHandSelection(
   // once a card is committed only a DIFFERENT card is (the mid-flow switch),
   // and a Sell that already flipped an industry offers none.
   if (is('playing.action.selectingAction'))
-    return { hint: 'Pick an action — or play a card first', selectedIds: [] }
+    return { hint: null, selectedIds: [] }
   if (is('playing.action.cardSelected')) {
+    // Same "Holding <card>" wording as every deeper step: the held card is
+    // the only live state the tray adds here, and the dock already carries
+    // the title, the card chip and the Put back control.
     const held = snapshot.context.selectedCard
     return {
-      hint: 'Pick an action for this card — tap it again to put it back',
+      hint: held ? `Holding ${cardTitle(held)}` : null,
       selectedIds: held ? [held.id] : [],
     }
   }
@@ -999,6 +1006,14 @@ export function ActionDock({
             </button>
           ))}
         </div>
+        {/* Card-first entry lives here rather than on a tray label: the dock
+            scrolls with its own panel, so it can never cover another one. */}
+        <p
+          className="text-[12px] leading-snug"
+          style={{ color: 'rgba(231,215,177,.5)' }}
+        >
+          Or play a card from your hand to see the actions it can start.
+        </p>
         <PassButton
           disabled={!can({ type: 'PASS' })}
           onPass={() => send({ type: 'PASS' })}

--- a/src/components/hand-selection.test.ts
+++ b/src/components/hand-selection.test.ts
@@ -30,18 +30,19 @@ const wolverhampton: LocationCard = {
 }
 
 describe('getHandSelection — held card persists through the whole flow', () => {
-  test('card-first idle: nothing held, hand live', () => {
+  test('card-first idle: hand live, but the tray says nothing', () => {
     expect(getHandSelection(snap('playing.action.selectingAction'))).toEqual({
-      hint: 'Pick an action — or play a card first',
+      hint: null,
       selectedIds: [],
     })
   })
 
-  test('cardSelected: held card highlighted (put back / switch handled by machine)', () => {
+  test('cardSelected: held card highlighted and named (put back / switch handled by machine)', () => {
     const sel = getHandSelection(
       snap('playing.action.cardSelected', { selectedCard: wolverhampton }),
     )
     expect(sel?.selectedIds).toEqual(['loc-wolverhampton-1'])
+    expect(sel?.hint).toBe('Holding Wolverhampton')
   })
 
   test('deeper Network step keeps the card lifted and names it', () => {
@@ -81,6 +82,21 @@ describe('getHandSelection — held card persists through the whole flow', () =>
     expect(
       getHandSelection(snap('playing.action.networking.selectingCard')),
     ).toEqual({ hint: 'Network — discard a card', selectedIds: [] })
+  })
+
+  test('no hint ever restates the dock title', () => {
+    for (const path of [
+      'playing.action.selectingAction',
+      'playing.action.cardSelected',
+      'playing.action.building.selectingCard',
+      'playing.action.scouting.selectingCards',
+      'playing.action.networking.selectingLink',
+    ]) {
+      const sel = getHandSelection(snap(path, { selectedCard: wolverhampton }))
+      expect(sel?.hint?.toLowerCase() ?? '', path).not.toContain(
+        'choose an action',
+      )
+    }
   })
 
   test('the held hint is order-independent: a deep step reached action-first reads identically', () => {

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -565,8 +565,8 @@ button.bb2-card {
 /* The tray sizes cards by scaling the whole fan; the width compensates the
  * scale (100% / s) so the usable layout width stays the full viewport —
  * without it a phone tray would waste 28% of an already-narrow screen.
- * The scale lives on the tray root, not the box, because the hint pill is a
- * SIBLING of the fan and has to reserve its clearance in the same scale. */
+ * The scale lives on the tray root, not the box, so the step label
+ * (.bb2-tray-label, a sibling of the fan) can anchor to the scaled band. */
 .bb2-handtray {
   --bb-hand-scale: 0.72;
 }
@@ -578,19 +578,28 @@ button.bb2-card {
   transform: scale(var(--bb-hand-scale));
   width: calc(100% / var(--bb-hand-scale));
 }
-/* The tray's own step label. Absolutely positioned so it reserves no height
- * — the fan never moves when it appears or disappears (a hint that resized
- * the tray would reintroduce the jumping-hand regression PR #81 fixed).
+/* The tray's own step label, shown only while an action is in flight.
+ * Absolutely positioned so it reserves no height — the fan never moves when
+ * it appears or disappears (a hint that resized the tray would reintroduce
+ * the jumping-hand regression PR #81 fixed).
+ * It floats over whatever is beneath the fixed tray, so an idle label would
+ * sit on a scrolling panel's heading for the whole turn; each surface
+ * narrates its own idle state instead.
  * On phones it rides the top edge of the (scaled) card band, which overlays
  * the scrolling panel there, never the board. On desktop the band sits in
  * the board frame's bottom apron (the pb-[84px] strip the map never paints
  * into), so the label drops to the tray's bottom-left corner beside the
- * fan. Cards paint above it — a raised edge card may briefly cover it. */
+ * fan. It paints ABOVE the cards: a selected card keeps its lens for the
+ * whole flow and would otherwise sit on the label for the whole flow too.
+ * Click-transparent (the tray root is), so covering a card costs no tap. */
 .bb2-tray-label {
   position: absolute;
+  z-index: 1;
   left: 12px;
   bottom: calc(150px * var(--bb-hand-scale) - 16px);
-  max-width: 60%;
+  /* Every step's label fits a 390px phone at this width; a narrower cap
+   * ellipsised the Build and Scout steps mid-word. */
+  max-width: calc(100% - 24px);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;


### PR DESCRIPTION
## The complaint

> "the 'Pick an action or lay a card first' message is always in the way."

## What was actually still wrong

#103 already did most of the work here: it killed the floating pill and the static `hintClearance` reserve, so the hand fan no longer moves when a hint appears. What it did not change is that `getHandSelection()` still produced a label in **every** state, including idle.

That idle label is the one Julius quoted, and it is pure duplication — `Pick an action — or play a card first` next to a dock panel titled **Choose an action**. On a phone it is worse than redundant. The tray is `position: fixed` at the bottom of the viewport while the panel column scrolls underneath it, so the label sits on top of whatever panel heading happens to be at its line, for the whole turn: first the dock title it was restating, then, once you scroll, "The Exchanges".

<img width="390" alt="before, 390px" src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr113-before-390-idle.png" />

## What this changes

**The label exists only while an action is in flight.** Idle, the tray says nothing.

Idle narration belongs to the dock, which scrolls with its own content and therefore cannot cover another panel. The one thing the tray label uniquely advertised — that you can play a card first and see the actions it can start — is now a line in that panel.

Two follow-on fixes for the labels that remain, both visible on the Scout step at 390px:

- **They paint above the fan.** A *selected* card keeps its lens for the whole flow, so it was sitting on the label for the whole flow — the label was unreadable exactly when it mattered. The tray is click-transparent, so painting over a card costs no tap.
- **The width cap no longer truncates.** `Build — play a card from your hand` and `Scout — discard three cards (1/3)` were ellipsised mid-word on a phone.

The `cardSelected` step now reads `Holding <card>` like every deeper step, instead of a second copy of "Pick an action …". The dock already carries the title, the card chip and the **Put back** control there.

Mid-flow hints are otherwise untouched: the Scout counter, the per-action discard prompts and the held-card label all still work.

## The layout question

**No space is reserved, and none is reclaimed — because there was none to reclaim.** The label has been absolutely positioned since #103, so it contributes zero height in every state. I measured the fan's box at idle and mid-flow, at both widths: `top: 770, height: 150` at 1280px and `top: 756, height: 108` at 390px, identical in both states. Nothing moves as a hint comes or goes, so the PR #81 jumping-hand regression is not in play here.

What the idle label was consuming was not layout space but *legibility* of the panel underneath it, which is why the fix is conditional rendering rather than any change to the reserve.

## Legality is still engine-owned

Nothing here re-derives a rule. Which cards are clickable is still `state.can({type:'SELECT_CARD', cardId})` per card in the shell; board plates still come from `legal-targets.ts`. Checked on the site step: 1 of 27 cities lit, the held card marked selected, the rest live.

## Before / after

**1280px, idle** — the label was in the board frame's bottom apron here, harmless but redundant; it is now gone.

| before | after |
| --- | --- |
| <img width="640" src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr113-before-1280-idle.png" /> | <img width="640" src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr113-after-1280-idle.png" /> |

**390px, idle** — the label was on the "The Exchanges" heading; the dock now carries the card-first line in its own panel.

| before | after |
| --- | --- |
| <img width="320" src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr113-before-390-idle.png" /> | <img width="320" src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr113-after-390-idle.png" /> |

**390px, Scout with one card picked** — the in-flow label survives, and is now readable rather than buried under the selected card and cut off mid-word.

| before | after |
| --- | --- |
| <img width="320" src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr113-before-390-scout.png" /> | <img width="320" src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr113-after-390-scout.png" /> |

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm test` (889 passed), `pnpm build` — green.
- Full Playwright suite: 71 passed, 1 skipped (the pre-quarantined Develop journey).
- `card-first.spec.ts` updated rather than weakened: it now asserts the tray carries **no** label while idling, and scopes the "Holding" assertion to the dock's `held-card` chip so the tray's own `Holding <card>` cannot collide with it under strict mode.
- `hand-selection.test.ts` gains a sweep asserting no hint ever contains the dock title, which is the constraint the old comment stated in prose.

## Preview

**https://brass-birmingham-git-fm-2026-07-f538da-julius-retzers-projects.vercel.app/?demo**

Worth looking at on a phone: idle, then press Build or Scout, then pick a card.

## CI

`e2e` and `migrations` are green. `test` fails on a single case,
`gameStore.multiplayer.test.ts > over many games the first player is not always seat 0`
— a 30s timeout in a 20-game round trip against the CI database. It is a known
intermittent failure that also hits `main` (runs 30206663136, 30173631672), is
unrelated to anything here, and is being fixed separately. The other 888 tests
pass, and the whole suite is green locally against the Docker database.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance in the action panel explaining that cards can be played to reveal available actions.
  * Updated hand-tray labels to show contextual “Holding” information only when a card is selected or an action is in progress.

* **Bug Fixes**
  * Improved tray label positioning, layering, responsiveness, and tap-through behavior.
  * Prevented idle states from displaying unnecessary action prompts.

* **Documentation**
  * Clarified hand-tray label and hint behavior in the project guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->