### PR TITLE
fix(ui): scroll a held card's action list into view on phones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -699,8 +699,15 @@ What this means in practice:
   On phones a wizard step change scrolls the surface that owns the next tap
   into view (`step-scroll.ts` pure decision + `use-step-scroll.ts` applied
   half; 2s don't-fight-the-player window, `prefers-reduced-motion` honoured,
-  no-op on lg). The board legend sits top-right, clear of the frame's bottom
-  apron, which belongs to the hand tray.
+  no-op on lg). It is driven by the MACHINE's step and nothing else — that is
+  what keeps a touch PEEK (`hand-tray.tsx`'s local `peekedId`, no event) from
+  yanking the view while a player is only reading a card; a tap-handler scroll
+  would. Holding a card (`playing.action.cardSelected`) is a dock step: the
+  action list it can start is the next tap, and on a phone that panel sits
+  below the board. It scrolls only, never moves focus — the played card keeps
+  it, so an assistive cursor is not thrown into the dock mid-turn. The board
+  legend sits top-right, clear of the frame's bottom apron, which belongs to
+  the hand tray.
 - Boot order in `game.tsx` (client-side, behind a mount gate):
   `/?preview=gameover` → `/?era=rail` (rail fixture) → `/?demo` (canal
   fixture) → `/?fresh=1` → localStorage save (`bb2-save-v1`) → setup

--- a/e2e/step-scroll.spec.ts
+++ b/e2e/step-scroll.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * Phone step-scrolling (offline, ?demo fixture).
+ *
+ * On a phone the board takes the top of the screen and the action dock sits
+ * below it, mostly under the fold and under the fixed hand tray. Committing a
+ * hand card opens the list of actions that card can start — in the dock — so
+ * the dock is scrolled into view.
+ *
+ * The tap model it has to respect (see hand-tray.spec.ts): the first tap only
+ * PEEKS a card so it can be read, the second one plays it. The scroll is driven
+ * by the machine's step, which is what keeps a peek from moving the view — a
+ * peek sends no event.
+ */
+test.describe('phone: the held card brings its action list on screen', () => {
+  test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+  })
+
+  const dockPanel = (page: import('@playwright/test').Page) =>
+    page.getByTestId('side-panel').locator('.bb2-panel-active')
+
+  test('peeking moves nothing; playing the card scrolls the dock into view', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await expect(card).toBeVisible()
+
+    // At rest the dock's top edge is below the fold.
+    const before = (await dockPanel(page).boundingBox())!
+    expect(before.y).toBeGreaterThan(page.viewportSize()!.height / 2)
+    expect(await page.evaluate(() => window.scrollY)).toBe(0)
+
+    // First tap: a peek. No machine event, so nothing scrolls.
+    await card.tap()
+    await expect(card).toHaveAttribute('data-raised', 'true')
+    await page.waitForTimeout(600)
+    expect(await page.evaluate(() => window.scrollY)).toBe(0)
+
+    // Second tap: the card is committed and the dock arrives.
+    await card.tap()
+    await expect(page.getByText('Play this card')).toBeVisible()
+    await expect
+      .poll(async () => (await dockPanel(page).boundingBox())!.y, {
+        timeout: 4000,
+      })
+      .toBeLessThan(80)
+    // Landed at the top of the viewport rather than past it.
+    expect((await dockPanel(page).boundingBox())!.y).toBeGreaterThan(-2)
+    const title = (await page.getByText('Play this card').boundingBox())!
+    expect(title.y).toBeGreaterThan(0)
+    expect(title.y + title.height).toBeLessThan(page.viewportSize()!.height)
+
+    // Scrolling only: the tap keeps its focus. Moving it into the dock would
+    // yank a screen reader's cursor off the card the player just played.
+    expect(
+      await page.evaluate(
+        () =>
+          !!document.activeElement &&
+          document
+            .querySelector('[data-testid="side-panel"]')
+            ?.contains(document.activeElement),
+      ),
+    ).toBe(false)
+  })
+
+  test('a player who has just scrolled keeps their position', async ({
+    page,
+  }) => {
+    await page.goto('/?demo')
+    const card = page.getByTestId('card-brewery_2')
+    await expect(card).toBeVisible()
+
+    // Peek first, so only the committing tap has to land inside the
+    // suppression window (a wheel is not a pointerdown, so it keeps the peek).
+    await card.tap()
+    await expect(card).toHaveAttribute('data-raised', 'true')
+
+    await page.mouse.wheel(0, 300)
+    await expect
+      .poll(async () => page.evaluate(() => window.scrollY))
+      .toBeGreaterThan(0)
+    const parked = await page.evaluate(() => window.scrollY)
+
+    await card.tap()
+    await expect(page.getByText('Play this card')).toBeVisible()
+    await page.waitForTimeout(800)
+    expect(await page.evaluate(() => window.scrollY)).toBe(parked)
+  })
+})

