### PR TITLE
test(mp): make the starting-player randomness check fit the CI clock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1189,7 +1189,13 @@ When updating this file, preserve this bar for all agents and keep entries conci
   `dev`, `preview`, and the long-lived pre-migrated `ci` parent. Those
   DB-backed suites run ~30s over the network (vs instant files), so they set a
   30s per-file timeout via `vi.setConfig`; leave the global 5s for the
-  in-memory engine suite.
+  in-memory engine suite. A round trip costs ~15ms against the local Docker DB
+  and ~100ms+ against a Neon branch, so a DB test whose cost scales with a
+  sample count (many games/rows) passes locally and times out in CI unless the
+  samples run CONCURRENTLY — they are independent (own token, own per-token
+  lock in `withGameLock`). See the 20-sample starting-player test in
+  `gameStore.multiplayer.test.ts`: never shrink such a sample count to fit the
+  clock, parallelise it and state an explicit `timeout`.
 - LOCAL TEST DB IS DOCKER (added 2026-07-17, supersedes the Neon-branch default
   below for laptops): `compose.yaml` runs Postgres + the Neon HTTP proxy;
   `pnpm db:local` starts it and both `pnpm test` and `pnpm exec playwright test`

--- a/src/store/gameStore.multiplayer.test.ts
+++ b/src/store/gameStore.multiplayer.test.ts
@@ -52,8 +52,8 @@ async function freshGame() {
   await setSeatReady(host.token, 0, host.seatSecret, true)
   await setSeatReady(host.token, guest.seatId, guest.seatSecret, true)
   const started = await startGame(host.token, host.seatSecret)
-  expect(started.ok).toBe(true)
-  return { host, guest }
+  if (!started.ok) throw new Error(`start refused: ${started.error}`)
+  return { host, guest, started }
 }
 
 type Ctx = {
@@ -967,17 +967,31 @@ describe('multiplayer: the starting player is randomized server-side', () => {
     expect(b.turnOrder).toEqual(a.turnOrder)
   })
 
-  test('over many games the first player is not always seat 0', async () => {
-    // Real randomness over many 2-player games: the leader must vary (it was
-    // ALWAYS seat 0 before this change). With 20 fair coin flips, "all the
-    // same" has probability 2·2⁻²⁰ ≈ 2e-6 — effectively never, no retries.
-    const leaders = new Set<number>()
-    for (let n = 0; n < 20; n++) {
-      const { host } = await freshGame()
-      leaders.add((await startedCtx(host.token)).currentPlayerIndex)
-    }
-    expect(leaders.size).toBeGreaterThan(1)
-  })
+  // Sized so that a randomisation regression pinning the leader to one seat
+  // cannot slip through: with 20 fair coin flips, "all the same" has
+  // probability 2·2⁻²⁰ ≈ 2e-6 — effectively never, so no retry logic.
+  const RANDOMNESS_SAMPLES = 20
+
+  // The sample count is fixed by the statistics above, so the clock bends to
+  // it: headroom over the file-wide 30s, which is sized for the handful of
+  // round trips a single-game test makes.
+  test(
+    'over many games the first player is not always seat 0',
+    { timeout: 120_000 },
+    async () => {
+      // The samples run concurrently: each is 5 independent DB round trips and
+      // they share no state (per-game token, per-token lock). Serialized, this
+      // is ~100 round trips — fine against a warm local Postgres, over the
+      // clock against a remote branch on a loaded CI runner.
+      const leaders = await Promise.all(
+        Array.from({ length: RANDOMNESS_SAMPLES }, async () => {
+          const { started } = await freshGame()
+          return ctxOf(started.view).currentPlayerIndex
+        }),
+      )
+      expect(new Set(leaders).size).toBeGreaterThan(1)
+    },
+  )
 })
 
 describe('multiplayer: table names and private/public visibility', () => {


### PR DESCRIPTION
## Why `main` was intermittently red

`gameStore.multiplayer.test.ts > … > over many games the first player is not always seat 0`
was timing out at the file's 30s budget in CI (runs `30206663136`, `30173631672`,
`30163505810`), while passing on every local run — and occasionally passing in CI too.

It was never a hang. The test proves the starting seat varies by setting up 20 real
2-player games, and each sample was **6 sequential DB round trips**: create, join, two
ready-ups, start, then a reload to read the leader. That is ~120 serialized round trips
for one test.

The latency per round trip is what differs between the two environments:

| | per round trip | this test |
|---|---|---|
| local (Docker Postgres + Neon HTTP proxy, `pnpm db:local`) | ~15ms | 16.2s — fits under 30s |
| CI (ephemeral Neon branch, us-east-1, loaded runner, parallel vitest workers) | ~100ms+ | > 30s — times out |

The neighbouring single-game tests in the same CI run took 2–4s each for the same start
handoff, so 20 of them sequentially could not fit the clock. Nothing is leaking a handle
and the connection path is HTTP (`neon-http`), so there is no pool to exhaust.

## The fix

The 20 samples are fully independent — separate tokens, separate per-token locks, no
shared fixture — so they run concurrently, and each reads the leader from the view
`startGame` already returns rather than reloading the game (6 round trips → 5, and 20-way
parallel instead of serial).

**Sample count is unchanged: 20 before, 20 after.** The statistical claim it rests on
(20 fair coin flips, "all the same" ≈ 2e-6) is untouched, and the assertion is still
`new Set(leaders).size > 1`. The test also carries an explicit `timeout: 120_000` so its
budget is stated rather than silently inherited from a file-wide default sized for
single-game tests.

Measured on the local Docker DB: that test 16.2s → ~1s; the whole file 35s → ~20s.

## Validation

- `pnpm test` (all 95 files) green locally; `pnpm typecheck` and `pnpm lint` clean.
- The `test` job ran green **three times** on this branch (run `30208090880`, attempts 1–3),
  so the fix is not a lucky runner. In CI the test itself is now **2.2s** (it used to burn
  the full 30s and fail), and the whole file is 125s instead of ~152s.

## Notes / follow-ups (not done here)

- The file still runs ~150s in CI because most of its 35 tests build their own game
  through the full `create → join → ready → start` handoff, which is inherent to what
  they assert (the real start path). A shared started-game fixture for the read-only
  tests would cut most of that, but it changes what those tests exercise, so it belongs
  in its own change.
- Review gate: `codex review` (gpt-5.6-luna, xhigh reasoning) against `origin/main` —
  no findings at any severity.
