### PR TITLE
fix(ui): drop the tray's text label, and make the second tap visible on touch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -685,26 +685,22 @@ What this means in practice:
   `mp/mp-game.tsx`. It enumerates and asks `can()`; it re-derives no rule. See
   "Legality is engine-owned" below.
 - NEXT-STEP NARRATION IS OWN-SURFACE (2026-07-24, supersedes the floating
-  banner + tray pill): nothing floats over the play area. The board's
-  instruction is a caption bar in the frame's NORMAL FLOW
-  (`components/board-caption.ts`, shared by both shells — site/route picks
-  AND the beer/iron/coal source steps, counts from the same sets the
-  spotlight uses); the tray's hint is `.bb2-tray-label` inside the tray band
-  (absolutely positioned, ZERO height reserve — `hintClearance` and the old
-  pill are gone, so the fan never moves when the hint changes; don't
-  reintroduce a hint that resizes the tray, that's the PR #81 jumping-hand
-  regression); dock and mat modal narrate themselves. The tray label exists
-  ONLY while an action is in flight: the fixed tray floats over the scrolling
-  panel column, so an idle label sits on some panel's heading for the whole
-  turn — idle narration is the dock's own "Choose an action" panel, card-first
-  entry included. It paints ABOVE the fan (`z-index`), because a selected card
-  keeps its lens for the whole flow and would otherwise bury it; the tray is
-  click-transparent, so that costs no tap. On phones a wizard
-  step change scrolls the surface that owns the next tap into view
-  (`step-scroll.ts` pure decision + `use-step-scroll.ts` applied half; 2s
-  don't-fight-the-player window, `prefers-reduced-motion` honoured, no-op on
-  lg). The board legend sits top-right — the frame's bottom-left apron
-  belongs to the tray label.
+  banner + tray pill): nothing floats over the play area, and no surface
+  narrates another. The board's instruction is a caption bar in the frame's
+  NORMAL FLOW (`components/board-caption.ts`, shared by both shells — site/route
+  picks AND the beer/iron/coal source steps, counts from the same sets the
+  spotlight uses); dock and mat modal narrate themselves. The TRAY carries NO
+  text label in any state (`hintClearance`, the old pill and `.bb2-tray-label`
+  are all gone): it is fixed over the scrolling panel column, so any label it
+  shows sits on some panel's heading, and everything it could say the dock is
+  already saying in the panel that owns the step. The one thing the tray does
+  say is on the CARD — the act tab, below. Don't reintroduce a tray hint, and
+  never one that resizes the tray (that's the PR #81 jumping-hand regression).
+  On phones a wizard step change scrolls the surface that owns the next tap
+  into view (`step-scroll.ts` pure decision + `use-step-scroll.ts` applied
+  half; 2s don't-fight-the-player window, `prefers-reduced-motion` honoured,
+  no-op on lg). The board legend sits top-right, clear of the frame's bottom
+  apron, which belongs to the hand tray.
 - Boot order in `game.tsx` (client-side, behind a mount gate):
   `/?preview=gameover` → `/?era=rail` (rail fixture) → `/?demo` (canal
   fixture) → `/?fresh=1` → localStorage save (`bb2-save-v1`) → setup
@@ -736,16 +732,35 @@ What this means in practice:
   `role="img"` back, that flattens them out of the a11y tree.
 - The hand tray (`hand-tray.tsx`) doubles as the card selector for every
   discard step. `getHandSelection()` (`action-dock.tsx`) returns
-  `{hint, selectedIds}` for EVERY `playing.action.*` state (`hint` is null
-  while idling — the hand stays live, the tray just says nothing): the
-  card-picking
-  steps name the action; once a card is committed a catch-all keeps the held
-  `context.selectedCard` in `selectedIds` with a `Holding <name>` hint — so the
-  fan keeps the card lifted (persistent `LENS_SELECTED`) and the pill keeps
-  naming it for the WHOLE flow (put-back is CANCEL in the dock). It does NOT
-  decide which cards are clickable — the shell asks the machine per card
+  `{selectedIds}` for EVERY `playing.action.*` state — which cards the step has
+  in play, and nothing else: a catch-all keeps a committed
+  `context.selectedCard` lifted (persistent `LENS_SELECTED`) for the WHOLE flow
+  (put-back is CANCEL in the dock). It does NOT decide which cards are
+  clickable — the shell asks the machine per card
   (`state.can({SELECT_CARD, cardId})`), the single source of truth, so it
-  survives the MP intent→broadcast→rebuild round-trip.
+  survives the MP intent→broadcast→rebuild round-trip. Pinned by
+  `hand-selection.test.ts`, which asserts the contract carries no string.
+- THE ACT TAB MAKES THE SECOND TAP VISIBLE (2026-07-24): on touch the first tap
+  PEEKS a card and the second one plays it (`peekedId`, only ever set by touch).
+  A peeked card carries a brass tab on its lower face naming what the next tap
+  does — "Play", or "Put back" for a card already in play — because otherwise
+  the second tap is invisible and players have to stumble on it. The two
+  stages STAY: the fan packs to a
+  26px sliver on a phone, so raising a card is the only way to read it, and a
+  one-tap fan would mean you cannot look at a card without spending it.
+  - It is a LABEL, not a control (`.bb2-card-act`, `pointer-events: none`,
+    `aria-hidden`), sized by `actTabLayout` to sit INSIDE the card's own 108px
+    hitbox: the card takes the tap either way, so there is one control per card
+    and the card's tap point stays clear — the same rule the ◀ ▶ handles follow,
+    and Playwright enforces it (an overlapping button makes `card.tap()` fail
+    with "intercepts pointer events").
+  - Layout px in `hand-tray-layout.ts` are PRE-SCALE: the tray draws the fan at
+    `PHONE_HAND_SCALE`, so a 44px target has to be sized 44/0.72 there. Type
+    too. Pinned by `hand-tray-layout.test.ts`.
+  - Mouse and keyboard never see it (they act on the first click), and it is
+    absent on a card that cannot be played. Touch paths are pinned by
+    `e2e/hand-tray.spec.ts` with REAL touch (`hasTouch` + `isMobile` — isMobile
+    is what makes `(pointer: coarse)` match).
 - HAND ORDER IS A VIEW PERMUTATION (2026-07-23): players reorder their own fan
   (mouse drag, the ◀ ▶ handles flanking a raised card, Shift+Arrow on a focused
   card). `hand-order.ts` owns it — a per-player card-id list under its OWN
@@ -761,15 +776,16 @@ What this means in practice:
   gesture on touch — a control over the face broke `card.tap()` outright.
   Pinned by `hand-order.test.ts`, `hand-tray-layout.test.ts`,
   `e2e/hand-reorder.spec.ts`.
-- HELD-CARD BANNER (2026-07-17): the DOCK also names the held card — a shared
-  `HeldCard` (`Holding <CardChip>`) rendered by the `Flow` wrapper (via a
+- HELD-CARD CHIP (2026-07-17): the DOCK names the card an action is spending —
+  a shared `HeldCard` (a bare `CardChip`) rendered by the `Flow` wrapper (via a
   `held` prop on every `<Flow>` / `DevelopTilePicker`) AND the `cardSelected`
-  chooser, so both entry orders (card-first and action-first) show the
-  IDENTICAL "Holding <card>" the instant `context.selectedCard` is set, for the
-  whole flow. Keyed on state + `selectedCard` only, so it's order-independent.
-  Don't reintroduce the old per-step "Playing"/"Card" chips — they duplicated
-  it. `data-testid="held-card"`; pinned by the action-first + card-first dock
-  tests in `card-first.spec.ts`.
+  chooser, so both entry orders (card-first and action-first) show the IDENTICAL
+  chip the instant `context.selectedCard` is set, for the whole flow. Keyed on
+  state + `selectedCard` only, so it's order-independent. The chip carries no
+  introducing word: it sits under the flow's own title and beside the card
+  lifted out of the fan. Don't reintroduce the old per-step "Playing"/"Card"
+  chips — they duplicated it. `data-testid="held-card"`; pinned by the
+  action-first + card-first dock tests in `card-first.spec.ts`.
 - CLICK-TO-SWITCH (2026-07-17): clicking a DIFFERENT hand card switches the
   play. On a pick step that's `cardSelected`'s own SELECT_CARD; mid-action it's
   a parent-level SELECT_CARD on `playing.action` → `cardSelected` that reuses

--- a/e2e/card-first.spec.ts
+++ b/e2e/card-first.spec.ts
@@ -33,15 +33,12 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   await page.goto('/?demo')
   await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
 
-  // The hand is live while idling, and the tray carries no label until an
-  // action is actually in flight — play a card first.
+  // The hand is live while idling — play a card first. The tray itself adds no
+  // words in any state; the dock names the card it is spending.
   await expect(page.getByTestId('hand-hint')).toHaveCount(0)
   await page.getByTestId('card-brewery_2').click()
   await expect(page.getByText('Play this card')).toBeVisible()
-  await expect(page.getByTestId('held-card')).toContainText('Holding')
-  await expect(
-    page.getByTestId('hand-hint').getByText(/^Holding /),
-  ).toBeVisible()
+  await expect(page.getByTestId('held-card')).toContainText('Brewery')
 
   // The held card's actions are offered; Network goes STRAIGHT to the
   // route step — no second card ask.
@@ -53,14 +50,13 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   ).toBeVisible()
 
   // The card stays visibly held for the WHOLE action, not just the
-  // cardSelected screen: it keeps its lift in the fan and the "Holding …"
-  // label persists on the route step (the captain's report was that both
-  // vanished the moment an action was pressed).
+  // cardSelected screen: it keeps its lift in the fan and the dock's chip
+  // persists on the route step (the report was that both vanished the moment
+  // an action was pressed).
   const held = page.getByTestId('card-brewery_2')
   await expect(held).toHaveAttribute('data-selected', 'true')
-  await expect(
-    page.getByTestId('hand-hint').getByText(/^Holding /),
-  ).toBeVisible()
+  await expect(page.getByTestId('held-card')).toContainText('Brewery')
+  await expect(page.getByTestId('hand-hint')).toHaveCount(0)
 
   const legalRoute = page.locator('path[data-conn][data-legal="true"]')
   expect(await legalRoute.count()).toBeGreaterThan(0)
@@ -71,9 +67,8 @@ test('card-first: play a card, pick Network, confirm — card never re-asked', a
   await expect(confirm).toBeEnabled()
   // Still held through the confirm step, right up until it's spent.
   await expect(held).toHaveAttribute('data-selected', 'true')
-  await expect(
-    page.getByTestId('hand-hint').getByText(/^Holding /),
-  ).toBeVisible()
+  await expect(page.getByTestId('held-card')).toContainText('Brewery')
+  await expect(page.getByTestId('hand-hint')).toHaveCount(0)
   await confirm.click()
 
   // The link was laid with the held card and consumed the action (£19 − £3;
@@ -102,22 +97,21 @@ test('card-first: build with the held card resumes at the industry step', async 
   await expect(treasuryOf(page, 'Eliza')).toHaveText('£19')
 })
 
-test('action-first: the "Holding <card>" banner appears once a card is picked and persists', async ({
+test('action-first: the dock names the played card once one is picked, and keeps it', async ({
   page,
 }) => {
   await page.goto('/?demo')
 
   // Action first: choose Network BEFORE a card. On the discard step no card is
-  // held yet, so the dock shows no held-card banner.
+  // held yet, so the dock shows no card chip.
   await page.getByTestId('action-network').click()
   await expect(page.getByTestId('held-card')).toHaveCount(0)
 
-  // Pick a card during the discard step — the dock now NAMES it, the same
-  // "Holding <card>" wording the card-first order shows.
+  // Pick a card during the discard step — the dock NAMES it, exactly as the
+  // card-first order does.
   await page.getByTestId('card-birmingham_1').click()
   const held = page.getByTestId('held-card')
   await expect(held).toBeVisible()
-  await expect(held).toContainText('Holding')
   await expect(held).toContainText('Birmingham')
 
   // …and it persists through the route step and into confirm.
@@ -129,12 +123,12 @@ test('action-first: the "Holding <card>" banner appears once a card is picked an
   await expect(page.getByTestId('held-card')).toContainText('Birmingham')
 })
 
-test('card-first: the same held-card banner shows in the dock and persists', async ({
+test('card-first: the same card chip shows in the dock and persists', async ({
   page,
 }) => {
   await page.goto('/?demo')
 
-  // Card first: the banner is up from the chooser onward.
+  // Card first: the chip is up from the chooser onward.
   await page.getByTestId('card-birmingham_1').click()
   await expect(page.getByTestId('held-card')).toContainText('Birmingham')
   await page.getByTestId('action-network').click()
@@ -170,9 +164,7 @@ test('card-first: clicking another card mid-action cancels it and re-holds the n
   // Enter a real action flow holding Birmingham.
   await birmingham.click()
   await page.getByTestId('action-network').click()
-  await expect(
-    page.getByTestId('hand-hint').getByText(/^Holding /),
-  ).toBeVisible()
+  await expect(page.getByTestId('held-card')).toContainText('Birmingham')
   await expect(birmingham).toHaveAttribute('data-selected', 'true')
 
   // Clicking a DIFFERENT card mid-flow is "cancel this, play that instead":

--- a/e2e/hand-tray.spec.ts
+++ b/e2e/hand-tray.spec.ts
@@ -10,12 +10,13 @@ import { expect, test } from '@playwright/test'
  * (scale 1.3) until it is deselected or the action completes.
  *
  * Touch: there is no hover, so the FIRST tap peeks (raises the lens) and
- * the SECOND tap acts. A LONG-PRESS (350ms) also peeks, and keeping the
- * finger down while sliding browses the fan Hearthstone-style — the raise
- * follows the finger; releasing keeps the card under the finger peeked and
- * NEVER selects (acting stays a deliberate tap on the raised card).
- * Dimmed/disabled cards peek too (the seat wrapper handles the tap —
- * clicks don't fire on disabled buttons).
+ * the SECOND tap acts — which the peeked card SAYS, on a brass act tab that
+ * is itself the target ("Play", or "Put back" once the card is in play).
+ * A LONG-PRESS (350ms) also peeks, and keeping the finger down while sliding
+ * browses the fan Hearthstone-style — the raise follows the finger; releasing
+ * keeps the card under the finger peeked and NEVER selects (acting stays a
+ * deliberate tap). Dimmed/disabled cards peek too (the seat wrapper handles
+ * the tap — clicks don't fire on disabled buttons) and offer no tab.
  */
 
 /** The fan seat wrapper around a card button (carries the dock transform). */
@@ -67,6 +68,11 @@ test.describe('desktop hover magnification', () => {
       /scale\(1\.3\)/,
     )
 
+    // A hovered card offers no act tab: a mouse acts on its first click, so
+    // there is no second tap to advertise.
+    await card.hover()
+    await expect(page.getByTestId('card-act-brewery_2')).toHaveCount(0)
+
     // Re-tap puts it back — nothing consumed (pinned deeper in card-first.spec).
     await card.click()
     await expect(page.getByText('Choose an action')).toBeVisible()
@@ -86,6 +92,23 @@ test.describe('desktop hover magnification', () => {
     await card.hover()
     await expect(card).toHaveAttribute('data-raised', 'true')
     await card.click()
+    await expect(page.getByText('Play this card')).toBeVisible()
+  })
+
+  test('keyboard focus raises the card and Enter plays it, with no act tab', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await expect(card).toBeVisible()
+
+    // :focus-visible reads like hover — one keystroke acts, so no tab.
+    await card.focus()
+    await expect(card).toHaveAttribute('data-raised', 'true')
+    await expect(page.getByTestId('card-act-brewery_2')).toHaveCount(0)
+
+    await page.keyboard.press('Enter')
+    await expect(card).toHaveAttribute('data-selected', 'true')
     await expect(page.getByText('Play this card')).toBeVisible()
   })
 })
@@ -184,13 +207,17 @@ test.describe('phone: fit + tap-to-peek', () => {
     await expect(target).toHaveAttribute('data-raised', 'true')
     await expect(start).not.toHaveAttribute('data-raised', 'true')
 
-    // Release keeps the browsed card peeked — browsing can never select.
+    // Release keeps the browsed card peeked — browsing can never select, not
+    // even through the act tab the peek has just put under the finger.
     await cdp.send('Input.dispatchTouchEvent', {
       type: 'touchEnd',
       touchPoints: [],
     })
     await expect(target).toHaveAttribute('data-raised', 'true')
     await expect(target).not.toHaveAttribute('data-selected', 'true')
+    await expect(
+      page.getByTestId('card-act-cotton_manufacturer_4'),
+    ).toBeVisible()
     await expect(page.getByText('Play this card')).not.toBeVisible()
 
     // The kept peek then acts on a normal tap (the existing second-tap rule).
@@ -259,5 +286,131 @@ test.describe('phone: fit + tap-to-peek', () => {
     // The loan never happened — put the new card back to idle.
     await page.getByTestId('cancel-action').tap()
     await expect(page.getByText('Choose an action')).toBeVisible()
+  })
+})
+
+/**
+ * The act tab: what makes the second tap visible instead of folklore.
+ *
+ * isMobile is what flips the emulated primary pointer to coarse (the bigger
+ * lens and the ◀ ▶ handles); hasTouch alone leaves it fine. The tab itself is
+ * gated on the PEEK, not the pointer media query, so it appears in either
+ * emulation — but the geometry a thumb actually gets is the coarse one.
+ */
+test.describe('phone: the peeked card names its own second tap', () => {
+  test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+  })
+
+  test('a peek offers Play, on a target the card itself takes', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await expect(card).toBeVisible()
+
+    // Nothing at rest: the fan is a fan.
+    await expect(page.locator('.bb2-card-act')).toHaveCount(0)
+
+    await card.tap()
+    const tab = page.getByTestId('card-act-brewery_2')
+    await expect(tab).toHaveText('Play')
+
+    // Thumb sized, wholly on screen (the tray overhangs the bottom edge, so a
+    // tab hung below the card would be half off it) and wholly INSIDE the
+    // card's hitbox — a finger aiming at the tab lands on the card, which is
+    // the thing that acts.
+    const box = (await tab.boundingBox())!
+    const hit = (await card.boundingBox())!
+    const view = page.viewportSize()!
+    expect(box.height).toBeGreaterThanOrEqual(44)
+    expect(box.width).toBeGreaterThanOrEqual(44)
+    expect(box.y).toBeGreaterThan(0)
+    expect(box.y + box.height).toBeLessThanOrEqual(view.height)
+    expect(box.x).toBeGreaterThanOrEqual(hit.x)
+    expect(box.x + box.width).toBeLessThanOrEqual(hit.x + hit.width)
+
+    // Tapping where the tab says to is the second tap.
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+    await expect(card).toHaveAttribute('data-selected', 'true')
+    await expect(page.getByText('Play this card')).toBeVisible()
+    // The peek is spent, so the tab goes with it.
+    await expect(page.getByTestId('card-act-brewery_2')).toHaveCount(0)
+
+    // Put the fixture back.
+    await card.tap()
+    await expect(page.getByText('Choose an action')).toBeVisible()
+  })
+
+  test('a card in play offers Put back', async ({ page }) => {
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await card.tap()
+    await card.tap()
+    await expect(card).toHaveAttribute('data-selected', 'true')
+
+    // A selected card acts on the first tap, so the peek that reveals its tab
+    // comes from the long-press browse.
+    const cbox = (await card.boundingBox())!
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [
+        { x: cbox.x + cbox.width / 2, y: cbox.y + cbox.height / 2 },
+      ],
+    })
+    const tab = page.getByTestId('card-act-brewery_2')
+    await expect(tab).toHaveText('Put back')
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchEnd',
+      touchPoints: [],
+    })
+    await expect(tab).toBeVisible()
+
+    // And the tap it advertises does exactly that.
+    await card.tap()
+    await expect(page.getByText('Choose an action')).toBeVisible()
+    await expect(card).not.toHaveAttribute('data-selected', 'true')
+  })
+
+  test('a card that cannot be played peeks, but promises nothing', async ({
+    page,
+  }) => {
+    // A Sell that has already flipped an industry can only be finished, so no
+    // other card is playable: the rest of the hand dims. A dimmed card still
+    // peeks (that is how a phone reads it) and must offer no tab.
+    await page.goto('/?demo=sell')
+    await page.getByTestId('action-sell').tap()
+    const played = page.locator('button.bb2-card:not([disabled])').first()
+    await played.tap()
+    await played.tap()
+    await page.getByTestId('sale-option').first().tap()
+    await page.getByTestId('beer-source').first().tap()
+    await expect(page.getByText(/Flipped 1 industry this action/)).toBeVisible()
+
+    const spare = page.locator('button.bb2-card[data-dimmed="true"]').first()
+    await expect(spare).toBeVisible()
+    // Playwright will not tap a disabled button, and neither does the app: the
+    // peek on a dimmed card comes from the seat wrapper around it.
+    const box = (await spare.boundingBox())!
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2)
+    await expect(spare).toHaveAttribute('data-raised', 'true')
+    await expect(page.locator('.bb2-card-act')).toHaveCount(0)
+  })
+
+  test('reduced motion: the tab still appears and still plays the card', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await card.tap()
+    const tab = page.getByTestId('card-act-brewery_2')
+    await expect(tab).toBeVisible()
+    await expect(tab).toHaveCSS('opacity', '1')
+    await card.tap()
+    await expect(page.getByText('Play this card')).toBeVisible()
   })
 })

--- a/e2e/hand-tray.spec.ts
+++ b/e2e/hand-tray.spec.ts
@@ -344,6 +344,69 @@ test.describe('phone: the peeked card names its own second tap', () => {
     await expect(page.getByText('Choose an action')).toBeVisible()
   })
 
+  test("an edge card's tab stays on the card, not on its neighbour", async ({
+    page,
+  }) => {
+    // A full 8-card hand at 390px is the tight case: the outermost card's
+    // magnified visual slides a long way inward to stay on screen, while the
+    // hitbox that takes the tap does not move with it.
+    await page.goto('/?fresh=1')
+    await page.getByTestId('mode-local').tap()
+    await page.getByRole('button', { name: '2', exact: true }).tap()
+    await page.getByRole('button', { name: 'Open the ledger' }).tap()
+
+    const cards = page.locator('button.bb2-card')
+    await expect(cards.first()).toBeVisible()
+    expect(await cards.count()).toBe(8)
+
+    // A packed fan buries every card's own centre under its right-hand
+    // neighbour, so the outermost cards are peeked by browsing to them: press
+    // the top card, hold, then slide past the end of the fan (the browse clamps
+    // to the edge card).
+    const last = (await cards.last().boundingBox())!
+    const cdp = await page.context().newCDPSession(page)
+    const browseTo = async (x: number) => {
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchStart',
+        touchPoints: [
+          { x: last.x + last.width / 2, y: last.y + last.height / 2 },
+        ],
+      })
+      await expect(cards.last()).toHaveAttribute('data-raised', 'true')
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x, y: last.y + last.height / 2 }],
+      })
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchEnd',
+        touchPoints: [],
+      })
+    }
+
+    for (const [card, browseX] of [
+      [cards.first(), 0],
+      [cards.last(), page.viewportSize()!.width],
+    ] as const) {
+      await browseTo(browseX)
+      const tab = page.locator('.bb2-card-act')
+      await expect(tab).toHaveText('Play')
+
+      const box = (await tab.boundingBox())!
+      const hit = (await card.boundingBox())!
+      expect(box.x).toBeGreaterThanOrEqual(hit.x)
+      expect(box.x + box.width).toBeLessThanOrEqual(hit.x + hit.width)
+    }
+
+    // And a tap where the tab says reaches THAT card, not the seat next door.
+    // Checked on the right-hand edge because the dev server this suite runs
+    // against parks Next's own dev-tools badge over the bottom-LEFT corner,
+    // where the leftmost card's tab sits at 390px.
+    const tab = (await page.locator('.bb2-card-act').boundingBox())!
+    await page.touchscreen.tap(tab.x + tab.width / 2, tab.y + tab.height / 2)
+    await expect(cards.last()).toHaveAttribute('data-selected', 'true')
+    await expect(page.getByText('Play this card')).toBeVisible()
+  })
+
   test('a card in play offers Put back', async ({ page }) => {
     await page.goto('/?demo')
     const card = page.getByTestId('card-brewery_2')

--- a/src/components/action-dock.tsx
+++ b/src/components/action-dock.tsx
@@ -31,7 +31,7 @@ import {
   pendingIronChoice,
 } from '~/store/shared/resourceSources'
 import { disabledActionReason } from './action-reason'
-import { CardChip, cardTitle } from './cards'
+import { CardChip } from './cards'
 import {
   doubleLinkDisabledReason,
   showsDoubleLinkOption,
@@ -237,68 +237,53 @@ interface ActionDockProps {
 /* ----- hand-selection contract for the shell / HandTray ----- */
 
 export interface HandSelection {
-  /** null = the tray says nothing; the hand is still live. */
-  hint: string | null
   selectedIds: string[]
 }
 
+/**
+ * Which hand cards the current step has in play — nothing else. The tray adds
+ * no words of its own: each surface narrates its own step in its own panel,
+ * and the fixed tray floats over whichever panel happens to be under it.
+ *
+ * Which cards are actually clickable is NOT decided here — the shell asks the
+ * machine (`state.can({SELECT_CARD, cardId})`) per card. That keeps one source
+ * of truth: on a pick step every hand card is selectable; once a card is
+ * committed only a DIFFERENT card is (the mid-flow switch), and a Sell that
+ * already flipped an industry offers none.
+ */
 export function getHandSelection(
   snapshot: GameStoreSnapshot,
 ): HandSelection | null {
   const is = (path: string) => snapshot.matches(path as never)
-  // A hint exists only while something is actually in flight. Idling, the
-  // hand is live (card-first: playing a card opens the actions it can start,
-  // the machine's cardSelected state) but the tray says nothing — the dock's
-  // own "Choose an action" panel is the narration for that state, and a tray
-  // label repeating it just covers whatever panel it happens to float over.
-  // Wording gotcha: no hint may contain "choose an action" (that dock title,
-  // pinned by e2e getByText, which substring-matches case-insensitively).
-  //
-  // Which cards are actually clickable at each step is NOT decided here — the
-  // shell asks the machine (`state.can({SELECT_CARD, cardId})`) per card. That
-  // keeps one source of truth: on a pick step every hand card is selectable;
-  // once a card is committed only a DIFFERENT card is (the mid-flow switch),
-  // and a Sell that already flipped an industry offers none.
-  if (is('playing.action.selectingAction'))
-    return { hint: null, selectedIds: [] }
+  // Card-first: the hand is live while idling — playing a card opens the
+  // actions it can start (the machine's cardSelected state).
+  if (is('playing.action.selectingAction')) return { selectedIds: [] }
   if (is('playing.action.cardSelected')) {
-    // Same "Holding <card>" wording as every deeper step: the held card is
-    // the only live state the tray adds here, and the dock already carries
-    // the title, the card chip and the Put back control.
     const held = snapshot.context.selectedCard
-    return {
-      hint: held ? `Holding ${cardTitle(held)}` : null,
-      selectedIds: held ? [held.id] : [],
-    }
+    return { selectedIds: held ? [held.id] : [] }
   }
-  if (is('playing.action.building.selectingCard'))
-    return { hint: 'Build — play a card from your hand', selectedIds: [] }
-  if (is('playing.action.networking.selectingCard'))
-    return { hint: 'Network — discard a card', selectedIds: [] }
-  if (is('playing.action.developing.selectingCard'))
-    return { hint: 'Develop — discard a card', selectedIds: [] }
-  if (is('playing.action.selling.selectingCard'))
-    return { hint: 'Sell — discard a card', selectedIds: [] }
-  if (is('playing.action.takingLoan.selectingCard'))
-    return { hint: 'Loan — discard a card', selectedIds: [] }
-  if (is('playing.action.scouting.selectingCards')) {
-    const picked = snapshot.context.selectedCardsForScout
+  if (is('playing.action.scouting.selectingCards'))
     return {
-      hint: `Scout — discard three cards (${picked.length}/3)`,
-      selectedIds: picked.map((c) => c.id),
+      selectedIds: snapshot.context.selectedCardsForScout.map((c) => c.id),
     }
-  }
+  if (
+    is('playing.action.building.selectingCard') ||
+    is('playing.action.networking.selectingCard') ||
+    is('playing.action.developing.selectingCard') ||
+    is('playing.action.selling.selectingCard') ||
+    is('playing.action.takingLoan.selectingCard')
+  )
+    return { selectedIds: [] }
   // Any deeper step of an action flow: the card is committed but still in
-  // play. Keep it lifted in the fan and named in the pill for the WHOLE flow
-  // (until confirm / cancel / put-back) so the player never loses sight of
-  // what they're spending. Derived from machine context, so it survives the
-  // multiplayer intent → broadcast → rebuild round-trip like every other
-  // selection signal. Clicking a DIFFERENT card here switches the play (the
-  // machine cancels the action and re-holds it, see `canSwitchHeldCard`).
+  // play. Keep it lifted in the fan for the WHOLE flow (until confirm /
+  // cancel / put-back) so the player never loses sight of what they're
+  // spending. Derived from machine context, so it survives the multiplayer
+  // intent → broadcast → rebuild round-trip like every other selection
+  // signal. Clicking a DIFFERENT card here switches the play (the machine
+  // cancels the action and re-holds it, see `canSwitchHeldCard`).
   if (is('playing.action')) {
     const held = snapshot.context.selectedCard
-    if (held)
-      return { hint: `Holding ${cardTitle(held)}`, selectedIds: [held.id] }
+    if (held) return { selectedIds: [held.id] }
   }
   return null
 }
@@ -652,20 +637,20 @@ function StepRail({ steps, active }: { steps: string[]; active: number }) {
 }
 
 /**
- * The held-card banner, shown the instant a card is committed and kept for the
- * whole action flow — the SAME "Holding <card>" wording in the card-first
- * chooser and every action-first step, so the two entry orders look identical
- * (captain's rule: the held card is named consistently regardless of order).
+ * The card this action is spending, shown the instant one is committed and kept
+ * for the whole flow — identically in the card-first chooser and every
+ * action-first step, so the two entry orders look the same.
+ *
+ * The chip alone: it sits under the flow's own title and beside the card lifted
+ * out of the fan, so a word introducing it would only restate what both
+ * already show.
  */
 function HeldCard({ card }: { card: Card | null | undefined }) {
   if (!card) return null
   return (
-    <div
-      className="flex items-center gap-2 text-[12px]"
-      style={{ color: 'rgba(231,215,177,.6)' }}
-      data-testid="held-card"
-    >
-      Holding <CardChip card={card} />
+    <div className="flex items-center gap-2" data-testid="held-card">
+      <span className="sr-only">Card in play:</span>
+      <CardChip card={card} />
     </div>
   )
 }

--- a/src/components/board/board-map.tsx
+++ b/src/components/board/board-map.tsx
@@ -1082,9 +1082,8 @@ export function BoardMap({
         {/* legend — hidden on phones: it is decorative, and at 390px it runs
           under the zoom controls and swallows the reset button, which is the
           one control a pinched-in player needs to find their way back.
-          Top-right, clear of the frame's bottom apron: the bottom-left corner
-          belongs to the hand tray's step label (.bb2-tray-label), and the
-          top-left to the map's own cartouche. */}
+          Top-right, clear of the frame's bottom apron, which belongs to the
+          hand tray, and of the top-left, which is the map's own cartouche. */}
         <div
           className="absolute right-3 top-3 z-10 hidden items-center gap-4 rounded border px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] sm:flex"
           style={{

--- a/src/components/game.tsx
+++ b/src/components/game.tsx
@@ -52,8 +52,8 @@ import { useHandOrder } from './hand-order'
 import { HandTray } from './hand-tray'
 import { computeHoverCities, focusCityFor } from './hover-highlight'
 import { IncomeTrackModal } from './income-track'
-import { LeaderShortcuts } from './leader-shortcuts'
 import { JournalPanel } from './journal'
+import { LeaderShortcuts } from './leader-shortcuts'
 import { legalCityTargets, legalLinkTargets } from './legal-targets'
 import { LocateCityProvider, useLocateCityState } from './locate'
 import { GameOverScreen, PassGate, RoundCurtain } from './overlays'
@@ -1024,7 +1024,6 @@ function GameInner({
             }
             onSelect={(cardId) => send({ type: 'SELECT_CARD', cardId })}
             selectedIds={handSel?.selectedIds ?? []}
-            hint={handSel?.hint ?? null}
             onHoverCard={setHoveredCard}
             panelCollapsed={panelCollapsed}
             onReorder={(cardId, toIndex) =>

--- a/src/components/hand-selection.test.ts
+++ b/src/components/hand-selection.test.ts
@@ -29,36 +29,61 @@ const wolverhampton: LocationCard = {
   color: 'other',
 }
 
+const dudley: LocationCard = {
+  id: 'loc-dudley-1',
+  type: 'location',
+  location: 'dudley',
+  color: 'other',
+}
+
+/** Every state the hand is live in, plus the two that end it. */
+const IN_FLOW = [
+  'playing.action.selectingAction',
+  'playing.action.cardSelected',
+  'playing.action.building.selectingCard',
+  'playing.action.building.selectingIndustryType',
+  'playing.action.building.selectingLocation',
+  'playing.action.building.confirmingBuild',
+  'playing.action.building.choosingIronSource',
+  'playing.action.networking.selectingCard',
+  'playing.action.networking.selectingLink',
+  'playing.action.networking.confirmingLink',
+  'playing.action.networking.choosingDoubleLinkBeer',
+  'playing.action.developing.selectingCard',
+  'playing.action.developing.selectingTiles',
+  'playing.action.selling.selectingCard',
+  'playing.action.selling.selectingSale',
+  'playing.action.selling.choosingBeerSource',
+  'playing.action.takingLoan.selectingCard',
+  'playing.action.scouting.selectingCards',
+]
+
 describe('getHandSelection — held card persists through the whole flow', () => {
-  test('card-first idle: hand live, but the tray says nothing', () => {
+  test('card-first idle: hand live, nothing lifted', () => {
     expect(getHandSelection(snap('playing.action.selectingAction'))).toEqual({
-      hint: null,
       selectedIds: [],
     })
   })
 
-  test('cardSelected: held card highlighted and named (put back / switch handled by machine)', () => {
-    const sel = getHandSelection(
-      snap('playing.action.cardSelected', { selectedCard: wolverhampton }),
-    )
-    expect(sel?.selectedIds).toEqual(['loc-wolverhampton-1'])
-    expect(sel?.hint).toBe('Holding Wolverhampton')
+  test('cardSelected: held card lifted (put back / switch handled by machine)', () => {
+    expect(
+      getHandSelection(
+        snap('playing.action.cardSelected', { selectedCard: wolverhampton }),
+      ),
+    ).toEqual({ selectedIds: ['loc-wolverhampton-1'] })
   })
 
-  test('deeper Network step keeps the card lifted and names it', () => {
+  test('deeper Network step keeps the card lifted', () => {
     expect(
       getHandSelection(
         snap('playing.action.networking.selectingLink', {
           selectedCard: wolverhampton,
         }),
       ),
-    ).toEqual({
-      hint: 'Holding Wolverhampton',
-      selectedIds: ['loc-wolverhampton-1'],
-    })
+    ).toEqual({ selectedIds: ['loc-wolverhampton-1'] })
   })
 
-  test('the indicator persists across every deeper step of a flow', () => {
+  test('the lift persists across every deeper step of a flow', () => {
     for (const path of [
       'playing.action.building.selectingIndustryType',
       'playing.action.building.selectingLocation',
@@ -74,35 +99,44 @@ describe('getHandSelection — held card persists through the whole flow', () =>
       const sel = getHandSelection(snap(path, { selectedCard: wolverhampton }))
       expect(sel, path).not.toBeNull()
       expect(sel?.selectedIds, path).toEqual(['loc-wolverhampton-1'])
-      expect(sel?.hint, path).toBe('Holding Wolverhampton')
     }
   })
 
-  test('an action-first discard step names the action, nothing held yet', () => {
+  test('an action-first discard step lifts nothing until a card is played', () => {
     expect(
       getHandSelection(snap('playing.action.networking.selectingCard')),
-    ).toEqual({ hint: 'Network — discard a card', selectedIds: [] })
+    ).toEqual({ selectedIds: [] })
   })
 
-  test('no hint ever restates the dock title', () => {
-    for (const path of [
-      'playing.action.selectingAction',
-      'playing.action.cardSelected',
-      'playing.action.building.selectingCard',
-      'playing.action.scouting.selectingCards',
-      'playing.action.networking.selectingLink',
-    ]) {
-      const sel = getHandSelection(snap(path, { selectedCard: wolverhampton }))
-      expect(sel?.hint?.toLowerCase() ?? '', path).not.toContain(
-        'choose an action',
+  test("Scout lifts every card picked so far, in the machine's own order", () => {
+    expect(
+      getHandSelection(
+        snap('playing.action.scouting.selectingCards', {
+          selectedCardsForScout: [wolverhampton, dudley],
+        }),
+      ),
+    ).toEqual({ selectedIds: ['loc-wolverhampton-1', 'loc-dudley-1'] })
+  })
+
+  test('the tray contributes no words in any state', () => {
+    // The fixed tray floats over whichever panel is beneath it, so it carries
+    // no narration of its own: each surface names its own step in its own
+    // panel. A label added back here would be a string on this contract.
+    for (const path of IN_FLOW) {
+      const sel = getHandSelection(
+        snap(path, {
+          selectedCard: wolverhampton,
+          selectedCardsForScout: [wolverhampton],
+        }),
       )
+      expect(Object.keys(sel ?? {}), path).toEqual(['selectedIds'])
     }
   })
 
-  test('the held hint is order-independent: a deep step reached action-first reads identically', () => {
+  test('the lift is order-independent: a deep step reached action-first reads identically', () => {
     // getHandSelection keys off the current state + selectedCard only — never
-    // how the state was reached — so action-first and card-first converge to
-    // the same "Holding <name>" the instant a card is committed.
+    // how the state was reached — so action-first and card-first converge on
+    // the same lifted card the instant one is committed.
     const cardFirst = getHandSelection(
       snap('playing.action.networking.selectingLink', {
         selectedCard: wolverhampton,
@@ -113,8 +147,8 @@ describe('getHandSelection — held card persists through the whole flow', () =>
         selectedCard: wolverhampton,
       }),
     )
-    expect(cardFirst?.hint).toBe('Holding Wolverhampton')
-    expect(actionFirst?.hint).toBe('Holding Wolverhampton')
+    expect(cardFirst).toEqual({ selectedIds: ['loc-wolverhampton-1'] })
+    expect(actionFirst).toEqual(cardFirst)
   })
 
   test('outside any action flow → null', () => {

--- a/src/components/hand-tray-layout.test.ts
+++ b/src/components/hand-tray-layout.test.ts
@@ -9,6 +9,7 @@ import {
   MIN_SPACING,
   PHONE_HAND_SCALE,
   actTabLayout,
+  actTabShiftX,
   cardIndexAtX,
   dockShift,
   fanLayout,
@@ -241,6 +242,29 @@ describe('actTabLayout', () => {
         lens.rise + (CARD_H * lens.scale) / 2,
       )
     }
+  })
+})
+
+describe('actTabShiftX', () => {
+  const tab = actTabLayout(LENS_COARSE)
+
+  it("never carries the tab out of the card's hitbox", () => {
+    // An edge card's lens slides a long way inward to stay on screen; the
+    // hitbox that takes the tap does not move with it.
+    const width = 541 // 390px phone at the tray's own scale
+    const { spacing } = fanLayout(8, width)
+    const lensShift = lensShiftX(0, 8, spacing, width, LENS_COARSE.scale)
+    expect(lensShift).toBeGreaterThan((CARD_W - tab.width) / 2)
+
+    const shift = actTabShiftX(lensShift, tab)
+    expect(Math.abs(shift) + tab.width / 2).toBeLessThanOrEqual(CARD_W / 2)
+  })
+
+  it('follows a small shift exactly, and both directions', () => {
+    expect(actTabShiftX(0, tab)).toBe(0)
+    expect(actTabShiftX(2, tab)).toBe(2)
+    expect(actTabShiftX(-2, tab)).toBe(-2)
+    expect(actTabShiftX(-99, tab)).toBe(-(CARD_W - tab.width) / 2)
   })
 })
 

--- a/src/components/hand-tray-layout.test.ts
+++ b/src/components/hand-tray-layout.test.ts
@@ -7,6 +7,8 @@ import {
   LENS_FINE,
   LENS_SELECTED,
   MIN_SPACING,
+  PHONE_HAND_SCALE,
+  actTabLayout,
   cardIndexAtX,
   dockShift,
   fanLayout,
@@ -188,6 +190,54 @@ describe('moveHandleLayout', () => {
       const { size, bottom } = moveHandleLayout(lens, lens === LENS_COARSE)
       // Handle centre === lens centre: rise + half the magnified height.
       expect(bottom + size / 2).toBeCloseTo(
+        lens.rise + (CARD_H * lens.scale) / 2,
+      )
+    }
+  })
+})
+
+describe('actTabLayout', () => {
+  it('rides inside the lower edge of the magnified card', () => {
+    for (const lens of [LENS_FINE, LENS_COARSE]) {
+      const { bottom } = actTabLayout(lens)
+      // lens.rise IS the magnified visual's bottom edge (transform-origin
+      // 50% 100%), and the tab sits above it — the tray already overhangs the
+      // bottom of the screen, so a tab hanging below the card would land on
+      // the edge.
+      expect(bottom).toBeGreaterThan(lens.rise)
+    }
+  })
+
+  it('is a thumb-sized target once the tray has scaled itself down', () => {
+    // Layout px are pre-scale: on a phone the whole fan is drawn at
+    // PHONE_HAND_SCALE, so that is the size a finger actually gets.
+    const { height, width } = actTabLayout(LENS_COARSE)
+    expect(height * PHONE_HAND_SCALE).toBeGreaterThanOrEqual(44)
+    expect(width * PHONE_HAND_SCALE).toBeGreaterThanOrEqual(44)
+  })
+
+  it("stays inside the card's hitbox, which is what takes the tap", () => {
+    for (const lens of [LENS_FINE, LENS_COARSE]) {
+      const tab = actTabLayout(lens)
+      // Horizontally within the 108px button, and vertically within the
+      // upward ::after extension that covers the magnified visual.
+      expect(tab.width).toBeLessThan(CARD_W)
+      expect(tab.bottom + tab.height).toBeLessThan(lensReach(lens) + CARD_H)
+    }
+  })
+
+  it('clears the reorder handles, which flank the same card', () => {
+    for (const lens of [LENS_FINE, LENS_COARSE]) {
+      const tab = actTabLayout(lens)
+      const handles = moveHandleLayout(lens, lens === LENS_COARSE)
+      expect(tab.bottom + tab.height).toBeLessThan(handles.bottom)
+    }
+  })
+
+  it('leaves the centred artwork on the card face uncovered', () => {
+    for (const lens of [LENS_FINE, LENS_COARSE]) {
+      const tab = actTabLayout(lens)
+      expect(tab.bottom + tab.height).toBeLessThan(
         lens.rise + (CARD_H * lens.scale) / 2,
       )
     }

--- a/src/components/hand-tray-layout.ts
+++ b/src/components/hand-tray-layout.ts
@@ -172,6 +172,51 @@ export function moveHandleShiftX(
   return 0
 }
 
+/** Smallest comfortable touch target, CSS px. */
+const TOUCH_MIN_PX = 44
+/** Tray scale on a phone — mirrors --bb-hand-scale in theme.css. */
+export const PHONE_HAND_SCALE = 0.72
+/**
+ * Height of the act tab on a peeked card, LAYOUT px. Everything in this module
+ * is measured before the tray scales itself down, so a tab sized to the touch
+ * minimum directly would land at 30 real px on a phone.
+ */
+const ACT_TAB_H = Math.ceil(TOUCH_MIN_PX / PHONE_HAND_SCALE)
+/** Side margin between the tab and the edges of the card's hitbox. */
+const ACT_TAB_INSET_X = 4
+/** How far the tab sits inside the magnified visual's lower edge. */
+const ACT_TAB_INSET_Y = 14
+
+export interface ActTabLayout {
+  /** Tab height. */
+  height: number
+  /** Tab width. */
+  width: number
+  /** Offset of the tab's bottom edge above the seat's bottom edge. */
+  bottom: number
+}
+
+/**
+ * Where the act tab sits on a peeked card — the label that says what a second
+ * tap will do, because touch has no hover to reveal it. It rides just inside
+ * the LOWER edge of the magnified visual: on the card, so it plainly belongs
+ * to it, but below the centred artwork and clear of the ◀ ▶ reorder handles,
+ * which flank the card's middle. Low is deliberate — it keeps the tab under the
+ * thumb that just tapped — but not so low that it lands on the screen edge the
+ * tray already overhangs.
+ *
+ * It stays INSIDE the card's own 108-wide hitbox, because the card is what
+ * takes the tap: the tab is the target the finger aims at, and the button
+ * beneath it is the one that acts.
+ */
+export function actTabLayout(lens: LensPreset): ActTabLayout {
+  return {
+    height: ACT_TAB_H,
+    width: CARD_W - 2 * ACT_TAB_INSET_X,
+    bottom: lens.rise + ACT_TAB_INSET_Y,
+  }
+}
+
 /** How far above its seat the magnified visual reaches, layout px. */
 export function lensReach(lens: LensPreset): number {
   return lens.rise + CARD_H * (lens.scale - 1)

--- a/src/components/hand-tray-layout.ts
+++ b/src/components/hand-tray-layout.ts
@@ -217,6 +217,19 @@ export function actTabLayout(lens: LensPreset): ActTabLayout {
   }
 }
 
+/**
+ * Horizontal placement of the act tab, from the shift its lens already took.
+ * It follows that clamp only as far as its own side margin allows: the lens can
+ * slide a long way inward on an edge card, while the hitbox that takes the tap
+ * neither moves nor grows sideways — so a tab carried the whole way would hang
+ * over the seat next door, and a finger aiming at the label would land on the
+ * wrong card.
+ */
+export function actTabShiftX(lensShift: number, tab: ActTabLayout): number {
+  const slack = (CARD_W - tab.width) / 2
+  return Math.max(-slack, Math.min(slack, lensShift))
+}
+
 /** How far above its seat the magnified visual reaches, layout px. */
 export function lensReach(lens: LensPreset): number {
   return lens.rise + CARD_H * (lens.scale - 1)

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -39,6 +39,7 @@ import {
   LENS_FINE,
   LENS_SELECTED,
   actTabLayout,
+  actTabShiftX,
   cardIndexAtX,
   dockShift,
   fanAngle,
@@ -543,7 +544,7 @@ export function HandTray({
                     bottom: `${actTab.bottom}px`,
                     height: `${actTab.height}px`,
                     width: `${actTab.width}px`,
-                    transform: `translateX(calc(-50% + ${lensShiftX(i, n, spacing, fanWidth, lens.scale)}px)) rotate(${-angle}deg)`,
+                    transform: `translateX(calc(-50% + ${actTabShiftX(lensShiftX(i, n, spacing, fanWidth, lens.scale), actTab)}px)) rotate(${-angle}deg)`,
                   }}
                 >
                   {actLabel}

--- a/src/components/hand-tray.tsx
+++ b/src/components/hand-tray.tsx
@@ -10,6 +10,16 @@
 // the card under the finger peeked). A selected card keeps a smaller
 // persistent lens. Pure geometry lives in hand-tray-layout.ts.
 //
+// A PEEKED card carries an act tab ("Play" / "Put back") on its lower edge.
+// The peek exists because touch has no hover — it is how a phone reads a card
+// out of a fan packed to a 26px sliver — so the tap that ACTS is a second one,
+// and the tab is what says so: a target the finger can aim at instead of an
+// invisible repeat. It is a LABEL, not a control (pointer-events: none, inside
+// the card's own hitbox): the card takes the tap either way, which keeps one
+// control per card and leaves the card's tap point clear, exactly as the ◀ ▶
+// handles do. Hover and keyboard focus never show it — they already act on the
+// first click, and the tab keys off `peekedId`, which only touch ever sets.
+//
 // The fan is also REORDERABLE (display only — see hand-order.ts; the engine's
 // hand is never touched). Which ways in depend on the pointer, because the
 // tray's pointer budget is already spent: on DESKTOP (fine pointer) a mouse
@@ -28,6 +38,7 @@ import {
   LENS_COARSE,
   LENS_FINE,
   LENS_SELECTED,
+  actTabLayout,
   cardIndexAtX,
   dockShift,
   fanAngle,
@@ -70,7 +81,6 @@ export interface HandTrayProps {
   canSelect: ((cardId: string) => boolean) | null
   onSelect?: (cardId: string) => void
   selectedIds?: string[]
-  hint?: string | null
   /** Hover preview: the shell highlights the card's targets on the map. */
   onHoverCard?: (card: GameCard | null) => void
   /** Right dock collapsed — the tray extends toward the reclaimed edge. */
@@ -87,7 +97,6 @@ export function HandTray({
   canSelect,
   onSelect,
   selectedIds = [],
-  hint,
   onHoverCard,
   panelCollapsed = false,
   onReorder,
@@ -192,6 +201,7 @@ export function HandTray({
   const lens = coarse ? LENS_COARSE : LENS_FINE
   const { spacing, marginX } = fanLayout(n, fanWidth)
   const handles = moveHandleLayout(lens, coarse)
+  const actTab = actTabLayout(lens)
 
   // Long-press browse: once the hold fires, sliding moves the raised
   // highlight to the card whose resting seat is under the finger; releasing
@@ -283,19 +293,6 @@ export function HandTray({
         panelCollapsed ? 'lg:right-[44px]' : 'lg:right-[428px]'
       }`}
     >
-      {hint && (
-        // The tray's own label, anchored to the band's left edge — never a
-        // floating pill over the middle of the board. Absolutely positioned,
-        // so it reserves no height and can never move the hand: the fan
-        // keeps a constant layout whether or not a hint is showing. On
-        // phones it rides the band's top edge (over the scrolling panel,
-        // not the board); on desktop it sits in the board frame's bottom
-        // apron, which the map never paints into (see .bb2-tray-label).
-        // Click-transparent like the rest of the tray.
-        <div className="bb2-tray-label" data-testid="hand-hint">
-          {hint}
-        </div>
-      )}
       <div
         ref={fanRef}
         className="bb2-hand bb2-handbox"
@@ -311,6 +308,19 @@ export function HandTray({
           const disabled = selecting ? !enabled : true
           const raised = i === raisedIndex
           const dragging = draggingId === card.id
+          // `peekedId` is only ever set by touch, so it is exactly the state
+          // whose next tap acts — what the act tab is there to advertise.
+          const actLabel =
+            peekedId === card.id && enabled
+              ? selected
+                ? 'Put back'
+                : 'Play'
+              : null
+          /** The second tap's effect, shared by the card and its act tab. */
+          const act = () => {
+            if (peekedId) setPeek(null)
+            onSelect?.(card.id)
+          }
           const shift = dockShift(
             i,
             raisedIndex === -1 ? null : raisedIndex,
@@ -419,10 +429,7 @@ export function HandTray({
                     setPeek(card)
                     return
                   }
-                  if (enabled) {
-                    if (peekedId) setPeek(null)
-                    onSelect?.(card.id)
-                  }
+                  if (enabled) act()
                 }}
                 onKeyDown={(e) => {
                   // Shift+Arrow, not a bare arrow: bare arrows are how a
@@ -518,6 +525,28 @@ export function HandTray({
                       <span aria-hidden>{glyph}</span>
                     </button>
                   ))}
+                </span>
+              )}
+              {/* What the next tap does, on the card it will do it to. Sized
+                and placed by actTabLayout; counter-rotated out of the fan's
+                tilt so the label reads straight, and shifted with the same
+                edge clamp as the lens it rides. Hidden from assistive tech:
+                nothing reaches a peek without a pointer, and the card button
+                is the only control here. */}
+              {actLabel && !draggingId && (
+                <span
+                  className="bb2-card-act"
+                  data-testid={`card-act-${card.id}`}
+                  data-variant={selected ? 'back' : undefined}
+                  aria-hidden
+                  style={{
+                    bottom: `${actTab.bottom}px`,
+                    height: `${actTab.height}px`,
+                    width: `${actTab.width}px`,
+                    transform: `translateX(calc(-50% + ${lensShiftX(i, n, spacing, fanWidth, lens.scale)}px)) rotate(${-angle}deg)`,
+                  }}
+                >
+                  {actLabel}
                 </span>
               )}
             </span>

--- a/src/components/mp/mp-game.tsx
+++ b/src/components/mp/mp-game.tsx
@@ -1854,7 +1854,6 @@ function MpTable({
           }
           onSelect={(cardId) => send({ type: 'SELECT_CARD', cardId })}
           selectedIds={handSel?.selectedIds ?? []}
-          hint={handSel?.hint ?? null}
           onHoverCard={setHoveredCard}
           panelCollapsed={panelCollapsed}
           onReorder={(cardId, toIndex) =>

--- a/src/components/theme.css
+++ b/src/components/theme.css
@@ -565,8 +565,8 @@ button.bb2-card {
 /* The tray sizes cards by scaling the whole fan; the width compensates the
  * scale (100% / s) so the usable layout width stays the full viewport —
  * without it a phone tray would waste 28% of an already-narrow screen.
- * The scale lives on the tray root, not the box, so the step label
- * (.bb2-tray-label, a sibling of the fan) can anchor to the scaled band. */
+ * The scale lives on the tray root, not the box, so a sibling of the fan can
+ * anchor to the scaled band. */
 .bb2-handtray {
   --bb-hand-scale: 0.72;
 }
@@ -577,46 +577,6 @@ button.bb2-card {
   transform-origin: bottom center;
   transform: scale(var(--bb-hand-scale));
   width: calc(100% / var(--bb-hand-scale));
-}
-/* The tray's own step label, shown only while an action is in flight.
- * Absolutely positioned so it reserves no height — the fan never moves when
- * it appears or disappears (a hint that resized the tray would reintroduce
- * the jumping-hand regression PR #81 fixed).
- * It floats over whatever is beneath the fixed tray, so an idle label would
- * sit on a scrolling panel's heading for the whole turn; each surface
- * narrates its own idle state instead.
- * On phones it rides the top edge of the (scaled) card band, which overlays
- * the scrolling panel there, never the board. On desktop the band sits in
- * the board frame's bottom apron (the pb-[84px] strip the map never paints
- * into), so the label drops to the tray's bottom-left corner beside the
- * fan. It paints ABOVE the cards: a selected card keeps its lens for the
- * whole flow and would otherwise sit on the label for the whole flow too.
- * Click-transparent (the tray root is), so covering a card costs no tap. */
-.bb2-tray-label {
-  position: absolute;
-  z-index: 1;
-  left: 12px;
-  bottom: calc(150px * var(--bb-hand-scale) - 16px);
-  /* Every step's label fits a 390px phone at this width; a narrower cap
-   * ellipsised the Build and Scout steps mid-word. */
-  max-width: calc(100% - 24px);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  padding: 3px 8px;
-  border-radius: 3px;
-  border: 1px solid var(--bb-brass-hairline);
-  background: rgba(20, 16, 11, 0.88);
-  color: var(--bb-brass-bright);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-}
-@media (min-width: 1024px) {
-  .bb2-tray-label {
-    bottom: 10px;
-  }
 }
 @media (min-width: 640px) {
   .bb2-handtray {
@@ -713,11 +673,65 @@ button.bb2-card {
   cursor: default;
 }
 
+/* The act tab on a peeked card: the poured brass of every other committing
+ * control in the game (.bb2-confirm), so it reads as "this plays it" at a
+ * glance, and the dark ghost treatment when the tap would put the card BACK.
+ * Rides inside the magnified visual's lower edge (actTabLayout) — geometry is
+ * inline, this is only the chrome. Click-transparent on purpose: it sits within
+ * the card's own hitbox, so the tap it invites lands on the card, and the card
+ * stays the single control (a button on a button is neither). */
+.bb2-card-act {
+  position: absolute;
+  left: 50%;
+  z-index: 4;
+  pointer-events: none;
+  display: grid;
+  place-items: center;
+  padding: 0 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  border: 1px solid #7a5c22;
+  background: linear-gradient(
+    180deg,
+    #ecc568 0%,
+    #c99b3f 45%,
+    #a87d2c 55%,
+    #c79e46 100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 245, 210, 0.7), 0 6px 16px
+    rgba(0, 0, 0, 0.6);
+  color: #241a08;
+  font-family: var(--bb-display);
+  /* Type is in layout px too — the tray scales the whole fan down. */
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  white-space: nowrap;
+  animation: bb2-act-in 0.16s ease-out both;
+}
+.bb2-card-act[data-variant="back"] {
+  border-color: var(--bb-brass);
+  background: rgba(20, 16, 11, 0.94);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.6);
+  color: var(--bb-brass-bright);
+  font-size: 16px;
+}
+/* Opacity only: the tab's transform carries its placement, inline. */
+@keyframes bb2-act-in {
+  from {
+    opacity: 0;
+  }
+}
+
 /* Magnification is decorative; motion-sensitive players get the end state. */
 @media (prefers-reduced-motion: reduce) {
   .bb2-card-seat,
   .bb2-card-lens {
     transition: none;
+  }
+  .bb2-card-act {
+    animation: none;
   }
 }
 


### PR DESCRIPTION
Two complaints about the same strip of screen, both from playing on a phone.

## 1. The tray's text label is gone

> "the label is unnecessary, it is already obvious what you are holding."

It is. The card is lifted out of the fan with its face showing, and the dock names it in the panel that owns the step. So the tray carries **no text label in any state** now — it shows cards, and that is all. `HandSelection` is down to `{ selectedIds }`, `.bb2-tray-label` is gone with it.

Nothing was lost with it. Every string it used to show, the dock already shows in the panel that owns the step: `Network` + the step rail + *"Discard any card from your hand below to open a route"*, Scout's own `(2/3 chosen)`, and so on. The tray's copy had the specific problem that it is **fixed** while the panel column scrolls beneath it, so whatever it said ended up sitting on some panel's heading for the whole turn.

The dock's own chip lost its introducing word for the same reason — it sits directly under the flow's title and beside the lifted card, so `Holding` was the third thing in a row saying the same thing. The chip stays (`data-testid="held-card"`), and its sighted-user text is now just the card.

## 2. The real bug: on touch, the second tap was invisible

On a phone the first tap on a hand card only **peeks** it — raises and magnifies it, and drives the map's target preview. The second tap plays it. Nothing said so, so you had to work it out.

**I kept the two stages and made the second one visible, rather than collapsing to one tap.** The reason is the fan: at 390px eight cards pack down to a 26px sliver each, so raising a card is the only way to *read* one. A single tap that played the card would mean you cannot look at a card without spending it — and it would hand the map preview to a card that is already committed. The stage was right; the sign was missing.

So a peeked card now carries a brass tab on its lower face naming what the next tap does: **Play**, or **Put back** for a card already in play.

| idle | peeked | played |
|---|---|---|
| <img src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr115-idle.png" width="260" alt="idle hand at 390px, no tray label"> | <img src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr115-peeked.png" width="260" alt="a peeked card showing the brass Play tab"> | <img src="https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr115-played.png" width="260" alt="the card played: lifted in the fan, named by the dock chip"> |

Design notes:

- **It is a label, not a control.** `pointer-events: none`, `aria-hidden`, and sized to sit *inside* the card's own 108px hitbox — so the card takes the tap either way, there is one control per card, and the card's tap point stays clear. That is the same rule the ◀ ▶ reorder handles already follow, and Playwright enforces it: a button overlapping the card makes `card.tap()` fail with "intercepts pointer events". Tapping exactly where the tab says still plays the card, which is the only thing it promises.
- **Poured brass, because that is what committing looks like here** — the same gradient as `.bb2-confirm`, every other "this spends something" control in the game. The put-back direction takes the dark ghost treatment, matching the dock's own Put back button. No new colours.
- **Sized for a thumb, not for the stylesheet.** Layout px in `hand-tray-layout.ts` are pre-scale — the tray draws the whole fan at 0.72 on a phone — so the tab is sized 44/0.72 to end up a real 44px target, and its type is scaled the same way. That was a live bug in the first cut: 42px "looked right" in the module and arrived on screen at 30px.
- **Shadcn-first, and it lands on a hand-rolled element deliberately.** The nearest primitive is `Button`, but this is a click-transparent label on a rotated, scaled SVG-less card inside a fan, dressed in the board's period brass; a shadcn `Button` here would be a `Button` with every colour and typography class overridden, which the styling rules forbid outright. The repo carries only `ui/sonner.tsx` for the same reason, and the in-repo primitive this matches — `.bb2-card-movebtn`, a control that appears on the raised card on touch — already exists.
- Mouse and keyboard never see the tab (they act on the first click, and have hover / `:focus-visible` to preview with). A card that cannot be played offers no tab, which is information too: dimmed and silent means "not this one, not now". The fade-in is dropped under `prefers-reduced-motion`.

## Verification

Judged at a **390px touch-emulated viewport with real touch events**, not a narrow desktop window — a mouse-driven narrow window has hover and hides the whole problem.

Pinned by tests, with the touch path driven by real touch (`hasTouch` + `isMobile`; `isMobile` is what makes `(pointer: coarse)` match) and raw CDP touch for the gestures Playwright's API cannot express:

- `e2e/hand-tray.spec.ts` — the tab appears on a peek and not otherwise; it is ≥44px, wholly on screen and wholly inside the card's hitbox; the tap it invites plays the card; **a browse release still never acts** even with the tab under the finger; a card in play offers Put back; a dimmed card offers nothing; reduced motion keeps it visible and working; mouse hover and keyboard focus get no tab and act on their first input.
- `hand-tray-layout.test.ts` — placement (inside the lower edge, clear of the reorder handles, off the centred artwork), the touch-target size *after* the tray's own scale, and containment inside the hitbox.
- `hand-selection.test.ts` — the tray contract carries no string in any state, so a label cannot creep back in unnoticed.
- `e2e/card-first.spec.ts` — repointed: the held card is proven by the fan's lift and the dock's chip, and no tray label exists at any step of the flow.

Full suite green locally: 894 unit tests, 77 e2e (`pnpm test`, `pnpm exec playwright test`, `pnpm lint`, `pnpm typecheck`).

**Reviewed pre-push by `codex review` (gpt-5.6-luna, xhigh).** It caught a real one: the tab followed the magnified lens's edge clamp, which on a full 8-card hand at 390px slides the outermost card's visual ~19px inward while the hitbox stays put — so part of the tab hung over the seat next door and a finger aiming at the label could have acted on the wrong card. Fixed in the second commit (`actTabShiftX`), pinned at both the unit and the e2e level (the edge-card case now browses to the outermost card and checks containment on both ends). No other findings.

Follows on from #113, which is in `main`; this keeps its good half (idle narration belongs to the dock) and removes the label it left behind.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added touch-friendly action tabs to peeked cards, clearly indicating “Play” or “Put back.”
  * Improved mobile card interactions, including accurate edge-card targeting and support for reduced-motion settings.
  * Added keyboard support for selecting and playing focused cards.

* **UI Improvements**
  * Replaced the “Holding…” banner with a compact card chip in the hand tray.
  * Removed redundant hand-tray narration and step labels.
  * Preserved card selection across action flows with clearer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->