--- a/src/components/step-scroll.test.ts
+++ b/src/components/step-scroll.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { createActor } from 'xstate'
+import type { Card } from '../data/cards'
+import { getInitialPlayerIndustryTilesWithQuantities } from '../data/industryTiles'
+import { gameStore } from '../store/gameStore'
 import {
   SCROLL_SUPPRESS_MS,
   shouldStepScroll,
@@ -17,6 +21,12 @@ describe('stepScrollTarget', () => {
     expect(stepScrollTarget(matchesOnly(step))).toBe('board')
   })
 
+  it('a committed card is a dock step — the action list is the next tap', () => {
+    expect(stepScrollTarget(matchesOnly('playing.action.cardSelected'))).toBe(
+      'dock',
+    )
+  })
+
   it.each([
     'playing.action.building.confirmingBuild',
     'playing.action.networking.confirmingLink',
@@ -33,7 +43,7 @@ describe('stepScrollTarget', () => {
     expect(stepScrollTarget(matchesOnly(step))).toBe('dock')
   })
 
-  it('card-pick and develop steps move nothing (tray is fixed, modal covers)', () => {
+  it('card-PICK and develop steps move nothing (tray is fixed, modal covers)', () => {
     for (const step of [
       'playing.action.selectingAction',
       'playing.action.building.selectingCard',
@@ -94,5 +104,119 @@ describe('shouldStepScroll', () => {
         lastUserScrollAt: base.now - SCROLL_SUPPRESS_MS,
       }),
     ).toBe(true)
+  })
+})
+
+/**
+ * The peek/commit split, pinned against the real machine.
+ *
+ * On touch the first tap only PEEKS a card (`hand-tray.tsx` local state, no
+ * event) and the second one plays it. The scroll therefore has to be driven by
+ * the machine's state, which is what makes a peek incapable of moving the view:
+ * no event, no step change, nothing to scroll to.
+ */
+describe('the scroll target follows the machine, not a tap', () => {
+  const coalCard = {
+    id: 'ss_ind_coal',
+    type: 'industry',
+    industries: ['coal'],
+  } as Card
+
+  const targetOf = (snapshot: { matches: (p: never) => boolean }) =>
+    stepScrollTarget((p: never) => snapshot.matches(p))
+
+  const startedGame = () => {
+    const actor = createActor(gameStore)
+    actor.start()
+    actor.send({
+      type: 'START_GAME',
+      players: [
+        {
+          id: '1',
+          name: 'Scroll One',
+          money: 30,
+          victoryPoints: 0,
+          income: 10,
+          color: 'red' as const,
+          character: 'Richard Arkwright' as const,
+          industryTilesOnMat: getInitialPlayerIndustryTilesWithQuantities(),
+        },
+        {
+          id: '2',
+          name: 'Scroll Two',
+          money: 30,
+          victoryPoints: 0,
+          income: 10,
+          color: 'green' as const,
+          character: 'Eliza Tinsley' as const,
+          industryTilesOnMat: getInitialPlayerIndustryTilesWithQuantities(),
+        },
+      ],
+    })
+    actor.send({
+      type: 'TEST_SET_PLAYER_HAND',
+      playerId: actor.getSnapshot().context.currentPlayerIndex,
+      hand: [coalCard],
+    })
+    return actor
+  }
+
+  it('holding a card lands on the dock; a peek sends nothing so nothing moves', () => {
+    const actor = startedGame()
+
+    // Idle — and a peek leaves the machine exactly here.
+    const idle = actor.getSnapshot()
+    expect(idle.matches({ playing: { action: 'selectingAction' } })).toBe(true)
+    expect(targetOf(idle)).toBeNull()
+    expect(stepKey((p: never) => idle.matches(p))).toBeNull()
+
+    // The committing tap.
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    const held = actor.getSnapshot()
+    expect(held.matches({ playing: { action: 'cardSelected' } })).toBe(true)
+    expect(targetOf(held)).toBe('dock')
+    expect(stepKey((p: never) => held.matches(p))).toBe(
+      'playing.action.cardSelected',
+    )
+
+    // Putting the card back is a step change too — back to nothing to scroll.
+    actor.send({ type: 'CANCEL' })
+    expect(targetOf(actor.getSnapshot())).toBeNull()
+  })
+
+  it('the dock scroll fires once per hold, and yields to a player scroll', () => {
+    const actor = startedGame()
+    actor.send({ type: 'SELECT_CARD', cardId: coalCard.id })
+    const step = stepKey((p: never) => actor.getSnapshot().matches(p))
+
+    expect(
+      shouldStepScroll({
+        prevStep: null,
+        step,
+        isPhone: true,
+        now: 10_000,
+        lastUserScrollAt: null,
+      }),
+    ).toBe(true)
+    // Parked in the hold (a re-render, a peek of another card): no re-scroll.
+    expect(
+      shouldStepScroll({
+        prevStep: step,
+        step,
+        isPhone: true,
+        now: 10_000,
+        lastUserScrollAt: null,
+      }),
+    ).toBe(false)
+    // The player scrolled somewhere on purpose a moment ago: they keep it.
+    expect(
+      shouldStepScroll({
+        prevStep: null,
+        step,
+        isPhone: true,
+        now: 10_000,
+        lastUserScrollAt: 9_500,
+      }),
+    ).toBe(false)
   })
 })

--- a/src/components/step-scroll.ts
+++ b/src/components/step-scroll.ts
@@ -24,12 +24,15 @@ const BOARD_STEPS = [
 // Confirm and sale steps live in the dock — as do the beer/iron/coal source
 // picks: the map only spotlights those candidates, the actual pick control is
 // the dock picker, so a phone auto-scroll to the board would strand the
-// player away from the only tappable control. Card-pick steps deliberately
-// map to nothing: the hand tray is bottom-fixed and always on screen, and
-// `developing.choosingIronSource` maps to nothing too — it auto-opens the
-// develop mat modal, which owns that pick, same as its `selectingTiles`/
+// player away from the only tappable control. `cardSelected` is a dock step
+// for the same reason: the card is committed and the next tap is the action
+// list it can start, which on a phone sits below the board. The steps still
+// PICKING a card map to nothing — the hand tray is bottom-fixed and always on
+// screen — and neither does `developing.choosingIronSource`, which auto-opens
+// the develop mat modal, owner of that pick like its `selectingTiles`/
 // `confirmingDevelop` siblings.
 const DOCK_STEPS = [
+  'playing.action.cardSelected',
   'playing.action.building.confirmingBuild',
   'playing.action.networking.confirmingLink',
   'playing.action.networking.confirmingDoubleLink',


### PR DESCRIPTION
On a phone the board owns the top of the screen and the action dock sits below
it, so playing a hand card left the player holding it with the next control off
screen — the list of actions that card can start was under the fold and under
the fixed hand tray.

`playing.action.cardSelected` joins the dock steps in `step-scroll.ts`. The
module's own comment was right that the *hand tray* never needs scrolling to
(it is bottom-fixed), but once a card is **committed** the surface that owns the
next tap is the dock, so that step belongs with the confirm and source-pick
steps. No new mechanism: same pure decision + `use-step-scroll.ts` applied half,
same 2s don't-fight-the-player window, same reduced-motion handling, same
phone-only gate.

### Peek must not scroll

Touch reaches a card in two taps — the first peeks it so it can be read, the
second plays it (#115). A scroll on the peek would yank the view out from under
a player who only wanted to look at a card, which is worse than the bug being
fixed here. The scroll is safe from that by construction: it is driven by the
machine's step, and a peek is local tray state (`peekedId`) that sends no event.
That is the property the tests pin, not just the happy path.

### Decisions

- **Scroll only, no focus move.** Julius asked for "scroll/focus"; moving focus
  programmatically after a state change is what throws an assistive cursor off
  the thing the player just touched, and the dock is a panel rather than a
  landmark with its own return path. Scrolling brings the panel to the player
  without taking their place in the interaction; the played card keeps focus. An
  e2e assertion pins that focus does not land inside the side panel.
- **Phone only**, unchanged from the module's existing scope: desktop shows the
  board and the dock side by side and is viewport-locked, so a scroll there
  would be noise.
- **The suppression window still wins.** A player who scrolled somewhere on
  purpose in the last 2s keeps their position, pinned both in the unit decision
  test and end-to-end with a real wheel scroll.

### Tests

- `step-scroll.test.ts`: `cardSelected` is a dock step; the card-*pick* steps
  still map to nothing. Plus a block driving the real `gameStore` — idle (where a
  peek leaves it) has no scroll target, `SELECT_CARD` lands on `dock`, put-back
  returns to nothing — and the once-per-hold / suppression cases on that step.
- `e2e/step-scroll.spec.ts` at 390×844 with touch: a peek leaves `scrollY` at 0,
  the second tap brings the panel and its title fully into view, and a manual
  scroll a moment earlier holds the player's position.
- Full unit suite (897) and full e2e suite (80) green locally.

### Review

`codex review` (gpt-5.6-luna, xhigh reasoning) against `origin/main`: no
findings, "patch is correct".

### Before / after at 390px

Peeked — the view has not moved, and the dock's heading is still clipped off the
bottom edge behind the tray:

![peeked, view unmoved](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr116-peek.png)

Played — the action list arrives:

![played, action list on screen](https://github.com/julius-retzer/brass-birmingham/releases/download/pr-review-images/pr116-play.png)
